### PR TITLE
Set Onboarding Subject

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.59-rc4
-appVersion: v0.2.59-rc4
+version: v0.2.59-rc5
+appVersion: v0.2.59-rc5
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/oauth2/oauth2.go
+++ b/pkg/oauth2/oauth2.go
@@ -1105,6 +1105,7 @@ func (a *Authenticator) Onboard(w http.ResponseWriter, r *http.Request) {
 	// are well within rights!
 	info := &authorization.Info{
 		Userinfo: &openapi.Userinfo{
+			Sub:   state.IDToken.Email.Email,
 			Email: &state.IDToken.Email.Email,
 		},
 	}


### PR DESCRIPTION
Just noticed the auditing is driven off subject, not email, which we may want to switcheroo in the future as alluded to in a bunch of comments.