### PR TITLE
Revoke Tokens on Code Reuse

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.58-rc3
-appVersion: v0.2.58-rc3
+version: v0.2.58-rc4
+appVersion: v0.2.58-rc4
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/identity/crds/identity.unikorn-cloud.org_users.yaml
+++ b/charts/identity/crds/identity.unikorn-cloud.org_users.yaml
@@ -65,6 +65,11 @@ spec:
                         AccessToken s the access token currently issued for the
                         session.
                       type: string
+                    authorizationCodeID:
+                      description: |-
+                        AuthorizationCodeID is the authorization code ID used to generate
+                        the tokens.
+                      type: string
                     clientID:
                       description: ClientID is the client the session is bound to.
                       type: string
@@ -75,6 +80,7 @@ spec:
                       type: string
                   required:
                   - accessToken
+                  - authorizationCodeID
                   - clientID
                   - refreshToken
                   type: object

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -314,6 +314,9 @@ type UserSignup struct {
 type UserSession struct {
 	// ClientID is the client the session is bound to.
 	ClientID string `json:"clientID"`
+	// AuthorizationCodeID is the authorization code ID used to generate
+	// the tokens.
+	AuthorizationCodeID string `json:"authorizationCodeID"`
 	// AccessToken s the access token currently issued for the
 	// session.
 	AccessToken string `json:"accessToken"`


### PR DESCRIPTION
Add a unique ID to the authorization code, when we create a new session from the code associate the tokens with this.  If the code is potentially reused because it's not in the cache, revoke any tokens associated with that code ID.