### PR TITLE
Fixes for Refresh Tokens

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.52-rc5
-appVersion: v0.2.52-rc5
+version: v0.2.52-rc6
+appVersion: v0.2.52-rc6
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/oauth2/oauth2_test.go
+++ b/pkg/oauth2/oauth2_test.go
@@ -89,7 +89,7 @@ func TestTokens(t *testing.T) {
 		Subject:  "barry@foo.com",
 		Federated: &oauth2.Federated{
 			AccessToken:  "foo",
-			RefreshToken: &refreshToken,
+			RefreshToken: refreshToken,
 			Expiry:       time.Now().Add(2 * accessTokenDuration),
 		},
 	}

--- a/pkg/oauth2/tokens.go
+++ b/pkg/oauth2/tokens.go
@@ -113,7 +113,7 @@ type Federated struct {
 	Provider     string
 	Expiry       time.Time
 	AccessToken  string
-	RefreshToken *string
+	RefreshToken string
 }
 
 // ServiceAccount is any information required to issue a service account access token.
@@ -225,7 +225,10 @@ func (a *Authenticator) Issue(ctx context.Context, info *IssueInfo) (*Tokens, er
 		Expiry:      expiry,
 	}
 
-	if info.Federated != nil && info.Federated.RefreshToken != nil {
+	// Only supply a refresh token if the provider provided one.  We can then
+	// guarantee that all calls to refresh will then reauthenticate against
+	// the provider.
+	if info.Federated != nil && info.Federated.RefreshToken != "" {
 		rtClaims := &RefreshTokenClaims{
 			Claims: jwt.Claims{
 				ID:      uuid.New().String(),
@@ -241,7 +244,7 @@ func (a *Authenticator) Issue(ctx context.Context, info *IssueInfo) (*Tokens, er
 			Custom: &CustomRefreshTokenClaims{
 				Provider:     info.Federated.Provider,
 				ClientID:     info.ClientID,
-				RefreshToken: *info.Federated.RefreshToken,
+				RefreshToken: info.Federated.RefreshToken,
 			},
 		}
 


### PR DESCRIPTION
Not done enough testing with non-Google evidently.  This fixes a bunch of issues with providers that don't support refresh tokens.  And also fixes Google that got broken somewhere along the way.