### PR TITLE
Issuer Key Rotation

### DIFF
--- a/charts/identity/templates/certificate.yaml
+++ b/charts/identity/templates/certificate.yaml
@@ -12,3 +12,6 @@ spec:
     size: 521
   commonName : Unikorn Server JOSE Key
   secretName: unikorn-identity-jose-tls
+  # Twice the duration to caterfor overlap, then convert to hours (2 * 24).
+  duration: {{ printf "%dh" (mul .Values.issuer.maxTokenDurationDays 48) }}
+  renewBefore: {{ printf "%dh" (mul .Values.issuer.maxTokenDurationDays 24) }}

--- a/charts/identity/templates/clusterrole.yaml
+++ b/charts/identity/templates/clusterrole.yaml
@@ -27,3 +27,13 @@ rules:
   verbs:
   - list
   - watch
+  - create
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update

--- a/charts/identity/templates/deployment.yaml
+++ b/charts/identity/templates/deployment.yaml
@@ -20,14 +20,7 @@ spec:
         args:
         - --namespace={{ .Release.Namespace }}
         - --host=https://{{ .Values.host }}
-        {{- with $branding := .Values.branding }}
-          {{- if $branding.loginRedirectURL }}
-            {{ printf "- --login-redirect-url=%s" $branding.loginRedirectURL | nindent 8 }}
-          {{- end }}
-          {{- if $branding.errorRedirectURL }}
-            {{ printf "- --error-redirect-url=%s" $branding.errorRedirectURL | nindent 8 }}
-          {{- end }}
-        {{- end }}
+        - --jose-tls-secret=unikorn-identity-jose-tls
         {{- with $cors := .Values.cors }}
           {{- range $origin := $cors.allowOrigin }}
             {{ printf "- --cors-allow-origin=%s" $origin | nindent 8 }}
@@ -39,10 +32,6 @@ spec:
         {{- if .Values.otlpEndpoint }}
           {{ printf "- --otlp-endpoint=%s" .Values.otlpEndpoint | nindent 8 }}
         {{- end }}
-        volumeMounts:
-        - name: unikorn-identity-jose-tls
-          mountPath: /var/lib/secrets/unikorn-cloud.org/jose
-          readOnly: true
         ports:
         - name: http
           containerPort: 6080
@@ -58,7 +47,3 @@ spec:
       serviceAccountName: unikorn-identity
       securityContext:
         runAsNonRoot: true
-      volumes:
-      - name: unikorn-identity-jose-tls
-        secret:
-          secretName: unikorn-identity-jose-tls

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -31,11 +31,14 @@ projectController:
 # oauth2 issuer etc.
 host: identity.acme.org
 
-# Branding options allow you to "white-box" and apply your own spin on the
-# login and error pages.
-# branding:
-#   loginRedirectURL: https://my-host/login
-#   errorRedirectURL: https://my-host/error
+# Issuer related configuration.
+issuer:
+  # maxTokenDurationDays defines the maximum length of time an issued JWT
+  # can last for.  Due to key rotation by cert-manager, the certificate will
+  # live twice as long as this value, but refresh at this age, so JWT tokens
+  # issued just before the rotation will function for their lifetime (or near
+  # enough).
+  maxTokenDurationDays: 90
 
 # A static list of registered client applications.
 # clients:

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-jose/go-jose/v3 v3.0.3
 	github.com/google/uuid v1.6.0
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.9.0
 	github.com/unikorn-cloud/core v0.1.29
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.24.0
@@ -17,6 +18,7 @@ require (
 	golang.org/x/oauth2 v0.18.0
 	k8s.io/api v0.29.3
 	k8s.io/apimachinery v0.29.3
+	k8s.io/client-go v0.29.3
 	sigs.k8s.io/controller-runtime v0.17.2
 )
 
@@ -37,6 +39,7 @@ require (
 	github.com/chenzhuoyu/iasm v0.9.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.0 // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/flosch/pongo2/v4 v4.0.2 // indirect
@@ -94,6 +97,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.0 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.19.0 // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.51.1 // indirect
@@ -134,7 +138,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/client-go v0.29.3 // indirect
 	k8s.io/component-base v0.29.3 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240322212309-b815d8309940 // indirect

--- a/pkg/authorization/authenticator.go
+++ b/pkg/authorization/authenticator.go
@@ -18,6 +18,8 @@ limitations under the License.
 package authorization
 
 import (
+	"context"
+
 	"github.com/unikorn-cloud/core/pkg/server/errors"
 	"github.com/unikorn-cloud/identity/pkg/jose"
 	"github.com/unikorn-cloud/identity/pkg/oauth2"
@@ -41,8 +43,8 @@ func NewAuthenticator(issuer *jose.JWTIssuer, oauth2 *oauth2.Authenticator) *Aut
 	}
 }
 
-func (a *Authenticator) JWKS() (interface{}, error) {
-	result, err := a.issuer.JWKS()
+func (a *Authenticator) JWKS(ctx context.Context) (interface{}, error) {
+	result, err := a.issuer.JWKS(ctx)
 	if err != nil {
 		return nil, errors.OAuth2ServerError("unable to generate json web key set").WithError(err)
 	}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -158,7 +158,7 @@ func (h *Handler) GetOauth2V2Userinfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) GetOauth2V2Jwks(w http.ResponseWriter, r *http.Request) {
-	result, err := h.authenticator.JWKS()
+	result, err := h.authenticator.JWKS(r.Context())
 	if err != nil {
 		errors.HandleError(w, r, err)
 		return

--- a/pkg/jose/jwe.go
+++ b/pkg/jose/jwe.go
@@ -18,17 +18,34 @@ limitations under the License.
 package jose
 
 import (
+	"context"
 	"crypto"
 	"crypto/sha256"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"os"
+	"reflect"
+	"time"
 
 	jose "github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/spf13/pflag"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -39,28 +56,28 @@ var (
 	// ErrTokenVerification is raised when token verification fails.
 	ErrTokenVerification = errors.New("failed to verify token")
 
+	// ErrMissingKey is raised when a key is missing from a secret.
+	ErrMissingKey = errors.New("failed to lookup key")
+
 	// ErrContextError is raised when a required value cannot be retrieved
 	// from a context.
 	ErrContextError = errors.New("value missing from context")
 )
 
-const (
-	tlsKeyPathDefault  = "/var/lib/secrets/unikorn-cloud.org/jose/tls.key"
-	tlsCertPathDefault = "/var/lib/secrets/unikorn-cloud.org/jose/tls.crt"
-)
-
 type Options struct {
-	// TLSKeyPath identifies where to get the JWE/JWS private key from.
-	TLSKeyPath string
+	// IssuerSecretName is the name of the secret that contains our managed
+	// signing key.
+	IssuerSecretName string
 
-	// TLSCertPath identifies where to get the JWE/JWS public key from.
-	TLSCertPath string
+	// RotationPeriod is used to tweak the period for certificate rotation
+	// detection.
+	RotationPeriod time.Duration
 }
 
 // AddFlags registers flags with the provided flag set.
 func (o *Options) AddFlags(f *pflag.FlagSet) {
-	f.StringVar(&o.TLSKeyPath, "jose-tls-key", tlsKeyPathDefault, "TLS key used to sign JWS and decrypt JWE.")
-	f.StringVar(&o.TLSCertPath, "jose-tls-cert", tlsCertPathDefault, "TLS cert used to verify JWS and encrypt JWE.")
+	f.StringVar(&o.IssuerSecretName, "jose-tls-secret", "", "TLS sgning key used for JWS/JWE.")
+	f.DurationVar(&o.RotationPeriod, "jose-tls-rotation-period", time.Minute, "How often to poll for signing key updates")
 }
 
 // JWTIssuer is in charge of API token issue and verification.
@@ -74,45 +91,294 @@ func (o *Options) AddFlags(f *pflag.FlagSet) {
 // all instances.
 type JWTIssuer struct {
 	options *Options
+
+	// client is the Kubernetes client for certificate management.
+	client client.Client
+
+	// namespace is where we are running so we can find leases and secrets.
+	namespace string
 }
 
 // NewJWTIssuer returns a new JWT issuer and validator.
-func NewJWTIssuer(options *Options) *JWTIssuer {
+func NewJWTIssuer(client client.Client, namespace string, options *Options) *JWTIssuer {
 	return &JWTIssuer{
-		options: options,
+		client:    client,
+		namespace: namespace,
+		options:   options,
 	}
+}
+
+type CoordinationClientGetter interface {
+	Client() (coordinationv1.CoordinationV1Interface, error)
+}
+
+type InClusterCoordinationClientGetter struct{}
+
+func (*InClusterCoordinationClientGetter) Client() (coordinationv1.CoordinationV1Interface, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	coordination, err := coordinationv1.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return coordination, nil
+}
+
+// Run starts the certificate management loop.
+// The certificate itself is managed by cert-manager, as a reissue duration of N
+// and a lifetime of 2N.  Tokens may be issued for a maximum duration of N.  Tokens
+// issued just before the certificates N will be able to be verified until their
+// expiration.  Now, to pull this off we need to:
+//
+//   - Keep a primary copy of the current key pair so we can see when it changes.
+//     with reference to the master copy managed by cert-manager.
+//   - When it does change, we need to demote the primary copy to the secondary,
+//     then update the new primary.
+//
+// Tokens will always be issued by the current primary, but may be verified by
+// either the primary or secondary.
+//
+// As identity is hoizontally scalable, we have another pain in the arse that
+// is split brain, so use leadership election to ease the burden.
+func (i *JWTIssuer) Run(ctx context.Context, coordinationClientGetter CoordinationClientGetter) error {
+	coordination, err := coordinationClientGetter.Client()
+	if err != nil {
+		return err
+	}
+
+	id, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+
+	id += "_" + string(uuid.NewUUID())
+
+	// TODO: logging is not in JSON and breaks jq.
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Namespace: i.namespace,
+			Name:      "unikorn-identity-jose-tls",
+		},
+		Client: coordination,
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: id,
+		},
+	}
+
+	lec := leaderelection.LeaderElectionConfig{
+		Lock:          lock,
+		LeaseDuration: 15 * time.Second,
+		RenewDeadline: 10 * time.Second,
+		RetryPeriod:   2 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: i.StartLeading,
+			OnStoppedLeading: i.StopLeading,
+		},
+	}
+
+	elector, err := leaderelection.NewLeaderElector(lec)
+	if err != nil {
+		return err
+	}
+
+	go elector.Run(ctx)
+
+	return nil
+}
+
+func (i *JWTIssuer) GetPrimaryKeyName() string {
+	return i.options.IssuerSecretName + "-primary"
+}
+
+func (i *JWTIssuer) GetSecondaryKeyName() string {
+	return i.options.IssuerSecretName + "-secondary"
+}
+
+func (i *JWTIssuer) getKey(ctx context.Context, name string, secret *corev1.Secret) error {
+	if err := i.client.Get(ctx, client.ObjectKey{Namespace: i.namespace, Name: name}, secret); err != nil && !kerrors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}
+
+// StartLeading does certificate rotation handling.
+// NOTE: there is a startup penalty waiting for the first tick, but on the first
+// invocation it's expected there won't be any traffic immediately anyway.
+func (i *JWTIssuer) StartLeading(ctx context.Context) {
+	log := log.FromContext(ctx)
+
+	ticker := time.NewTicker(i.options.RotationPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// This is obviously Sweet Baby Ray's
+			var secretSource corev1.Secret
+
+			if err := i.getKey(ctx, i.options.IssuerSecretName, &secretSource); err != nil {
+				log.Error(err, "failed to get JOSE secret source")
+				break
+			}
+
+			primaryKey := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: i.namespace,
+					Name:      i.GetPrimaryKeyName(),
+				},
+			}
+
+			if err := i.getKey(ctx, i.GetPrimaryKeyName(), &primaryKey); err != nil {
+				log.Error(err, "failed to get JOSE primary key")
+				break
+			}
+
+			// Check if the soure has been rotated, this will be true of the primary
+			// doesn't exist yet as its data will be nil.
+			sourceRotated := !reflect.DeepEqual(secretSource.Data, primaryKey.Data)
+
+			// If the key pair has been rotated, and the primary actually exists,
+			// then we need to copy it to the secondary to keep that alive for
+			// verification of currently issued tokens.
+			if sourceRotated && primaryKey.ResourceVersion != "" {
+				secondaryKey := corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: i.namespace,
+						Name:      i.GetSecondaryKeyName(),
+					},
+				}
+
+				mutate := func() error {
+					secondaryKey.Type = corev1.SecretTypeTLS
+					secondaryKey.Data = primaryKey.Data
+
+					return nil
+				}
+
+				result, err := controllerutil.CreateOrUpdate(ctx, i.client, &secondaryKey, mutate)
+				log.Info("JOSE secondary key recociled", "action", result)
+
+				if err != nil {
+					log.Error(err, "failed to update JOSE secondary key")
+					break
+				}
+			}
+
+			// The primary is always a copy of the source.
+			mutate := func() error {
+				primaryKey.Type = corev1.SecretTypeTLS
+				primaryKey.Data = secretSource.Data
+
+				return nil
+			}
+
+			result, err := controllerutil.CreateOrUpdate(ctx, i.client, &primaryKey, mutate)
+			log.Info("JOSE primary key recociled", "action", result)
+
+			if err != nil {
+				log.Error(err, "failed to update JOSE primary key")
+				break
+			}
+		}
+	}
+}
+
+func (i *JWTIssuer) StopLeading() {
+}
+
+func parsePrivatekey(pemData []byte) (crypto.PrivateKey, error) {
+	block, rest := pem.Decode(pemData)
+	if len(rest) > 0 {
+		return nil, fmt.Errorf("%w: Key encoding has extra data", ErrKeyFormat)
+	}
+
+	switch block.Type {
+	// PKCS1
+	case "RSA PRIVATE KEY":
+		return nil, fmt.Errorf("%w: RSA key unsupported", ErrKeyFormat)
+	// PKCS8
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+
+		return key, nil
+	// SEC1
+	case "EC PRIVATE KEY":
+		key, err := x509.ParseECPrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+
+		return key, nil
+	}
+
+	return nil, fmt.Errorf("%w: unknown key type %s", ErrKeyFormat, block.Type)
+}
+
+func parseCertificate(pemData []byte) (*x509.Certificate, error) {
+	block, rest := pem.Decode(pemData)
+	if len(rest) > 0 {
+		return nil, fmt.Errorf("%w: Key encoding has extra data", ErrKeyFormat)
+	}
+
+	if block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("%w: unknown certificate type %s", ErrKeyFormat, block.Type)
+	}
+
+	return x509.ParseCertificate(block.Bytes)
+}
+
+func getKeyID(cert *x509.Certificate) string {
+	kid := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+
+	return base64.RawURLEncoding.EncodeToString(kid[:])
 }
 
 // GetKeyPair returns the public key, private key and key id from the configuration data.
 // The key id is inspired by X.509 subject key identifiers, so a hash over the subject public
 // key info.
-func (i *JWTIssuer) GetKeyPair() (any, crypto.PrivateKey, string, error) {
-	// See JWTIssuer documentation for notes on caching.
-	tlsCertificate, err := tls.LoadX509KeyPair(i.options.TLSCertPath, i.options.TLSKeyPath)
+func (i *JWTIssuer) GetKeyPair(ctx context.Context) (*x509.Certificate, crypto.PrivateKey, error) {
+	// TODO: this is a temporary bandage until rotation is fully implemented.
+	var secret corev1.Secret
+
+	if err := i.client.Get(ctx, client.ObjectKey{Namespace: i.namespace, Name: i.options.IssuerSecretName}, &secret); err != nil {
+		return nil, nil, err
+	}
+
+	key, ok := secret.Data[corev1.TLSPrivateKeyKey]
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: JOSE secret does not contain tls.key", ErrMissingKey)
+	}
+
+	privateKey, err := parsePrivatekey(key)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, err
 	}
 
-	if len(tlsCertificate.Certificate) != 1 {
-		return nil, nil, "", fmt.Errorf("%w: unexpected certificate chain", ErrKeyFormat)
+	cert, ok := secret.Data[corev1.TLSCertKey]
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: JOSE secret does not contain tls.crt", ErrMissingKey)
 	}
 
-	certificate, err := x509.ParseCertificate(tlsCertificate.Certificate[0])
+	certificate, err := parseCertificate(cert)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, err
 	}
 
-	if certificate.PublicKeyAlgorithm != x509.ECDSA {
-		return nil, nil, "", fmt.Errorf("%w: certifcate public key algorithm is not ECDSA", ErrKeyFormat)
-	}
-
-	kid := sha256.Sum256(certificate.RawSubjectPublicKeyInfo)
-
-	return certificate.PublicKey, tlsCertificate.PrivateKey, base64.RawURLEncoding.EncodeToString(kid[:]), nil
+	return certificate, privateKey, nil
 }
 
-func (i *JWTIssuer) EncodeJWT(claims interface{}) (string, error) {
-	_, privateKey, _, err := i.GetKeyPair()
+func (i *JWTIssuer) EncodeJWT(ctx context.Context, claims interface{}) (string, error) {
+	_, privateKey, err := i.GetKeyPair(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get key pair: %w", err)
 	}
@@ -130,8 +396,8 @@ func (i *JWTIssuer) EncodeJWT(claims interface{}) (string, error) {
 	return jwt.Signed(signer).Claims(claims).CompactSerialize()
 }
 
-func (i *JWTIssuer) DecodeJWT(tokenString string, claims interface{}) error {
-	publicKey, _, _, err := i.GetKeyPair()
+func (i *JWTIssuer) DecodeJWT(ctx context.Context, tokenString string, claims interface{}) error {
+	cert, _, err := i.GetKeyPair(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get key pair: %w", err)
 	}
@@ -141,7 +407,7 @@ func (i *JWTIssuer) DecodeJWT(tokenString string, claims interface{}) error {
 		return err
 	}
 
-	if err := token.Claims(publicKey, claims); err != nil {
+	if err := token.Claims(cert.PublicKey, claims); err != nil {
 		return err
 	}
 
@@ -166,10 +432,10 @@ const (
 
 // EncodeJWEToken encodes, signs and encrypts as set of claims.
 // For access tokens this implemenrs https://datatracker.ietf.org/doc/html/rfc9068
-func (i *JWTIssuer) EncodeJWEToken(claims interface{}, tokenType TokenType) (string, error) {
+func (i *JWTIssuer) EncodeJWEToken(ctx context.Context, claims interface{}, tokenType TokenType) (string, error) {
 	// TODO: according to the spec we MUST support RS256, but we do both
 	// issue and verification, so not strictly necessary.
-	publicKey, privateKey, kid, err := i.GetKeyPair()
+	cert, privateKey, err := i.GetKeyPair(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get key pair: %w", err)
 	}
@@ -186,8 +452,8 @@ func (i *JWTIssuer) EncodeJWEToken(claims interface{}, tokenType TokenType) (str
 
 	recipient := jose.Recipient{
 		Algorithm: jose.ECDH_ES,
-		Key:       publicKey,
-		KeyID:     kid,
+		Key:       cert.PublicKey,
+		KeyID:     getKeyID(cert),
 	}
 
 	encrypterOptions := &jose.EncrypterOptions{}
@@ -206,8 +472,8 @@ func (i *JWTIssuer) EncodeJWEToken(claims interface{}, tokenType TokenType) (str
 	return token, nil
 }
 
-func (i *JWTIssuer) DecodeJWEToken(tokenString string, claims interface{}, tokenType TokenType) error {
-	publicKey, privateKey, _, err := i.GetKeyPair()
+func (i *JWTIssuer) DecodeJWEToken(ctx context.Context, tokenString string, claims interface{}, tokenType TokenType) error {
+	cert, privateKey, err := i.GetKeyPair(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get key pair: %w", err)
 	}
@@ -237,15 +503,15 @@ func (i *JWTIssuer) DecodeJWEToken(tokenString string, claims interface{}, token
 	}
 
 	// Parse and verify the claims with the public key.
-	if err := token.Claims(publicKey, claims); err != nil {
+	if err := token.Claims(cert.PublicKey, claims); err != nil {
 		return fmt.Errorf("failed to decrypt claims: %w", err)
 	}
 
 	return nil
 }
 
-func (i *JWTIssuer) JWKS() (*jose.JSONWebKeySet, error) {
-	pub, _, kid, err := i.GetKeyPair()
+func (i *JWTIssuer) JWKS(ctx context.Context) (*jose.JSONWebKeySet, error) {
+	cert, _, err := i.GetKeyPair(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -253,8 +519,8 @@ func (i *JWTIssuer) JWKS() (*jose.JSONWebKeySet, error) {
 	jwks := &jose.JSONWebKeySet{
 		Keys: []jose.JSONWebKey{
 			{
-				Key:   pub,
-				KeyID: kid,
+				Key:   cert.PublicKey,
+				KeyID: getKeyID(cert),
 				Use:   "sig",
 			},
 		},

--- a/pkg/jose/jwe_test.go
+++ b/pkg/jose/jwe_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2024 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jose_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/identity/pkg/jose"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	fakecoordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1/fake"
+	clientgotesting "k8s.io/client-go/testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	namespace     = "default"
+	refreshPeriod = time.Second
+	keySecretName = "tls-cert"
+)
+
+type FakeCoordinationClientGetter struct{}
+
+func (*FakeCoordinationClientGetter) Client() (coordinationv1.CoordinationV1Interface, error) {
+	coordination := &fakecoordinationv1.FakeCoordinationV1{
+		Fake: &clientgotesting.Fake{},
+	}
+
+	return coordination, nil
+}
+
+func generateSerial(t *testing.T) *big.Int {
+	t.Helper()
+
+	serial, err := rand.Int(rand.Reader, big.NewInt(0).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+
+	return serial
+}
+
+func rotateCertificate(t *testing.T, client client.Client, serial *big.Int) {
+	t.Helper()
+
+	pkey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(pkey)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "my-signing-key",
+		},
+		SerialNumber: serial,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Minute),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, pkey.Public(), pkey)
+	require.NoError(t, err)
+
+	keyBlock := &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: keyDER,
+	}
+
+	key := pem.EncodeToMemory(keyBlock)
+
+	certBlock := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	}
+
+	cert := pem.EncodeToMemory(certBlock)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      keySecretName,
+		},
+	}
+
+	mutate := func() error {
+		secret.Type = corev1.SecretTypeTLS
+		secret.Data = map[string][]byte{
+			corev1.TLSCertKey:       cert,
+			corev1.TLSPrivateKeyKey: key,
+		}
+
+		return nil
+	}
+
+	_, err = controllerutil.CreateOrUpdate(context.Background(), client, secret, mutate)
+	require.NoError(t, err)
+}
+
+func checkCertificate(t *testing.T, cli client.Client, name string, serial *big.Int) {
+	t.Helper()
+
+	var secret corev1.Secret
+
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: name}, &secret))
+
+	require.Contains(t, secret.Data, corev1.TLSCertKey)
+	require.Contains(t, secret.Data, corev1.TLSPrivateKeyKey)
+
+	tlsCert, err := tls.X509KeyPair(secret.Data[corev1.TLSCertKey], secret.Data[corev1.TLSPrivateKeyKey])
+	require.NoError(t, err)
+	require.Len(t, tlsCert.Certificate, 1)
+	require.NotEmpty(t, tlsCert.Certificate[0])
+
+	cert, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	require.NoError(t, err)
+	require.Equal(t, 0, cert.SerialNumber.Cmp(serial))
+}
+
+func checkCertificateNotExist(t *testing.T, cli client.Client, name string) {
+	t.Helper()
+
+	var secret corev1.Secret
+
+	require.Error(t, cli.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: name}, &secret))
+}
+
+func TestRotation(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewFakeClient()
+
+	serial1 := generateSerial(t)
+	rotateCertificate(t, client, serial1)
+
+	options := &jose.Options{
+		IssuerSecretName: keySecretName,
+		RotationPeriod:   refreshPeriod,
+	}
+
+	issuer := jose.NewJWTIssuer(client, "default", options)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, issuer.Run(ctx, &FakeCoordinationClientGetter{}))
+
+	// After at least one tick, expect the primary copy to exist, and the secondary not to.
+	time.Sleep(refreshPeriod * 2)
+	checkCertificate(t, client, issuer.GetPrimaryKeyName(), serial1)
+	checkCertificateNotExist(t, client, issuer.GetSecondaryKeyName())
+
+	// After ar at least another tick, expect the state to be the same.
+	time.Sleep(refreshPeriod)
+	checkCertificate(t, client, issuer.GetPrimaryKeyName(), serial1)
+	checkCertificateNotExist(t, client, issuer.GetSecondaryKeyName())
+
+	// Rotate the certificate, and after at least one tick the primary should be updated
+	// and the old primary copied to the secondary.
+	serial2 := generateSerial(t)
+	rotateCertificate(t, client, serial2)
+
+	time.Sleep(refreshPeriod * 2)
+	checkCertificate(t, client, issuer.GetPrimaryKeyName(), serial2)
+	checkCertificate(t, client, issuer.GetSecondaryKeyName(), serial1)
+
+	// After ar at least another tick, expect the state to be the same.
+	time.Sleep(refreshPeriod)
+	checkCertificate(t, client, issuer.GetPrimaryKeyName(), serial2)
+	checkCertificate(t, client, issuer.GetSecondaryKeyName(), serial1)
+
+	// And one more time...
+	serial3 := generateSerial(t)
+	rotateCertificate(t, client, serial3)
+
+	time.Sleep(refreshPeriod * 2)
+	checkCertificate(t, client, issuer.GetPrimaryKeyName(), serial3)
+	checkCertificate(t, client, issuer.GetSecondaryKeyName(), serial2)
+}

--- a/pkg/middleware/openapi/local/authorizer.go
+++ b/pkg/middleware/openapi/local/authorizer.go
@@ -68,7 +68,7 @@ func (a *Authorizer) authorizeOAuth2(r *http.Request) (string, *userinfo.UserInf
 	}
 
 	// Check the token is from us, for us, and in date.
-	claims, err := a.authenticator.Verify(r, token)
+	claims, err := a.authenticator.Verify(r.Context(), r, token)
 	if err != nil {
 		return "", nil, errors.OAuth2AccessDenied("token validation failed").WithError(err)
 	}

--- a/pkg/oauth2/accesstoken.go
+++ b/pkg/oauth2/accesstoken.go
@@ -18,6 +18,7 @@ limitations under the License.
 package oauth2
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -55,7 +56,7 @@ type Claims struct {
 }
 
 // Issue issues a new JWT access token.
-func (a *Authenticator) Issue(r *http.Request, code *Code, expiresAt time.Time) (string, error) {
+func (a *Authenticator) Issue(ctx context.Context, r *http.Request, code *Code, expiresAt time.Time) (string, error) {
 	now := time.Now()
 
 	nowRFC7519 := jwt.NumericDate(now.Unix())
@@ -78,7 +79,7 @@ func (a *Authenticator) Issue(r *http.Request, code *Code, expiresAt time.Time) 
 		},
 	}
 
-	token, err := a.issuer.EncodeJWEToken(claims, jose.TokenTypeAccessToken)
+	token, err := a.issuer.EncodeJWEToken(ctx, claims, jose.TokenTypeAccessToken)
 	if err != nil {
 		return "", err
 	}
@@ -87,11 +88,11 @@ func (a *Authenticator) Issue(r *http.Request, code *Code, expiresAt time.Time) 
 }
 
 // Verify checks the access token parses and validates.
-func (a *Authenticator) Verify(r *http.Request, tokenString string) (*Claims, error) {
+func (a *Authenticator) Verify(ctx context.Context, r *http.Request, tokenString string) (*Claims, error) {
 	// Parse and verify the claims with the public key.
 	claims := &Claims{}
 
-	if err := a.issuer.DecodeJWEToken(tokenString, claims, jose.TokenTypeAccessToken); err != nil {
+	if err := a.issuer.DecodeJWEToken(ctx, tokenString, claims, jose.TokenTypeAccessToken); err != nil {
 		return nil, fmt.Errorf("failed to decrypt claims: %w", err)
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -126,7 +126,11 @@ func (s *Server) GetServer(client client.Client) (*http.Server, error) {
 	router.MethodNotAllowed(http.HandlerFunc(handler.MethodNotAllowed))
 
 	// Setup authn/authz
-	issuer := jose.NewJWTIssuer(&s.JoseOptions)
+	issuer := jose.NewJWTIssuer(client, s.Options.Namespace, &s.JoseOptions)
+	if err := issuer.Run(context.TODO(), &jose.InClusterCoordinationClientGetter{}); err != nil {
+		return nil, err
+	}
+
 	rbac := rbac.New(client, s.Options.Namespace)
 	oauth2 := oauth2.New(&s.OAuth2Options, s.Options.Namespace, client, issuer, rbac)
 	authenticator := authorization.NewAuthenticator(issuer, oauth2)


### PR DESCRIPTION
THe problem we are solving here is currently a token may be issued right before the key pair is rotated, so be comes invalid almost immediately. This will become more troublesome down the line with automation requiring long lived keys (i.e. refresh tokens).  A solution is to create keys that last for 2N, and rotate every N, so any token issued just before a rotation will work for a time of N.  To pull this off we need to create copies of the current keypair and the previous for verification purposes and rotation detection.