### PR TITLE
Harden JWT Verification

### DIFF
--- a/pkg/oauth2/accesstoken.go
+++ b/pkg/oauth2/accesstoken.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/google/uuid"
+
+	"github.com/unikorn-cloud/identity/pkg/jose"
 )
 
 var (
@@ -77,7 +79,7 @@ func (a *Authenticator) Issue(r *http.Request, code *Code, expiresAt time.Time) 
 		},
 	}
 
-	token, err := a.issuer.EncodeJWEToken(claims)
+	token, err := a.issuer.EncodeJWEToken(claims, jose.TokenTypeAccessToken)
 	if err != nil {
 		return "", err
 	}
@@ -90,7 +92,7 @@ func (a *Authenticator) Verify(r *http.Request, tokenString string) (*Claims, er
 	// Parse and verify the claims with the public key.
 	claims := &Claims{}
 
-	if err := a.issuer.DecodeJWEToken(tokenString, claims); err != nil {
+	if err := a.issuer.DecodeJWEToken(tokenString, claims, jose.TokenTypeAccessToken); err != nil {
 		return nil, fmt.Errorf("failed to decrypt claims: %w", err)
 	}
 

--- a/pkg/oauth2/federated.go
+++ b/pkg/oauth2/federated.go
@@ -569,7 +569,7 @@ func (a *Authenticator) providerAuthenticationRequest(w http.ResponseWriter, r *
 		oidcState.ClientNonce = query.Get("nonce")
 	}
 
-	state, err := a.issuer.EncodeJWEToken(oidcState)
+	state, err := a.issuer.EncodeJWEToken(oidcState, jose.TokenTypeLoginState)
 	if err != nil {
 		authorizationError(w, r, clientRedirectURI, ErrorServerError, "failed to encode oidc state: "+err.Error())
 		return
@@ -697,7 +697,7 @@ func (a *Authenticator) OIDCCallback(w http.ResponseWriter, r *http.Request) {
 	// Extract our state for the next part...
 	state := &State{}
 
-	if err := a.issuer.DecodeJWEToken(query.Get("state"), state); err != nil {
+	if err := a.issuer.DecodeJWEToken(query.Get("state"), state, jose.TokenTypeLoginState); err != nil {
 		htmlError(w, r, http.StatusBadRequest, "oidc state failed to decode")
 		return
 	}
@@ -797,7 +797,7 @@ func (a *Authenticator) OIDCCallback(w http.ResponseWriter, r *http.Request) {
 		Groups:              groups,
 	}
 
-	code, err := a.issuer.EncodeJWEToken(oauth2Code)
+	code, err := a.issuer.EncodeJWEToken(oauth2Code, jose.TokenTypeAuthorizationCode)
 	if err != nil {
 		authorizationError(w, r, state.ClientRedirectURI, ErrorServerError, "failed to encode authorization code: "+err.Error())
 		return
@@ -912,7 +912,7 @@ func (a *Authenticator) Token(w http.ResponseWriter, r *http.Request) (*generate
 
 	code := &Code{}
 
-	if err := a.issuer.DecodeJWEToken(r.Form.Get("code"), code); err != nil {
+	if err := a.issuer.DecodeJWEToken(r.Form.Get("code"), code, jose.TokenTypeAuthorizationCode); err != nil {
 		return nil, errors.OAuth2InvalidRequest("failed to parse code: " + err.Error())
 	}
 


### PR DESCRIPTION
Especially token type, so we can prevent potential reuse in different security contexts.