### PR TITLE
Remove overly generic go build rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,10 +109,6 @@ all: $(COMMAND_BINARIES) $(CONTROLLER_BINARIES) $(CRDDIR)
 $(BINDIR) $(BINDIR)/amd64-linux $(BINDIR)/arm64-linux $(BINDIR)/amd64-darwin $(BINDIR)/arm64-darwin:
 	mkdir -p $@
 
-# Create a binary from a command.
-$(BINDIR)/%: $(SOURCES) $(GENDIR) $(OPENAPI_FILES) | $(BINDIR)
-	CGO_ENABLED=0 go build $(FLAGS) -o $@ $(CMDDIR)/$*/main.go
-
 $(BINDIR)/amd64-linux/%: $(SOURCES) $(GENDIR) $(OPENAPI_FILES) | $(BINDIR)/amd64-linux
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(FLAGS) -o $@ $(CMDDIR)/$*/main.go
 


### PR DESCRIPTION
The pattern `bin/%` matches e.g.,
`bin/amd64-linux/unikorn-controller`, but will bind `$*` to `amd64-linux/unikorn-controller` in the recipe and thereby fail.

The (GNU) make pre-installed in MacOS falls foul of this, but brew-installed GNU make runs OK. Still, let's avoid ambiguity if we don't need it.
