### PR TITLE
Create RBAC for Compute Clusters

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.41
-appVersion: v0.2.41
+version: v0.2.42
+appVersion: v0.2.42
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -147,8 +147,6 @@ roles:
         applications: [read]
         applicationsets: [create,read,update,delete]
         computeclusters: [create,read,update,delete]
-        servers: [create,read,update,delete]
-        securitygroups: [create,read,update,delete]
   # A reader can view projects they are a member of and view
   # kubernetes clusters.
   reader:
@@ -163,8 +161,6 @@ roles:
         applications: [read]
         applicationsets: [read]
         computeclusters: [read]
-        servers: [read]
-        securitygroups: [read]
 
 ingress:
   # Sets the ingress class to use.

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -90,6 +90,9 @@ roles:
         kubernetesclusters: [create,read,update,delete]
         applications: [create,read,update,delete]
         applicationsets: [create,read,update,delete]
+        computeclusters: [create,read,update,delete]
+        servers: [create,read,update,delete]
+        securitygroups: [create,read,update,delete]
   # An infrastructure manager service is a role primarily for Kubernetes like
   # services that can manage identities and physical networks on behalf of a cluster.
   infra-manager-service:
@@ -125,6 +128,9 @@ roles:
         kubernetesclusters: [create,read,update,delete]
         applications: [read]
         applicationsets: [create,read,update,delete]
+        computeclusters: [create,read,update,delete]
+        servers: [create,read,update,delete]
+        securitygroups: [create,read,update,delete]
   # A user can view projects they are a member of and
   # provision kubernetes clusters.
   user:
@@ -140,6 +146,9 @@ roles:
         kubernetesclusters: [create,read,update,delete]
         applications: [read]
         applicationsets: [create,read,update,delete]
+        computeclusters: [create,read,update,delete]
+        servers: [create,read,update,delete]
+        securitygroups: [create,read,update,delete]
   # A reader can view projects they are a member of and view
   # kubernetes clusters.
   reader:
@@ -153,6 +162,9 @@ roles:
         kubernetesclusters: [read]
         applications: [read]
         applicationsets: [read]
+        computeclusters: [read]
+        servers: [read]
+        securitygroups: [read]
 
 ingress:
   # Sets the ingress class to use.


### PR DESCRIPTION
This pull request introduces RBAC for the following endpoints: computeclusters, servers, and securitygroups to ensure users have appropriate access levels based on their roles.