### PR TITLE
Fix Non-Federated Login Types

### DIFF
--- a/pkg/oauth2/tokens.go
+++ b/pkg/oauth2/tokens.go
@@ -413,8 +413,7 @@ func (a *Authenticator) verifyCustomClaims(ctx context.Context, info *VerifyInfo
 }
 
 func (a *Authenticator) verifyUserSession(ctx context.Context, info *VerifyInfo, claims *AccessTokenClaims) error {
-	if claims.Custom.Type != AccessTokenTypeFederated {
-		fmt.Println("not federeated")
+	if claims.Custom == nil || claims.Custom.Type != AccessTokenTypeFederated {
 		return nil
 	}
 


### PR DESCRIPTION
Only actual people should verify their user sessions, for financial grade auth e.g. services, this is ignored.