### PR TITLE
Fix Segmentation Fault

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.57-rc13
-appVersion: v0.2.57-rc13
+version: v0.2.57-rc14
+appVersion: v0.2.57-rc14
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/middleware/openapi/local/authorizer.go
+++ b/pkg/middleware/openapi/local/authorizer.go
@@ -94,7 +94,7 @@ func (a *Authorizer) authorizeOAuth2(r *http.Request) (*authorization.Info, erro
 		Sub: claims.Subject,
 	}
 
-	if slices.Contains(claims.Custom.Scope, "email") {
+	if claims.Custom != nil && slices.Contains(claims.Custom.Scope, "email") {
 		userinfo.Email = ptr.To(claims.Subject)
 		userinfo.EmailVerified = ptr.To(true)
 	}


### PR DESCRIPTION
When building the userinfo in the local middleware we should check for scopes before derefencing.