### PR TITLE
Add Token Caching

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.35
-appVersion: v0.2.35
+version: v0.2.36
+appVersion: v0.2.36
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/oauth2/oauth2_test.go
+++ b/pkg/oauth2/oauth2_test.go
@@ -61,6 +61,7 @@ func TestTokens(t *testing.T) {
 		AccessTokenDuration:  accessTokenDuration,
 		RefreshTokenDuration: refreshTokenDuration,
 		TokenLeewayDuration:  accessTokenDuration,
+		TokenCacheSize:       1024,
 	}
 
 	authenticator := oauth2.New(options, josetesting.Namespace, client, issuer, nil)


### PR DESCRIPTION
Transpires that validating tokens is very expensive, so add a cache to identity to speed this up.