### PR TITLE
Fix CodeQL Warnings

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.51
-appVersion: v0.2.51
+version: v0.2.52-rc1
+appVersion: v0.2.52-rc1
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/jose/jose.go
+++ b/pkg/jose/jose.go
@@ -489,6 +489,10 @@ const (
 	//nolint:gosec
 	TokenTypeLoginState TokenType = "unikorn-cloud.org/loginstate+jwt"
 
+	// TokenTypeLoginDialogState is deinfed by us to prevent reuse in other contexts.
+	//nolint:gosec
+	TokenTypeLoginDialogState TokenType = "unikorn-cloud.org/logindialogstate+jwt"
+
 	// TokenTypeRefreshToken is defined to prevent reuse in other contexts.
 	//nolint:gosec
 	TokenTypeRefreshToken TokenType = "unikorn-cloud.org/rt+jwt"


### PR DESCRIPTION
For the most part it's not relying on user provided query parameters for driving redirects or template rendering.

Fixes #151 and #152