### PR TITLE
OpenID Connect Conformance Part 2

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.57-rc1
-appVersion: v0.2.57-rc1
+version: v0.2.57-rc2
+appVersion: v0.2.57-rc2
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -130,6 +130,7 @@ func (h *Handler) GetWellKnownOpenidConfiguration(w http.ResponseWriter, r *http
 			openapi.ES512,
 		},
 		CodeChallengeMethodsSupported: []openapi.CodeChallengeMethod{
+			openapi.Plain,
 			openapi.S256,
 		},
 	}


### PR DESCRIPTION
Basic client authorization scheme and support for plain PKCE.  Sadly required for oauth2.0, even though we only supported the more secure oauth2.1.  But for interoperability :shrug: