### PR TITLE
Create RBAC For Applications

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.40
-appVersion: v0.2.40
+version: v0.2.41
+appVersion: v0.2.41
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -88,6 +88,8 @@ roles:
         physicalnetworks: [create,read,update,delete]
         kubernetesclustermanagers: [create,read,update,delete]
         kubernetesclusters: [create,read,update,delete]
+        applications: [create,read,update,delete]
+        applicationsets: [create,read,update,delete]
   # An infrastructure manager service is a role primarily for Kubernetes like
   # services that can manage identities and physical networks on behalf of a cluster.
   infra-manager-service:
@@ -98,6 +100,14 @@ roles:
         identities: [read,delete]
         physicalnetworks: [read,delete]
         quotas: [read,update]
+  # An application manager is a role primarily for the application service that
+  # needs to be able to see the Kubernetes clusters it's deploying applications
+  # on to.
+  application-manager-service:
+    description: Application manager service
+    scopes:
+      global:
+        kubernetesclusters: [read]
   # An administrator can do anything within an organization.
   administrator:
     description: Organization administrator
@@ -113,6 +123,8 @@ roles:
         physicalnetworks: [create]
         kubernetesclustermanagers: [create,read,update,delete]
         kubernetesclusters: [create,read,update,delete]
+        applications: [read]
+        applicationsets: [create,read,update,delete]
   # A user can view projects they are a member of and
   # provision kubernetes clusters.
   user:
@@ -126,6 +138,8 @@ roles:
         physicalnetworks: [create]
         kubernetesclustermanagers: [read]
         kubernetesclusters: [create,read,update,delete]
+        applications: [read]
+        applicationsets: [create,read,update,delete]
   # A reader can view projects they are a member of and view
   # kubernetes clusters.
   reader:
@@ -137,6 +151,8 @@ roles:
         projects: [read]
         kubernetesclustermanagers: [read]
         kubernetesclusters: [read]
+        applications: [read]
+        applicationsets: [read]
 
 ingress:
   # Sets the ingress class to use.


### PR DESCRIPTION
We need RBAC protection on the applications endpoint that allows the read of platform defined applications, and applicationsets that allow the actual creation of applications onto Kubernetes clusters... I say that because we could possibly define Ansible applications in future for use on general compute.