### PR TITLE
Second Attempt at Key IDs

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.37
-appVersion: v0.2.37
+version: v0.2.38
+appVersion: v0.2.38
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -73,7 +73,7 @@ issuer:
 # are applied to the organization, regardless of project scoping etc.
 roles:
   # A platform-admin can do anything anywhere.
-  platform-adminstrator:
+  platform-administrator:
     description: Platform administrator
     scopes:
       global:
@@ -99,7 +99,7 @@ roles:
         physicalnetworks: [read,delete]
         quotas: [read,update]
   # An administrator can do anything within an organization.
-  adminstrator:
+  administrator:
     description: Organization administrator
     scopes:
       organization:

--- a/pkg/jose/jose.go
+++ b/pkg/jose/jose.go
@@ -411,7 +411,9 @@ func (i *JWTIssuer) EncodeJWT(ctx context.Context, claims interface{}) (string, 
 	}
 
 	options := &jose.SignerOptions{
-		EmbedJWK: true,
+		ExtraHeaders: map[jose.HeaderKey]interface{}{
+			"kid": getKeyID(keyPair.Cert),
+		},
 	}
 
 	signer, err := jose.NewSigner(signingKey, options)


### PR DESCRIPTION
So according to the node jwks stuff, it requires a single candidate key, and it doesn't match on the embedded key at all, just the KID, so we need to inject this into the headers to disambiguate.