### PR TITLE
Add Some Tests for Principal Behavior

### DIFF
--- a/pkg/handler/common/common.go
+++ b/pkg/handler/common/common.go
@@ -265,6 +265,10 @@ func SetIdentityMetadata(ctx context.Context, meta *metav1.ObjectMeta) error {
 		return err
 	}
 
+	if meta.Annotations == nil {
+		meta.Annotations = map[string]string{}
+	}
+
 	meta.Annotations[constants.CreatorAnnotation] = info.Userinfo.Sub
 
 	principal, err := principal.FromContext(ctx)
@@ -275,10 +279,18 @@ func SetIdentityMetadata(ctx context.Context, meta *metav1.ObjectMeta) error {
 	meta.Annotations[constants.CreatorPrincipalAnnotation] = principal.Actor
 
 	if principal.OrganizationID != "" {
+		if meta.Labels == nil {
+			meta.Labels = map[string]string{}
+		}
+
 		meta.Labels[constants.OrganizationPrincipalLabel] = principal.OrganizationID
 	}
 
 	if principal.ProjectID != "" {
+		if meta.Labels == nil {
+			meta.Labels = map[string]string{}
+		}
+
 		meta.Labels[constants.ProjectPrincipalLabel] = principal.ProjectID
 	}
 

--- a/pkg/handler/common/common_test.go
+++ b/pkg/handler/common/common_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/core/pkg/constants"
+	"github.com/unikorn-cloud/identity/pkg/handler/common"
+	"github.com/unikorn-cloud/identity/pkg/handler/common/fixtures"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestMetadataCreate ensures identity and principal information is correcly
+// applied to an unscoped object.
+func TestMetadataCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx := fixtures.HandlerContextFixture(t.Context(), 0)
+
+	meta := &metav1.ObjectMeta{}
+
+	require.NoError(t, common.SetIdentityMetadata(ctx, meta))
+
+	require.Nil(t, meta.Labels)
+
+	require.NotNil(t, meta.Annotations)
+	require.Equal(t, fixtures.TokenActor, meta.Annotations[constants.CreatorAnnotation])
+	require.Equal(t, fixtures.PrincipalActor, meta.Annotations[constants.CreatorPrincipalAnnotation])
+}
+
+// TestMetadataCreateWithOrganization ensures identity and principal information is correcly
+// applied to an organization scoped object.
+func TestMetadataCreateWithOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx := fixtures.HandlerContextFixture(t.Context(), fixtures.WithOrganization)
+
+	meta := &metav1.ObjectMeta{}
+
+	require.NoError(t, common.SetIdentityMetadata(ctx, meta))
+
+	require.NotNil(t, meta.Labels)
+	require.Equal(t, fixtures.PrincipalOrganizationID, meta.Labels[constants.OrganizationPrincipalLabel])
+	require.NotContains(t, meta.Labels, constants.ProjectPrincipalLabel)
+
+	require.NotNil(t, meta.Annotations)
+	require.Equal(t, fixtures.TokenActor, meta.Annotations[constants.CreatorAnnotation])
+	require.Equal(t, fixtures.PrincipalActor, meta.Annotations[constants.CreatorPrincipalAnnotation])
+}
+
+// TestMetadataCreateWithProject ensures identity and principal information is correcly
+// applied to a project scoped object.
+func TestMetadataCreateWithProject(t *testing.T) {
+	t.Parallel()
+
+	ctx := fixtures.HandlerContextFixture(t.Context(), fixtures.WithProject)
+
+	meta := &metav1.ObjectMeta{}
+
+	require.NoError(t, common.SetIdentityMetadata(ctx, meta))
+
+	require.NotNil(t, meta.Labels)
+	require.Equal(t, fixtures.PrincipalOrganizationID, meta.Labels[constants.OrganizationPrincipalLabel])
+	require.Equal(t, fixtures.PrincipalProjectID, meta.Labels[constants.ProjectPrincipalLabel])
+
+	require.NotNil(t, meta.Annotations)
+	require.Equal(t, fixtures.TokenActor, meta.Annotations[constants.CreatorAnnotation])
+	require.Equal(t, fixtures.PrincipalActor, meta.Annotations[constants.CreatorPrincipalAnnotation])
+}

--- a/pkg/handler/common/fixtures/fixtures.go
+++ b/pkg/handler/common/fixtures/fixtures.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fixtures
+
+import (
+	"context"
+
+	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
+	"github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/principal"
+)
+
+const (
+	TokenActor = "ella.purnell"
+
+	PrincipalActor          = "robert.denero"
+	PrincipalOrganizationID = "f18ccbbe-e61b-4fe9-bc00-2661f792f39e"
+	PrincipalProjectID      = "ec9145b2-91dd-408b-8d8f-d4b5e3c6c360"
+
+	WithOrganization = 1 << iota
+	WithProject
+)
+
+// HandlerContextFixture provides the necessary identity based context
+// for a handler unit test.
+func HandlerContextFixture(ctx context.Context, flags int) context.Context {
+	info := &authorization.Info{
+		Userinfo: &openapi.Userinfo{
+			Sub: TokenActor,
+		},
+	}
+
+	p := &principal.Principal{
+		Actor: PrincipalActor,
+	}
+
+	if flags&(WithOrganization|WithProject) != 0 {
+		p.OrganizationID = PrincipalOrganizationID
+	}
+
+	if flags&WithProject != 0 {
+		p.ProjectID = PrincipalProjectID
+	}
+
+	ctx = authorization.NewContext(ctx, info)
+	ctx = principal.NewContext(ctx, p)
+
+	return ctx
+}


### PR DESCRIPTION
Basically codify the expected behaviour of principals with regards to resource creation, and expose it as a fixture library for tests in other packages/repositories.