### PR TITLE
Expand Kubectl Tooling

### DIFF
--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -22,16 +22,16 @@ import (
 	"github.com/unikorn-cloud/identity/pkg/cmd/factory"
 )
 
-func GetCommand(factory *factory.Factory) *cobra.Command {
+func Command(factory *factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a resource",
 	}
 
 	cmd.AddCommand(
-		getCreateOrganization(factory),
-		getCreateUser(factory),
-		getCreateGroup(factory),
+		createOrganization(factory),
+		createUser(factory),
+		createGroup(factory),
 	)
 
 	return cmd

--- a/pkg/cmd/create/create_group.go
+++ b/pkg/cmd/create/create_group.go
@@ -252,7 +252,7 @@ func (o *createGroupOptions) execute(ctx context.Context, cli client.Client) err
 	return nil
 }
 
-func getCreateGroup(factory *factory.Factory) *cobra.Command {
+func createGroup(factory *factory.Factory) *cobra.Command {
 	o := createGroupOptions{
 		ConfigFlags: factory.ConfigFlags,
 	}

--- a/pkg/cmd/create/create_organization.go
+++ b/pkg/cmd/create/create_organization.go
@@ -135,7 +135,7 @@ func (o *createOrganizationOptions) execute(ctx context.Context, cli client.Clie
 	return nil
 }
 
-func getCreateOrganization(factory *factory.Factory) *cobra.Command {
+func createOrganization(factory *factory.Factory) *cobra.Command {
 	o := createOrganizationOptions{
 		ConfigFlags: factory.ConfigFlags,
 	}

--- a/pkg/cmd/create/create_user.go
+++ b/pkg/cmd/create/create_user.go
@@ -83,7 +83,7 @@ func (o *createUserOptions) execute(ctx context.Context, cli client.Client) erro
 	return nil
 }
 
-func getCreateUser(factory *factory.Factory) *cobra.Command {
+func createUser(factory *factory.Factory) *cobra.Command {
 	o := createUserOptions{
 		ConfigFlags: factory.ConfigFlags,
 	}

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -14,48 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package get
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 
-	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
-	"github.com/unikorn-cloud/identity/pkg/cmd/create"
 	"github.com/unikorn-cloud/identity/pkg/cmd/factory"
-	"github.com/unikorn-cloud/identity/pkg/cmd/get"
-
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
-func main() {
-	if err := unikornv1.AddToScheme(scheme.Scheme); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
+func Command(factory *factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "kubectl-unikorn",
-		Short: "Unikorn kubectl plugin",
-	}
-
-	factory := factory.NewFactory()
-	factory.AddFlags(cmd.PersistentFlags())
-
-	if err := factory.RegisterCompletionFunctions(cmd); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		Use:   "get",
+		Short: "Get resource information",
 	}
 
 	cmd.AddCommand(
-		create.Command(factory),
-		get.Command(factory),
+		getUser(factory),
 	)
 
-	if err := cmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+	return cmd
 }

--- a/pkg/cmd/get/get_user.go
+++ b/pkg/cmd/get/get_user.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2024-2025 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/unikorn-cloud/core/pkg/constants"
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/identity/pkg/cmd/factory"
+	"github.com/unikorn-cloud/identity/pkg/cmd/flags"
+	"github.com/unikorn-cloud/identity/pkg/cmd/util"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	ErrConsistency = errors.New("consistency error")
+)
+
+type createUserOptions struct {
+	ConfigFlags *genericclioptions.ConfigFlags
+
+	organization flags.HostnameVar
+	email        string
+
+	organizationID        string
+	organizationNamespace string
+}
+
+func (o *createUserOptions) AddFlags(cmd *cobra.Command, factory *factory.Factory) error {
+	cmd.Flags().Var(&o.organization, "organization", "Organization name.")
+	cmd.Flags().StringVar(&o.email, "email", "", "User subject email address.")
+
+	if err := cmd.RegisterFlagCompletionFunc("organization", factory.ResourceNameCompletionFunc("organization.identity.unikorn-cloud.org", "")); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateOrganization ensures the organization doesn't already exist.
+func (o *createUserOptions) validateOrganization(ctx context.Context, cli client.Client) error {
+	if o.organization.String() == "" {
+		return nil
+	}
+
+	organization, err := util.GetOrganization(ctx, cli, *o.ConfigFlags.Namespace, o.organization.String())
+	if err != nil {
+		return err
+	}
+
+	o.organizationID = organization.Name
+	o.organizationNamespace = organization.Status.Namespace
+
+	return nil
+}
+
+func (o *createUserOptions) validate(ctx context.Context, cli client.Client) error {
+	validators := []func(context.Context, client.Client) error{
+		o.validateOrganization,
+	}
+
+	for _, validator := range validators {
+		if err := validator(ctx, cli); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+//nolint:cyclop
+func (o *createUserOptions) execute(ctx context.Context, cli client.Client) error {
+	users := &unikornv1.UserList{}
+
+	if err := cli.List(ctx, users, &client.ListOptions{}); err != nil {
+		return err
+	}
+
+	userIndex := make(map[string]*unikornv1.User, len(users.Items))
+
+	for i := range users.Items {
+		userIndex[users.Items[i].Name] = &users.Items[i]
+	}
+
+	organizations := &unikornv1.OrganizationList{}
+
+	if err := cli.List(ctx, organizations, &client.ListOptions{}); err != nil {
+		return err
+	}
+
+	organizationIndex := make(map[string]*unikornv1.Organization, len(organizations.Items))
+
+	for i := range organizations.Items {
+		organizationIndex[organizations.Items[i].Name] = &organizations.Items[i]
+	}
+
+	organizationUsers := &unikornv1.OrganizationUserList{}
+
+	if err := cli.List(ctx, organizationUsers, &client.ListOptions{}); err != nil {
+		return err
+	}
+
+	table := &metav1.Table{
+		ColumnDefinitions: []metav1.TableColumnDefinition{
+			{
+				Name: "namespace",
+			},
+			{
+				Name: "id",
+			},
+			{
+				Name: "email",
+			},
+			{
+				Name: "organization",
+			},
+		},
+		Rows: make([]metav1.TableRow, 0, len(organizationUsers.Items)),
+	}
+
+	for i := range organizationUsers.Items {
+		ou := &organizationUsers.Items[i]
+
+		user, ok := userIndex[ou.Labels[constants.UserLabel]]
+		if !ok {
+			return fmt.Errorf("%w: organization user %s in namespace %s doesn't have corresponding user resource", ErrConsistency, ou.Name, ou.Namespace)
+		}
+
+		if o.email != "" && user.Spec.Subject != o.email {
+			continue
+		}
+
+		organization, ok := organizationIndex[ou.Labels[constants.OrganizationLabel]]
+		if !ok {
+			return fmt.Errorf("%w: organization user %s in namespace %s doesn't have corresponding organization resource", ErrConsistency, ou.Name, ou.Namespace)
+		}
+
+		if o.organizationID != "" && organization.Name != o.organizationID {
+			continue
+		}
+
+		table.Rows = append(table.Rows, metav1.TableRow{
+			Cells: []interface{}{
+				ou.Namespace,
+				ou.Name,
+				user.Spec.Subject,
+				organization.Labels[constants.NameLabel],
+			},
+		})
+	}
+
+	return printers.NewTablePrinter(printers.PrintOptions{}).PrintObj(table, os.Stdout)
+}
+
+func getUser(factory *factory.Factory) *cobra.Command {
+	o := createUserOptions{
+		ConfigFlags: factory.ConfigFlags,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "user",
+		Short: "List users",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+
+			client, err := factory.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := o.validate(ctx, client); err != nil {
+				return err
+			}
+
+			if err := o.execute(ctx, client); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	if err := o.AddFlags(cmd, factory); err != nil {
+		panic(err)
+	}
+
+	return cmd
+}


### PR DESCRIPTION
Make following the links easier by doing it for you and outputting as a nice table.  This allows targetted filtering based on email or organization name for ease of support.  It also allows consistency checking across the whole estate as a sanity check.