### PR TITLE
Fix Userless Login

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.58-rc8
-appVersion: v0.2.58-rc8
+version: v0.2.58-rc9
+appVersion: v0.2.58-rc9
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 


### PR DESCRIPTION
3rd party onboarding relies on a user being able to login in order to extract their identity information and make organizations etc. on their behalf.  Sadly in issuing tokens, we need to add them to a user record in order to ensure single-use and revocation, which obviously doesn't tally with the original intention of OIDC, so hack around this.