### PR TITLE
Refactor JOSE

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -162,14 +162,8 @@ func (h *Handler) GetOauth2V2Userinfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) GetOauth2V2Jwks(w http.ResponseWriter, r *http.Request) {
-	result, err := h.issuer.JWKS(r.Context())
-	if err != nil {
-		errors.HandleError(w, r, errors.OAuth2ServerError("unable to generate json web key set").WithError(err))
-		return
-	}
-
 	h.setUncacheable(w)
-	util.WriteJSONResponse(w, r, http.StatusOK, result)
+	util.WriteJSONResponse(w, r, http.StatusOK, h.issuer.GetJSONWebKeySet(r.Context()))
 }
 
 func (h *Handler) GetOidcCallback(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The initial idea was to use the key ID to lookup the correct key when verifying and descrypting, but that led to the realization that you can use a JWK rather than a crypto key everywhere, and that leads to the eky ID being populated coreectly, so it's an all around win!