### PR TITLE
Add Key ID to ID Tokens

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.36
-appVersion: v0.2.36
+version: v0.2.37
+appVersion: v0.2.37
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/jose/jose.go
+++ b/pkg/jose/jose.go
@@ -410,7 +410,11 @@ func (i *JWTIssuer) EncodeJWT(ctx context.Context, claims interface{}) (string, 
 		Key:       keyPair.Key,
 	}
 
-	signer, err := jose.NewSigner(signingKey, nil)
+	options := &jose.SignerOptions{
+		EmbedJWK: true,
+	}
+
+	signer, err := jose.NewSigner(signingKey, options)
 	if err != nil {
 		return "", fmt.Errorf("failed to create signer: %w", err)
 	}


### PR DESCRIPTION
Rather than just check the signature against all keys, some libraries expect only a single key for a signature type.  Obviously due to key rotation we maintain multiple, so we need to add the key ID to the token to disabiguate, because a loop just isn't simple enough...