### PR TITLE
Add Account Creation Token Single Use

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: v0.2.59-rc5
-appVersion: v0.2.59-rc5
+version: v0.2.59-rc6
+appVersion: v0.2.59-rc6
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/oauth2/oauth2_test.go
+++ b/pkg/oauth2/oauth2_test.go
@@ -86,11 +86,12 @@ func TestTokens(t *testing.T) {
 	rbac := rbac.New(client, josetesting.Namespace, &rbac.Options{})
 
 	options := &oauth2.Options{
-		AccessTokenDuration:  accessTokenDuration,
-		RefreshTokenDuration: refreshTokenDuration,
-		TokenLeewayDuration:  accessTokenDuration,
-		TokenCacheSize:       1024,
-		CodeCacheSize:        1024,
+		AccessTokenDuration:      accessTokenDuration,
+		RefreshTokenDuration:     refreshTokenDuration,
+		TokenLeewayDuration:      accessTokenDuration,
+		TokenCacheSize:           1024,
+		CodeCacheSize:            1024,
+		AccountCreationCacheSize: 1024,
 	}
 
 	authenticator := oauth2.New(options, josetesting.Namespace, client, issuer, rbac)


### PR DESCRIPTION
The exfiltration of a token can lead to multiple accounts being created and impersonation.  Limit the token to a single use and add a cache timeout to expire the token.