### PR TITLE
Auto-Generate Quotas

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.53-rc4
-appVersion: v0.2.53-rc4
+version: v0.2.53-rc5
+appVersion: v0.2.53-rc5
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/handler/organizations/client.go
+++ b/pkg/handler/organizations/client.go
@@ -186,7 +186,6 @@ func (c *Client) List(ctx context.Context, rbacClient *rbac.RBAC) (openapi.Organ
 		return nil, errors.OAuth2ServerError("failed to list organizations").WithError(err)
 	}
 
-	// TODO: service accounts???
 	users, err := rbacClient.GetActiveUsers(ctx, info.Userinfo.Sub)
 	if err != nil {
 		return nil, errors.OAuth2ServerError("failed to list active subjects").WithError(err)


### PR DESCRIPTION
Elegant upgrade path alert... if an organization quota does not exist, then create a virtual one.  If an individual quota doesn't exist, then create a virtual one from the metadata.  If some old quotas exist, then delete them!