### PR TITLE
Basic Taint Checking

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.21
-appVersion: v0.2.21
+version: v0.2.22
+appVersion: v0.2.22
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/handler/organizations/client.go
+++ b/pkg/handler/organizations/client.go
@@ -192,6 +192,7 @@ func (c *Client) generate(ctx context.Context, in *openapi.OrganizationWrite) *u
 	}
 
 	if in.Spec.OrganizationType == openapi.Domain {
+		// TODO: Validate the providerID exists.
 		out.Spec.Domain = in.Spec.Domain
 		out.Spec.ProviderScope = util.ToPointer(unikornv1.ProviderScope(*in.Spec.ProviderScope))
 		out.Spec.ProviderID = in.Spec.ProviderID


### PR DESCRIPTION
Ensure API users (you know who), don't taint the system with erroneous inputs and render it unusable, as this stuff will render RBAC doomed.