### PR TITLE
Work Around Request Size

### DIFF
--- a/pkg/oauth2/oauth2.go
+++ b/pkg/oauth2/oauth2.go
@@ -824,9 +824,15 @@ func (a *Authenticator) OIDCCallback(w http.ResponseWriter, r *http.Request) {
 		ClientNonce:         state.ClientNonce,
 		OAuth2Provider:      state.OAuth2Provider,
 		IDToken:             idTokenClaims,
-		AccessToken:         tokens.AccessToken,
-		RefreshToken:        tokens.RefreshToken,
 		AccessTokenExpiry:   tokens.Expiry,
+	}
+
+	driver := providers.New(providerResource.Spec.Type)
+
+	// These can be big, see the provider comment for why.
+	if driver.RequiresAccessToken() {
+		oauth2Code.AccessToken = tokens.AccessToken
+		oauth2Code.RefreshToken = tokens.RefreshToken
 	}
 
 	code, err := a.issuer.EncodeJWEToken(r.Context(), oauth2Code, jose.TokenTypeAuthorizationCode)

--- a/pkg/oauth2/providers/google/provider.go
+++ b/pkg/oauth2/providers/google/provider.go
@@ -53,6 +53,10 @@ func (*Provider) Scopes() []string {
 	}
 }
 
+func (*Provider) RequiresAccessToken() bool {
+	return true
+}
+
 type Group struct {
 	Name        string `json:"name"`
 	DisplayName string `json:"displayName"`

--- a/pkg/oauth2/providers/interfaces.go
+++ b/pkg/oauth2/providers/interfaces.go
@@ -32,6 +32,15 @@ type Provider interface {
 	// to operate correctly.
 	Scopes() []string
 
+	// RequiresAccessToken defines whether the access and refresh tokens are
+	// required for operation.
+	// TODO: this is because Microsoft's tokens are massive and blow nginx's
+	// request size limit (4096).  We really need to cache these securely and
+	// internally so we don't have to pass them around.  For example hand to
+	// the client an ID and private key that can decrpyt from storage, in memory
+	// on demand.
+	RequiresAccessToken() bool
+
 	// Groups returns a list of groups the user belongs to.
 	Groups(ctx context.Context, organization *unikornv1.Organization, accessToken string) ([]types.Group, error)
 }

--- a/pkg/oauth2/providers/null.go
+++ b/pkg/oauth2/providers/null.go
@@ -38,6 +38,10 @@ func (*nullProvider) Scopes() []string {
 	return nil
 }
 
+func (*nullProvider) RequiresAccessToken() bool {
+	return false
+}
+
 func (*nullProvider) Groups(ctx context.Context, organization *unikornv1.Organization, accessToken string) ([]types.Group, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Login in Entra is causing the request size to be blown due to large tokens, probably hinting they encode permissions in there rather thand doing a DB lookup.  As a quick hack, remove the tokens from the code and our tokens to reduce the size, as they aren't necessary.  A long term solution will be to save these details in a DB and pass around much smaller identifiers to allow a lookup.  We need the DB anyway for access token single use and revocaction.