### PR TITLE
Make Regions Organization Scoped

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.25
-appVersion: v0.2.25
+version: v0.2.26
+appVersion: v0.2.26
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -83,7 +83,8 @@ roles:
         roles: [create,read,update,delete]
         groups: [create,read,update,delete]
         projects: [create,read,update,delete]
-        infrastructure: [create,read,update,delete]
+        regions: [create,read,update,delete]
+        identities: [create,read,update,delete]
         kubernetesclustermanagers: [create,read,update,delete]
         kubernetesclusters: [create,read,update,delete]
   # An administrator can do anything within an organization.
@@ -96,7 +97,8 @@ roles:
         roles: [create,read,update,delete]
         groups: [create,read,update,delete]
         projects: [create,read,update,delete]
-        infrastructure: [create,read,update,delete]
+        regions: [read]
+        identities: [create]
         kubernetesclustermanagers: [create,read,update,delete]
         kubernetesclusters: [create,read,update,delete]
   # A user can view projects they are a member of and
@@ -104,9 +106,11 @@ roles:
   user:
     description: Project user
     scopes:
+      organization:
+        regions: [read]
       project:
         projects: [read]
-        infrastructure: [create,read]
+        identities: [create]
         kubernetesclustermanagers: [read]
         kubernetesclusters: [create,read,update,delete]
   # A reader can view projects they are a member of and view
@@ -114,9 +118,10 @@ roles:
   reader:
     description: Project reader
     scopes:
+      organization:
+        regions: [read]
       project:
         projects: [read]
-        infrastructure: [read]
         kubernetesclustermanagers: [read]
         kubernetesclusters: [read]
 


### PR DESCRIPTION
After playing with the UI, it semms quite apparent that mapping a region ID to a name, when the region is itself project scoped is quite heavy weight and unwieldy.  To remedy this we move regions back to the organization scope so we need only a single lookup, relying on RBAC information to do any filtering.  This also splits up regions and instrastructure so readers can map to regions, but not create identities etc.