### PR TITLE
Fix Role RBAC

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.20
-appVersion: v0.2.20
+version: v0.2.21
+appVersion: v0.2.21
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/identity/crds/identity.unikorn-cloud.org_roles.yaml
+++ b/charts/identity/crds/identity.unikorn-cloud.org_roles.yaml
@@ -56,11 +56,6 @@ spec:
           spec:
             description: RoleSpec defines the role's requested state.
             properties:
-              protected:
-                description: |-
-                  Protected means the role will only be shown to users if they already
-                  have it in the scope of the organization.
-                type: boolean
               scopes:
                 description: Scopes are a list of uniquely named scopes for the role.
                 properties:

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -140,9 +140,6 @@ type Role struct {
 
 // RoleSpec defines the role's requested state.
 type RoleSpec struct {
-	// Protected means the role will only be shown to users if they already
-	// have it in the scope of the organization.
-	Protected bool `json:"protected,omitempty"`
 	// Scopes are a list of uniquely named scopes for the role.
 	Scopes RoleScopes `json:"scopes,omitempty"`
 }

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -187,7 +187,7 @@ func (h *Handler) GetApiV1OrganizationsOrganizationIDRoles(w http.ResponseWriter
 		return
 	}
 
-	result, err := roles.New(h.client, h.namespace).List(r.Context())
+	result, err := roles.New(h.client, h.namespace).List(r.Context(), organizationID)
 	if err != nil {
 		errors.HandleError(w, r, err)
 		return


### PR DESCRIPTION
So bloody simple when you think about it!  When reading roles, only return the ones you already have all the permissions for at the same or greated scope.  Basically reuses the existing functions like magic!