### PR TITLE
Tighten RBAC

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.43
-appVersion: v0.2.43
+version: v0.2.44
+appVersion: v0.2.44
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -77,32 +77,42 @@ roles:
     description: Platform administrator
     scopes:
       global:
-        organizations: [create,read,update,delete]
-        oauth2providers: [create,read,update,delete]
-        roles: [create,read,update,delete]
-        groups: [create,read,update,delete]
-        projects: [create,read,update,delete]
-        regions: [create,read,update,delete]
-        identities: [create,read,update,delete]
-        quotas: [create,read,update,delete]
-        physicalnetworks: [create,read,update,delete]
-        kubernetesclustermanagers: [create,read,update,delete]
-        kubernetesclusters: [create,read,update,delete]
-        applications: [create,read,update,delete]
-        applicationsets: [create,read,update,delete]
-        computeclusters: [create,read,update,delete]
-        servers: [create,read,update,delete]
-        securitygroups: [create,read,update,delete]
+        identity:organizations: [create,read,update,delete]
+        identity:oauth2providers: [create,read,update,delete]
+        identity:roles: [create,read,update,delete]
+        identity:groups: [create,read,update,delete]
+        identity:projects: [create,read,update,delete]
+        region:regions: [create,read,update,delete]
+        region:flavors: [create,read,update,delete]
+        region:images: [create,read,update,delete]
+        region:externalnetworks: [create,read,update,delete]
+        region:identities: [create,read,update,delete]
+        region:physicalnetworks: [create,read,update,delete]
+        region:securitygroups: [create,read,update,delete]
+        region:servers: [create,read,update,delete]
+        kubernetes:flavors: [create,read,update,delete]
+        kubernetes:images: [create,read,update,delete]
+        kubernetes:clustermanagers: [create,read,update,delete]
+        kubernetes:clusters: [create,read,update,delete]
+        compute:flavors: [create,read,update,delete]
+        compute:images: [create,read,update,delete]
+        compute:clusters: [create,read,update,delete]
+        application:applications: [create,read,update,delete]
+        application:applicationsets: [create,read,update,delete]
   # An infrastructure manager service is a role primarily for Kubernetes like
   # services that can manage identities and physical networks on behalf of a cluster.
   infra-manager-service:
     decription: Infrastructure manager service
     scopes:
       global:
-        regions: [read]
-        identities: [read,delete]
-        physicalnetworks: [read,delete]
-        quotas: [read,update]
+        region:identities: [create,read,delete]
+        region:regions: [read]
+        region:flavors: [read]
+        region:images: [read]
+        region:externalnetworks: [read]
+        region:physicalnetworks: [create,read,delete]
+        region:servers: [create,read,update,delete]
+        region:securitygroups: [create,read,update,delete]
   # An application manager is a role primarily for the application service that
   # needs to be able to see the Kubernetes clusters it's deploying applications
   # on to.
@@ -110,57 +120,60 @@ roles:
     description: Application manager service
     scopes:
       global:
-        kubernetesclusters: [read]
+        kubernetes:clusters: [read]
   # An administrator can do anything within an organization.
   administrator:
     description: Organization administrator
     scopes:
       organization:
-        organizations: [read,update]
-        oauth2providers: [create,read,update,delete]
-        roles: [create,read,update,delete]
-        groups: [create,read,update,delete]
-        projects: [create,read,update,delete]
-        regions: [read]
-        identities: [create]
-        physicalnetworks: [create]
-        kubernetesclustermanagers: [create,read,update,delete]
-        kubernetesclusters: [create,read,update,delete]
-        applications: [read]
-        applicationsets: [create,read,update,delete]
-        computeclusters: [create,read,update,delete]
-        servers: [create,read,update,delete]
-        securitygroups: [create,read,update,delete]
+        identity:organizations: [read,update]
+        identity:oauth2providers: [create,read,update,delete]
+        identity:roles: [create,read,update,delete]
+        identity:groups: [create,read,update,delete]
+        identity:projects: [create,read,update,delete]
+        region:regions: [read]
+        kubernetes:flavors: [read]
+        kubernetes:images: [read]
+        kubernetes:clusters: [create,read,update,delete]
+        compute:flavors: [read]
+        compute:images: [read]
+        compute:clusters: [create,read,update,delete]
+        application:applications: [read]
+        application:applicationsets: [create,read,update,delete]
   # A user can view projects they are a member of and
-  # provision kubernetes clusters.
+  # provision clusters.
   user:
     description: Project user
     scopes:
       organization:
-        regions: [read]
+        region:regions: [read]
+        kubernetes:flavors: [read]
+        kubernetes:images: [read]
+        compute:flavors: [read]
+        compute:images: [read]
       project:
-        projects: [read]
-        identities: [create]
-        physicalnetworks: [create]
-        kubernetesclustermanagers: [read]
-        kubernetesclusters: [create,read,update,delete]
-        applications: [read]
-        applicationsets: [create,read,update,delete]
-        computeclusters: [create,read,update,delete]
+        identity:projects: [read]
+        kubernetes:clusters: [create,read,update,delete]
+        compute:clusters: [create,read,update,delete]
+        application:applications: [read]
+        application:applicationsets: [create,read,update,delete]
   # A reader can view projects they are a member of and view
   # kubernetes clusters.
   reader:
     description: Project reader
     scopes:
       organization:
-        regions: [read]
+        region:regions: [read]
+        kubernetes:flavors: [read]
+        kubernetes:images: [read]
+        compute:flavors: [read]
+        compute:images: [read]
       project:
-        projects: [read]
-        kubernetesclustermanagers: [read]
-        kubernetesclusters: [read]
-        applications: [read]
-        applicationsets: [read]
-        computeclusters: [read]
+        identity:projects: [read]
+        kubernetes:clusters: [read]
+        compute:clusters: [read]
+        application:applications: [read]
+        application:applicationsets: [read]
 
 ingress:
   # Sets the ingress class to use.

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2024 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+// AccessTokener provides an interface to retrieve an access token.
+type AccessTokener interface {
+	Get() string
+}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -195,7 +195,7 @@ func (h *Handler) GetApiV1OrganizationsOrganizationIDAcl(w http.ResponseWriter, 
 }
 
 func (h *Handler) GetApiV1OrganizationsOrganizationIDRoles(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter) {
-	if err := rbac.AllowOrganizationScope(r.Context(), "roles", openapi.Read, organizationID); err != nil {
+	if err := rbac.AllowOrganizationScope(r.Context(), "identity:roles", openapi.Read, organizationID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -211,7 +211,7 @@ func (h *Handler) GetApiV1OrganizationsOrganizationIDRoles(w http.ResponseWriter
 }
 
 func (h *Handler) GetApiV1OrganizationsOrganizationIDOauth2providers(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter) {
-	if err := rbac.AllowOrganizationScope(r.Context(), "oauth2providers", openapi.Read, organizationID); err != nil {
+	if err := rbac.AllowOrganizationScope(r.Context(), "identity:oauth2providers", openapi.Read, organizationID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -227,7 +227,7 @@ func (h *Handler) GetApiV1OrganizationsOrganizationIDOauth2providers(w http.Resp
 }
 
 func (h *Handler) PostApiV1OrganizationsOrganizationIDOauth2providers(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter) {
-	if err := rbac.AllowOrganizationScope(r.Context(), "oauth2providers", openapi.Create, organizationID); err != nil {
+	if err := rbac.AllowOrganizationScope(r.Context(), "identity:oauth2providers", openapi.Create, organizationID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -250,7 +250,7 @@ func (h *Handler) PostApiV1OrganizationsOrganizationIDOauth2providers(w http.Res
 }
 
 func (h *Handler) PutApiV1OrganizationsOrganizationIDOauth2providersProviderID(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter, providerID openapi.Oauth2ProvderIDParameter) {
-	if err := rbac.AllowOrganizationScope(r.Context(), "oauth2providers", openapi.Update, organizationID); err != nil {
+	if err := rbac.AllowOrganizationScope(r.Context(), "identity:oauth2providers", openapi.Update, organizationID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -272,7 +272,7 @@ func (h *Handler) PutApiV1OrganizationsOrganizationIDOauth2providersProviderID(w
 }
 
 func (h *Handler) DeleteApiV1OrganizationsOrganizationIDOauth2providersProviderID(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter, providerID openapi.Oauth2ProvderIDParameter) {
-	if err := rbac.AllowOrganizationScope(r.Context(), "oauth2providers", openapi.Delete, organizationID); err != nil {
+	if err := rbac.AllowOrganizationScope(r.Context(), "identity:oauth2providers", openapi.Delete, organizationID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -298,7 +298,7 @@ func (h *Handler) GetApiV1Organizations(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h *Handler) GetApiV1OrganizationsOrganizationID(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter) {
-	if err := rbac.AllowOrganizationScope(r.Context(), "organizations", openapi.Read, organizationID); err != nil {
+	if err := rbac.AllowOrganizationScope(r.Context(), "identity:organizations", openapi.Read, organizationID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -314,7 +314,7 @@ func (h *Handler) GetApiV1OrganizationsOrganizationID(w http.ResponseWriter, r *
 }
 
 func (h *Handler) PutApiV1OrganizationsOrganizationID(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter) {
-	if err := rbac.AllowOrganizationScope(r.Context(), "organizations", openapi.Update, organizationID); err != nil {
+	if err := rbac.AllowOrganizationScope(r.Context(), "identity:organizations", openapi.Update, organizationID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -336,7 +336,7 @@ func (h *Handler) PutApiV1OrganizationsOrganizationID(w http.ResponseWriter, r *
 }
 
 func (h *Handler) GetApiV1OrganizationsOrganizationIDAvailableGroups(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter) {
-	if err := rbac.AllowOrganizationScope(r.Context(), "groups", openapi.Read, organizationID); err != nil {
+	if err := rbac.AllowOrganizationScope(r.Context(), "identity:groups", openapi.Read, organizationID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -352,7 +352,7 @@ func (h *Handler) GetApiV1OrganizationsOrganizationIDAvailableGroups(w http.Resp
 }
 
 func (h *Handler) GetApiV1OrganizationsOrganizationIDGroups(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter) {
-	if err := rbac.AllowOrganizationScope(r.Context(), "groups", openapi.Read, organizationID); err != nil {
+	if err := rbac.AllowOrganizationScope(r.Context(), "identity:groups", openapi.Read, organizationID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -368,7 +368,7 @@ func (h *Handler) GetApiV1OrganizationsOrganizationIDGroups(w http.ResponseWrite
 }
 
 func (h *Handler) PostApiV1OrganizationsOrganizationIDGroups(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter) {
-	if err := rbac.AllowOrganizationScope(r.Context(), "groups", openapi.Create, organizationID); err != nil {
+	if err := rbac.AllowOrganizationScope(r.Context(), "identity:groups", openapi.Create, organizationID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -391,7 +391,7 @@ func (h *Handler) PostApiV1OrganizationsOrganizationIDGroups(w http.ResponseWrit
 }
 
 func (h *Handler) GetApiV1OrganizationsOrganizationIDGroupsGroupid(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter, groupID openapi.GroupidParameter) {
-	if err := rbac.AllowOrganizationScope(r.Context(), "groups", openapi.Read, organizationID); err != nil {
+	if err := rbac.AllowOrganizationScope(r.Context(), "identity:groups", openapi.Read, organizationID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -407,7 +407,7 @@ func (h *Handler) GetApiV1OrganizationsOrganizationIDGroupsGroupid(w http.Respon
 }
 
 func (h *Handler) DeleteApiV1OrganizationsOrganizationIDGroupsGroupid(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter, groupID openapi.GroupidParameter) {
-	if err := rbac.AllowOrganizationScope(r.Context(), "groups", openapi.Delete, organizationID); err != nil {
+	if err := rbac.AllowOrganizationScope(r.Context(), "identity:groups", openapi.Delete, organizationID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -422,7 +422,7 @@ func (h *Handler) DeleteApiV1OrganizationsOrganizationIDGroupsGroupid(w http.Res
 }
 
 func (h *Handler) PutApiV1OrganizationsOrganizationIDGroupsGroupid(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter, groupID openapi.GroupidParameter) {
-	if err := rbac.AllowOrganizationScope(r.Context(), "groups", openapi.Update, organizationID); err != nil {
+	if err := rbac.AllowOrganizationScope(r.Context(), "identity:groups", openapi.Update, organizationID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -452,7 +452,7 @@ func (h *Handler) GetApiV1OrganizationsOrganizationIDProjects(w http.ResponseWri
 
 	// Apply RBAC after listing as a filter.
 	result = slices.DeleteFunc(result, func(resource openapi.ProjectRead) bool {
-		return rbac.AllowProjectScope(r.Context(), "projects", openapi.Read, organizationID, resource.Metadata.Id) != nil
+		return rbac.AllowProjectScope(r.Context(), "identity:projects", openapi.Read, organizationID, resource.Metadata.Id) != nil
 	})
 
 	h.setUncacheable(w)
@@ -460,7 +460,7 @@ func (h *Handler) GetApiV1OrganizationsOrganizationIDProjects(w http.ResponseWri
 }
 
 func (h *Handler) PostApiV1OrganizationsOrganizationIDProjects(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter) {
-	if err := rbac.AllowOrganizationScope(r.Context(), "projects", openapi.Create, organizationID); err != nil {
+	if err := rbac.AllowOrganizationScope(r.Context(), "identity:projects", openapi.Create, organizationID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -483,7 +483,7 @@ func (h *Handler) PostApiV1OrganizationsOrganizationIDProjects(w http.ResponseWr
 }
 
 func (h *Handler) GetApiV1OrganizationsOrganizationIDProjectsProjectID(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter, projectID openapi.ProjectIDParameter) {
-	if err := rbac.AllowProjectScope(r.Context(), "projects", openapi.Read, organizationID, projectID); err != nil {
+	if err := rbac.AllowProjectScope(r.Context(), "identity:projects", openapi.Read, organizationID, projectID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -499,7 +499,7 @@ func (h *Handler) GetApiV1OrganizationsOrganizationIDProjectsProjectID(w http.Re
 }
 
 func (h *Handler) PutApiV1OrganizationsOrganizationIDProjectsProjectID(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter, projectID openapi.ProjectIDParameter) {
-	if err := rbac.AllowProjectScope(r.Context(), "projects", openapi.Update, organizationID, projectID); err != nil {
+	if err := rbac.AllowProjectScope(r.Context(), "identity:projects", openapi.Update, organizationID, projectID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -521,7 +521,7 @@ func (h *Handler) PutApiV1OrganizationsOrganizationIDProjectsProjectID(w http.Re
 }
 
 func (h *Handler) DeleteApiV1OrganizationsOrganizationIDProjectsProjectID(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter, projectID openapi.ProjectIDParameter) {
-	if err := rbac.AllowProjectScope(r.Context(), "projects", openapi.Delete, organizationID, projectID); err != nil {
+	if err := rbac.AllowProjectScope(r.Context(), "identity:projects", openapi.Delete, organizationID, projectID); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}

--- a/pkg/handler/organizations/client.go
+++ b/pkg/handler/organizations/client.go
@@ -149,7 +149,7 @@ func (c *Client) List(ctx context.Context, rbacClient *rbac.RBAC) (openapi.Organ
 	// will have an unscoped ACL, so can check for global access to all organizations.
 	// If we don't have that then we need to use RBAC to get a list of organizations we are
 	// members of and return only them.
-	if err := rbac.AllowGlobalScope(ctx, "organizations", openapi.Read); err != nil {
+	if err := rbac.AllowGlobalScope(ctx, "identity:organizations", openapi.Read); err != nil {
 		userinfo, err := authorization.UserinfoFromContext(ctx)
 		if err != nil {
 			return nil, errors.OAuth2ServerError("userinfo is not set").WithError(err)

--- a/pkg/middleware/openapi/accesstoken/context.go
+++ b/pkg/middleware/openapi/accesstoken/context.go
@@ -40,3 +40,24 @@ func FromContext(ctx context.Context) (string, error) {
 
 	return "", errors.ErrInvalidContext
 }
+
+type Getter struct {
+	accessToken string
+}
+
+func NewGetter(ctx context.Context) (*Getter, error) {
+	accessToken, err := FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	getter := &Getter{
+		accessToken: accessToken,
+	}
+
+	return getter, nil
+}
+
+func (a *Getter) Get() string {
+	return a.accessToken
+}


### PR DESCRIPTION
In the old world, before service accounts, the user needed excess premissions to achieve anything, as the token was propagated around services.  You couldn't have a user that could just provision Kubernetes, they needed to be able to provision identities and physical networks too, the latter is a major concern when it comes to DoS attacks against the platform via the API.