### PR TITLE
test(api): expand integration test coverage for service accounts, users, and projects

### DIFF
--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -143,8 +143,12 @@ func (c *APIClient) GetProject(ctx context.Context, orgID, projectID string) (*i
 	path := c.endpoints.GetProject(orgID, projectID)
 
 	//nolint:bodyclose // DoRequest handles response body closing internally
-	_, respBody, err := c.DoRequest(ctx, http.MethodGet, path, nil, http.StatusOK)
+	resp, respBody, err := c.DoRequest(ctx, http.MethodGet, path, nil, http.StatusOK)
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("project %s: %w", projectID, coreclient.ErrResourceNotFound)
+		}
+
 		return nil, fmt.Errorf("getting project: %w", err)
 	}
 
@@ -358,4 +362,318 @@ func (c *APIClient) GetQuotas(ctx context.Context, orgID string) (*identityopena
 	}
 
 	return &quotas, nil
+}
+
+// SetQuotas updates the quotas for an organization.
+func (c *APIClient) SetQuotas(ctx context.Context, orgID string, quotas identityopenapi.QuotasWrite) (*identityopenapi.QuotasRead, error) {
+	path := c.endpoints.GetQuotas(orgID)
+
+	body, err := json.Marshal(quotas)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling quotas: %w", err)
+	}
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	_, respBody, err := c.DoRequest(ctx, http.MethodPut, path, bytes.NewReader(body), http.StatusOK)
+	if err != nil {
+		return nil, fmt.Errorf("setting quotas: %w", err)
+	}
+
+	var updated identityopenapi.QuotasRead
+	if err := json.Unmarshal(respBody, &updated); err != nil {
+		return nil, fmt.Errorf("unmarshaling updated quotas: %w", err)
+	}
+
+	return &updated, nil
+}
+
+// UpdateOrganization updates an organization.
+func (c *APIClient) UpdateOrganization(ctx context.Context, orgID string, org identityopenapi.OrganizationWrite) error {
+	return putResourceVoid(c, ctx, c.endpoints.GetOrganization(orgID), orgID, "organization", org)
+}
+
+// CreateProject creates a new project in an organization.
+func (c *APIClient) CreateProject(ctx context.Context, orgID string, project identityopenapi.ProjectWrite) (*identityopenapi.ProjectRead, error) {
+	path := c.endpoints.ListProjects(orgID)
+
+	body, err := json.Marshal(project)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling project: %w", err)
+	}
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	_, respBody, err := c.DoRequest(ctx, http.MethodPost, path, bytes.NewReader(body), http.StatusAccepted)
+	if err != nil {
+		return nil, fmt.Errorf("creating project: %w", err)
+	}
+
+	var created identityopenapi.ProjectRead
+	if err := json.Unmarshal(respBody, &created); err != nil {
+		return nil, fmt.Errorf("unmarshaling created project: %w", err)
+	}
+
+	return &created, nil
+}
+
+// UpdateProject updates an existing project.
+func (c *APIClient) UpdateProject(ctx context.Context, orgID, projectID string, project identityopenapi.ProjectWrite) error {
+	return putResourceVoid(c, ctx, c.endpoints.GetProject(orgID, projectID), projectID, "project", project)
+}
+
+// DeleteProject deletes a project from an organization.
+func (c *APIClient) DeleteProject(ctx context.Context, orgID, projectID string) error {
+	path := c.endpoints.GetProject(orgID, projectID)
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	resp, _, err := c.DoRequest(ctx, http.MethodDelete, path, nil, http.StatusAccepted)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("project %s: %w", projectID, coreclient.ErrResourceNotFound)
+		}
+
+		return fmt.Errorf("deleting project: %w", err)
+	}
+
+	return nil
+}
+
+// CreateServiceAccount creates a new service account in an organization.
+// The returned ServiceAccountCreate.Status.AccessToken is non-nil and contains
+// the one-time access token — it is only present on create and rotate responses.
+func (c *APIClient) CreateServiceAccount(ctx context.Context, orgID string, sa identityopenapi.ServiceAccountWrite) (*identityopenapi.ServiceAccountCreate, error) {
+	path := c.endpoints.ListServiceAccounts(orgID)
+
+	body, err := json.Marshal(sa)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling service account: %w", err)
+	}
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	_, respBody, err := c.DoRequest(ctx, http.MethodPost, path, bytes.NewReader(body), http.StatusCreated)
+	if err != nil {
+		return nil, fmt.Errorf("creating service account: %w", err)
+	}
+
+	var created identityopenapi.ServiceAccountCreate
+	if err := json.Unmarshal(respBody, &created); err != nil {
+		return nil, fmt.Errorf("unmarshaling created service account: %w", err)
+	}
+
+	return &created, nil
+}
+
+// putResourceVoid marshals req and PUTs it to path, discarding the response body.
+// It maps 404 responses to coreclient.ErrResourceNotFound.
+func putResourceVoid[Req any](c *APIClient, ctx context.Context, path, resourceID, resourceKind string, req Req) error {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", resourceKind, err)
+	}
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	resp, _, err := c.DoRequest(ctx, http.MethodPut, path, bytes.NewReader(body), http.StatusOK)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("%s %s: %w", resourceKind, resourceID, coreclient.ErrResourceNotFound)
+		}
+
+		return fmt.Errorf("updating %s: %w", resourceKind, err)
+	}
+
+	return nil
+}
+
+// putResource marshals req, PUTs it to path, and unmarshals the response into R.
+// It maps 404 responses to coreclient.ErrResourceNotFound using resourceKind and resourceID in error messages.
+func putResource[Req, R any](c *APIClient, ctx context.Context, path, resourceID, resourceKind string, req Req) (*R, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling %s: %w", resourceKind, err)
+	}
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	resp, respBody, err := c.DoRequest(ctx, http.MethodPut, path, bytes.NewReader(body), http.StatusOK)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("%s %s: %w", resourceKind, resourceID, coreclient.ErrResourceNotFound)
+		}
+
+		return nil, fmt.Errorf("updating %s: %w", resourceKind, err)
+	}
+
+	var result R
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("unmarshaling updated %s: %w", resourceKind, err)
+	}
+
+	return &result, nil
+}
+
+// UpdateServiceAccount updates an existing service account.
+func (c *APIClient) UpdateServiceAccount(ctx context.Context, orgID, saID string, sa identityopenapi.ServiceAccountWrite) (*identityopenapi.ServiceAccountRead, error) {
+	return putResource[identityopenapi.ServiceAccountWrite, identityopenapi.ServiceAccountRead](
+		c, ctx, c.endpoints.GetServiceAccount(orgID, saID), saID, "service account", sa)
+}
+
+// DeleteServiceAccount deletes a service account from an organization.
+func (c *APIClient) DeleteServiceAccount(ctx context.Context, orgID, saID string) error {
+	path := c.endpoints.GetServiceAccount(orgID, saID)
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	resp, _, err := c.DoRequest(ctx, http.MethodDelete, path, nil, http.StatusOK)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("service account %s: %w", saID, coreclient.ErrResourceNotFound)
+		}
+
+		return fmt.Errorf("deleting service account: %w", err)
+	}
+
+	return nil
+}
+
+// RotateServiceAccount rotates the access token for a service account.
+// The returned ServiceAccountCreate.Status.AccessToken contains the new one-time token.
+func (c *APIClient) RotateServiceAccount(ctx context.Context, orgID, saID string) (*identityopenapi.ServiceAccountCreate, error) {
+	path := c.endpoints.RotateServiceAccount(orgID, saID)
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	resp, respBody, err := c.DoRequest(ctx, http.MethodPost, path, nil, http.StatusOK)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("service account %s: %w", saID, coreclient.ErrResourceNotFound)
+		}
+
+		return nil, fmt.Errorf("rotating service account: %w", err)
+	}
+
+	var rotated identityopenapi.ServiceAccountCreate
+	if err := json.Unmarshal(respBody, &rotated); err != nil {
+		return nil, fmt.Errorf("unmarshaling rotated service account: %w", err)
+	}
+
+	return &rotated, nil
+}
+
+// CreateUser creates a new user in an organization.
+func (c *APIClient) CreateUser(ctx context.Context, orgID string, user identityopenapi.UserWrite) (*identityopenapi.UserRead, error) {
+	path := c.endpoints.ListUsers(orgID)
+
+	body, err := json.Marshal(user)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling user: %w", err)
+	}
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	_, respBody, err := c.DoRequest(ctx, http.MethodPost, path, bytes.NewReader(body), http.StatusCreated)
+	if err != nil {
+		return nil, fmt.Errorf("creating user: %w", err)
+	}
+
+	var created identityopenapi.UserRead
+	if err := json.Unmarshal(respBody, &created); err != nil {
+		return nil, fmt.Errorf("unmarshaling created user: %w", err)
+	}
+
+	return &created, nil
+}
+
+// UpdateUser updates an existing user.
+func (c *APIClient) UpdateUser(ctx context.Context, orgID, userID string, user identityopenapi.UserWrite) (*identityopenapi.UserRead, error) {
+	return putResource[identityopenapi.UserWrite, identityopenapi.UserRead](
+		c, ctx, c.endpoints.GetUser(orgID, userID), userID, "user", user)
+}
+
+// DeleteUser deletes a user from an organization.
+func (c *APIClient) DeleteUser(ctx context.Context, orgID, userID string) error {
+	path := c.endpoints.GetUser(orgID, userID)
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	resp, _, err := c.DoRequest(ctx, http.MethodDelete, path, nil, http.StatusOK)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("user %s: %w", userID, coreclient.ErrResourceNotFound)
+		}
+
+		return fmt.Errorf("deleting user: %w", err)
+	}
+
+	return nil
+}
+
+// ListGlobalOauth2Providers lists platform-level OAuth2 providers (not scoped to an organization).
+func (c *APIClient) ListGlobalOauth2Providers(ctx context.Context) (identityopenapi.Oauth2Providers, error) {
+	path := c.endpoints.ListGlobalOauth2Providers()
+
+	return coreclient.ListResource[identityopenapi.Oauth2ProviderRead](
+		ctx,
+		c.APIClient,
+		path,
+		coreclient.ResponseHandlerConfig{
+			ResourceType:   "oauth2providers",
+			ResourceID:     "",
+			ResourceIDType: "",
+		},
+	)
+}
+
+// ListOauth2Providers lists all OAuth2 providers in an organization.
+func (c *APIClient) ListOauth2Providers(ctx context.Context, orgID string) (identityopenapi.Oauth2Providers, error) {
+	path := c.endpoints.ListOauth2Providers(orgID)
+
+	return coreclient.ListResource[identityopenapi.Oauth2ProviderRead](
+		ctx,
+		c.APIClient,
+		path,
+		coreclient.ResponseHandlerConfig{
+			ResourceType:   "oauth2providers",
+			ResourceID:     orgID,
+			ResourceIDType: "organization",
+		},
+	)
+}
+
+// CreateOauth2Provider creates a new OAuth2 provider in an organization.
+func (c *APIClient) CreateOauth2Provider(ctx context.Context, orgID string, provider identityopenapi.Oauth2ProviderWrite) (*identityopenapi.Oauth2ProviderRead, error) {
+	path := c.endpoints.ListOauth2Providers(orgID)
+
+	body, err := json.Marshal(provider)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling oauth2provider: %w", err)
+	}
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	_, respBody, err := c.DoRequest(ctx, http.MethodPost, path, bytes.NewReader(body), http.StatusCreated)
+	if err != nil {
+		return nil, fmt.Errorf("creating oauth2provider: %w", err)
+	}
+
+	var created identityopenapi.Oauth2ProviderRead
+	if err := json.Unmarshal(respBody, &created); err != nil {
+		return nil, fmt.Errorf("unmarshaling created oauth2provider: %w", err)
+	}
+
+	return &created, nil
+}
+
+// UpdateOauth2Provider updates an existing OAuth2 provider. Returns nil on success.
+func (c *APIClient) UpdateOauth2Provider(ctx context.Context, orgID, providerID string, provider identityopenapi.Oauth2ProviderWrite) error {
+	return putResourceVoid(c, ctx, c.endpoints.GetOauth2Provider(orgID, providerID), providerID, "oauth2provider", provider)
+}
+
+// DeleteOauth2Provider deletes an OAuth2 provider from an organization.
+func (c *APIClient) DeleteOauth2Provider(ctx context.Context, orgID, providerID string) error {
+	path := c.endpoints.GetOauth2Provider(orgID, providerID)
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	resp, _, err := c.DoRequest(ctx, http.MethodDelete, path, nil, http.StatusOK)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("oauth2provider %s: %w", providerID, coreclient.ErrResourceNotFound)
+		}
+
+		return fmt.Errorf("deleting oauth2provider: %w", err)
+	}
+
+	return nil
 }

--- a/test/api/config.go
+++ b/test/api/config.go
@@ -25,11 +25,13 @@ import (
 // TestConfig extends the base config with Identity-specific fields.
 type TestConfig struct {
 	coreconfig.BaseConfig
-	AdminToken string
-	UserToken  string
-	OrgID      string
-	ProjectID  string
-	UserSAID   string
+	AdminToken   string
+	UserToken    string
+	OrgID        string
+	ProjectID    string
+	AdminGroupID string
+	UserGroupID  string
+	UserSAID     string
 }
 
 // LoadTestConfig loads configuration from environment variables and .env files using viper.
@@ -68,11 +70,13 @@ func LoadTestConfig() (*TestConfig, error) {
 			LogRequests:     v.GetBool("LOG_REQUESTS"),
 			LogResponses:    v.GetBool("LOG_RESPONSES"),
 		},
-		AdminToken: firstNonEmpty(v.GetString("ADMIN_AUTH_TOKEN"), v.GetString("API_AUTH_TOKEN")),
-		UserToken:  v.GetString("USER_AUTH_TOKEN"),
-		OrgID:      v.GetString("TEST_ORG_ID"),
-		ProjectID:  v.GetString("TEST_PROJECT_ID"),
-		UserSAID:   v.GetString("TEST_USER_SA_ID"),
+		AdminToken:   firstNonEmpty(v.GetString("ADMIN_AUTH_TOKEN"), v.GetString("API_AUTH_TOKEN")),
+		UserToken:    v.GetString("USER_AUTH_TOKEN"),
+		OrgID:        v.GetString("TEST_ORG_ID"),
+		ProjectID:    v.GetString("TEST_PROJECT_ID"),
+		AdminGroupID: v.GetString("TEST_ADMIN_GROUP_ID"),
+		UserGroupID:  v.GetString("TEST_USER_GROUP_ID"),
+		UserSAID:     v.GetString("TEST_USER_SA_ID"),
 	}
 
 	// Validate required fields

--- a/test/api/endpoints.go
+++ b/test/api/endpoints.go
@@ -94,8 +94,45 @@ func (e *Endpoints) ListServiceAccounts(orgID string) string {
 		url.PathEscape(orgID))
 }
 
+// GetServiceAccount returns the endpoint for a specific service account.
+func (e *Endpoints) GetServiceAccount(orgID, saID string) string {
+	return fmt.Sprintf("/api/v1/organizations/%s/serviceaccounts/%s",
+		url.PathEscape(orgID), url.PathEscape(saID))
+}
+
+// RotateServiceAccount returns the endpoint for rotating a service account token.
+func (e *Endpoints) RotateServiceAccount(orgID, saID string) string {
+	return fmt.Sprintf("/api/v1/organizations/%s/serviceaccounts/%s/rotate",
+		url.PathEscape(orgID), url.PathEscape(saID))
+}
+
+// GetUser returns the endpoint for a specific user.
+// Used for PUT and DELETE — the server does not expose a GET /users/{userID} route.
+func (e *Endpoints) GetUser(orgID, userID string) string {
+	return fmt.Sprintf("/api/v1/organizations/%s/users/%s",
+		url.PathEscape(orgID), url.PathEscape(userID))
+}
+
 // GetQuotas returns the endpoint for getting quotas for an organization.
 func (e *Endpoints) GetQuotas(orgID string) string {
 	return fmt.Sprintf("/api/v1/organizations/%s/quotas",
 		url.PathEscape(orgID))
+}
+
+// ListGlobalOauth2Providers returns the endpoint for listing platform-level OAuth2 providers.
+func (e *Endpoints) ListGlobalOauth2Providers() string {
+	return "/api/v1/oauth2providers"
+}
+
+// ListOauth2Providers returns the endpoint for listing OAuth2 providers in an organization.
+func (e *Endpoints) ListOauth2Providers(orgID string) string {
+	return fmt.Sprintf("/api/v1/organizations/%s/oauth2providers",
+		url.PathEscape(orgID))
+}
+
+// GetOauth2Provider returns the endpoint for a specific OAuth2 provider.
+// Used for PUT and DELETE — the server does not expose a GET /oauth2providers/{providerID} route.
+func (e *Endpoints) GetOauth2Provider(orgID, providerID string) string {
+	return fmt.Sprintf("/api/v1/organizations/%s/oauth2providers/%s",
+		url.PathEscape(orgID), url.PathEscape(providerID))
 }

--- a/test/api/fixtures.go
+++ b/test/api/fixtures.go
@@ -19,6 +19,9 @@ package api
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
@@ -26,28 +29,67 @@ import (
 	. "github.com/onsi/gomega"
 
 	coreopenapi "github.com/unikorn-cloud/core/pkg/openapi"
+	coreclient "github.com/unikorn-cloud/core/pkg/testing/client"
 	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
 )
 
-// GroupPayloadBuilder builds group payloads for testing using type-safe OpenAPI structs.
-type GroupPayloadBuilder struct {
-	group  identityopenapi.GroupWrite
-	config *TestConfig
+// uniqueName returns a name safe for concurrent or fast-sequential use:
+// a timestamp for human readability plus a 4-byte random hex suffix to
+// prevent collisions when multiple tests run within the same second.
+func uniqueName(prefix string) string {
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
+
+	return fmt.Sprintf("%s-%s-%s", prefix, time.Now().Format("20060102-150405"), hex.EncodeToString(b))
 }
 
-// NewGroupPayload creates a new group payload builder with defaults from config.
+// OrganizationPayloadBuilder builds organization write payloads for testing.
+type OrganizationPayloadBuilder struct {
+	org identityopenapi.OrganizationWrite
+}
+
+// NewOrganizationPayload creates an empty organization payload builder.
+func NewOrganizationPayload() *OrganizationPayloadBuilder {
+	return &OrganizationPayloadBuilder{}
+}
+
+// FromRead initialises the builder from an OrganizationRead, preserving the existing
+// spec so that updates don't accidentally overwrite required fields like OrganizationType.
+func (b *OrganizationPayloadBuilder) FromRead(org identityopenapi.OrganizationRead) *OrganizationPayloadBuilder {
+	b.org = identityopenapi.OrganizationWrite{
+		Metadata: coreopenapi.ResourceWriteMetadata{
+			Name: org.Metadata.Name,
+		},
+		Spec: org.Spec,
+	}
+
+	return b
+}
+
+// WithName sets the organization name.
+func (b *OrganizationPayloadBuilder) WithName(name string) *OrganizationPayloadBuilder {
+	b.org.Metadata.Name = name
+	return b
+}
+
+// Build returns the typed OrganizationWrite struct.
+func (b *OrganizationPayloadBuilder) Build() identityopenapi.OrganizationWrite {
+	return b.org
+}
+
+// GroupPayloadBuilder builds group payloads for testing using type-safe OpenAPI structs.
+type GroupPayloadBuilder struct {
+	group identityopenapi.GroupWrite
+}
+
+// NewGroupPayload creates a new group payload builder with a unique name.
 func NewGroupPayload() *GroupPayloadBuilder {
-	config, err := LoadTestConfig()
-	Expect(err).NotTo(HaveOccurred(), "Failed to load test configuration")
-
-	timestamp := time.Now().Format("20060102-150405")
-	uniqueName := fmt.Sprintf("test-group-%s", timestamp)
-
 	return &GroupPayloadBuilder{
-		config: config,
 		group: identityopenapi.GroupWrite{
 			Metadata: coreopenapi.ResourceWriteMetadata{
-				Name: uniqueName,
+				Name: uniqueName("test-group"),
 			},
 			Spec: identityopenapi.GroupSpec{
 				RoleIDs:           []string{},
@@ -75,8 +117,14 @@ func (b *GroupPayloadBuilder) WithServiceAccountIDs(serviceAccountIDs []string) 
 	return b
 }
 
-// BuildTyped returns the typed group struct directly.
-func (b *GroupPayloadBuilder) BuildTyped() identityopenapi.GroupWrite {
+// WithUserIDs sets the user IDs for the group.
+func (b *GroupPayloadBuilder) WithUserIDs(userIDs []string) *GroupPayloadBuilder {
+	b.group.Spec.UserIDs = &userIDs
+	return b
+}
+
+// Build returns the typed group struct directly.
+func (b *GroupPayloadBuilder) Build() identityopenapi.GroupWrite {
 	return b.group
 }
 
@@ -103,8 +151,354 @@ func findOrphanedGroupID(ctx context.Context, client *APIClient, config *TestCon
 	return ""
 }
 
+// ServiceAccountPayloadBuilder builds service account payloads for testing.
+type ServiceAccountPayloadBuilder struct {
+	sa identityopenapi.ServiceAccountWrite
+}
+
+// NewServiceAccountPayload creates a new service account payload builder with a unique name.
+func NewServiceAccountPayload() *ServiceAccountPayloadBuilder {
+	return &ServiceAccountPayloadBuilder{
+		sa: identityopenapi.ServiceAccountWrite{
+			Metadata: coreopenapi.ResourceWriteMetadata{
+				Name: uniqueName("test-sa"),
+			},
+			Spec: identityopenapi.ServiceAccountSpec{
+				GroupIDs: []string{},
+			},
+		},
+	}
+}
+
+// WithName sets the service account name.
+func (b *ServiceAccountPayloadBuilder) WithName(name string) *ServiceAccountPayloadBuilder {
+	b.sa.Metadata.Name = name
+	return b
+}
+
+// WithGroupIDs sets the group IDs for the service account.
+func (b *ServiceAccountPayloadBuilder) WithGroupIDs(groupIDs []string) *ServiceAccountPayloadBuilder {
+	b.sa.Spec.GroupIDs = groupIDs
+	return b
+}
+
+// Build returns the typed service account struct.
+func (b *ServiceAccountPayloadBuilder) Build() identityopenapi.ServiceAccountWrite {
+	return b.sa
+}
+
+// CreateServiceAccountWithCleanup creates a service account and schedules automatic cleanup.
+func CreateServiceAccountWithCleanup(client *APIClient, ctx context.Context, config *TestConfig, payload identityopenapi.ServiceAccountWrite) (identityopenapi.ServiceAccountCreate, string) {
+	var saID string
+
+	DeferCleanup(func() {
+		if saID == "" {
+			return
+		}
+
+		GinkgoWriter.Printf("Cleaning up service account: %s\n", saID)
+
+		if err := client.DeleteServiceAccount(ctx, config.OrgID, saID); err != nil {
+			GinkgoWriter.Printf("Warning: Failed to delete service account %s: %v\n", saID, err)
+		} else {
+			GinkgoWriter.Printf("Successfully deleted service account: %s\n", saID)
+		}
+	})
+
+	created, err := client.CreateServiceAccount(ctx, config.OrgID, payload)
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to create service account: %v", err))
+	}
+
+	saID = created.Metadata.Id
+
+	GinkgoWriter.Printf("Created service account with ID: %s\n", saID)
+
+	return *created, saID
+}
+
+// UserPayloadBuilder builds user payloads for testing.
+type UserPayloadBuilder struct {
+	user identityopenapi.UserWrite
+}
+
+// NewUserPayload creates a new user payload builder with a unique subject.
+func NewUserPayload() *UserPayloadBuilder {
+	return &UserPayloadBuilder{
+		user: identityopenapi.UserWrite{
+			Spec: identityopenapi.UserSpec{
+				Subject:  uniqueName("test-user") + "@example.com",
+				State:    "active",
+				GroupIDs: []string{},
+			},
+		},
+	}
+}
+
+// WithSubject sets the user subject (email).
+func (b *UserPayloadBuilder) WithSubject(subject string) *UserPayloadBuilder {
+	b.user.Spec.Subject = subject
+	return b
+}
+
+// WithGroupIDs sets the group IDs for the user.
+func (b *UserPayloadBuilder) WithGroupIDs(groupIDs []string) *UserPayloadBuilder {
+	b.user.Spec.GroupIDs = groupIDs
+	return b
+}
+
+// WithState sets the user state.
+func (b *UserPayloadBuilder) WithState(state identityopenapi.UserState) *UserPayloadBuilder {
+	b.user.Spec.State = state
+	return b
+}
+
+// Build returns the typed user struct.
+func (b *UserPayloadBuilder) Build() identityopenapi.UserWrite {
+	return b.user
+}
+
+// CreateUserWithCleanup creates a user and schedules automatic cleanup.
+func CreateUserWithCleanup(client *APIClient, ctx context.Context, config *TestConfig, payload identityopenapi.UserWrite) (identityopenapi.UserRead, string) {
+	var userID string
+
+	DeferCleanup(func() {
+		if userID == "" {
+			return
+		}
+
+		GinkgoWriter.Printf("Cleaning up user: %s\n", userID)
+
+		if err := client.DeleteUser(ctx, config.OrgID, userID); err != nil {
+			GinkgoWriter.Printf("Warning: Failed to delete user %s: %v\n", userID, err)
+		} else {
+			GinkgoWriter.Printf("Successfully deleted user: %s\n", userID)
+		}
+	})
+
+	created, err := client.CreateUser(ctx, config.OrgID, payload)
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to create user: %v", err))
+	}
+
+	userID = created.Metadata.Id
+
+	GinkgoWriter.Printf("Created user with ID: %s\n", userID)
+
+	return *created, userID
+}
+
+// ProjectPayloadBuilder builds project payloads for testing.
+type ProjectPayloadBuilder struct {
+	project identityopenapi.ProjectWrite
+}
+
+// NewProjectPayload creates a new project payload builder with a unique name.
+func NewProjectPayload() *ProjectPayloadBuilder {
+	return &ProjectPayloadBuilder{
+		project: identityopenapi.ProjectWrite{
+			Metadata: coreopenapi.ResourceWriteMetadata{
+				Name: uniqueName("test-project"),
+			},
+			Spec: identityopenapi.ProjectSpec{
+				GroupIDs: []string{},
+			},
+		},
+	}
+}
+
+// WithName sets the project name.
+func (b *ProjectPayloadBuilder) WithName(name string) *ProjectPayloadBuilder {
+	b.project.Metadata.Name = name
+	return b
+}
+
+// WithGroupIDs sets the group IDs for the project.
+func (b *ProjectPayloadBuilder) WithGroupIDs(groupIDs []string) *ProjectPayloadBuilder {
+	b.project.Spec.GroupIDs = groupIDs
+	return b
+}
+
+// Build returns the typed project struct.
+func (b *ProjectPayloadBuilder) Build() identityopenapi.ProjectWrite {
+	return b.project
+}
+
+// CreateProjectWithCleanup creates a project and schedules automatic cleanup.
+// Project deletion is async (202), so cleanup polls until the project is gone.
+func CreateProjectWithCleanup(client *APIClient, ctx context.Context, config *TestConfig, payload identityopenapi.ProjectWrite) (identityopenapi.ProjectRead, string) {
+	var projectID string
+
+	DeferCleanup(func() {
+		if projectID == "" {
+			return
+		}
+
+		GinkgoWriter.Printf("Cleaning up project: %s\n", projectID)
+
+		if err := client.DeleteProject(ctx, config.OrgID, projectID); err != nil {
+			GinkgoWriter.Printf("Warning: Failed to delete project %s: %v\n", projectID, err)
+			return
+		}
+
+		Eventually(func() bool {
+			_, err := client.GetProject(ctx, config.OrgID, projectID)
+			return errors.Is(err, coreclient.ErrResourceNotFound)
+		}).WithTimeout(config.TestTimeout).WithPolling(2*time.Second).Should(BeTrue(),
+			"project %s should be deleted", projectID,
+		)
+
+		GinkgoWriter.Printf("Successfully deleted project: %s\n", projectID)
+	})
+
+	created, err := client.CreateProject(ctx, config.OrgID, payload)
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to create project: %v", err))
+	}
+
+	projectID = created.Metadata.Id
+
+	GinkgoWriter.Printf("Created project with ID: %s\n", projectID)
+
+	return *created, projectID
+}
+
+// WaitForProjectProvisioned polls until the project reaches provisioned state.
+// Projects are created asynchronously (202); mutations will conflict if the
+// controller is still reconciling, so callers must wait before updating.
+func WaitForProjectProvisioned(client *APIClient, ctx context.Context, config *TestConfig, projectID string) {
+	Eventually(func() bool {
+		project, err := client.GetProject(ctx, config.OrgID, projectID)
+		if err != nil {
+			return false
+		}
+
+		return project.Metadata.ProvisioningStatus == coreopenapi.ResourceProvisioningStatusProvisioned
+	}).WithTimeout(config.TestTimeout).WithPolling(2*time.Second).Should(BeTrue(),
+		"project %s should reach provisioned state", projectID)
+}
+
+// WaitForProjectInACL polls until projectID appears in the caller's organization ACL.
+// ACL propagation may lag project provisioning, so this must be called after
+// WaitForProjectProvisioned. Returns the matching AclProject for further assertions.
+func WaitForProjectInACL(callerClient *APIClient, ctx context.Context, config *TestConfig, projectID string) identityopenapi.AclProject {
+	var found identityopenapi.AclProject
+
+	Eventually(func() bool {
+		acl, err := callerClient.GetOrganizationACL(ctx, config.OrgID)
+		if err != nil || acl.Projects == nil {
+			return false
+		}
+
+		for _, p := range *acl.Projects {
+			if p.Id == projectID {
+				found = p
+				return true
+			}
+		}
+
+		return false
+	}).WithTimeout(config.TestTimeout).WithPolling(2*time.Second).Should(BeTrue(),
+		"project %s should appear in organization ACL", projectID)
+
+	return found
+}
+
+// WaitForProjectRemovedFromACL polls until projectID is no longer present in the
+// caller's organization ACL.
+func WaitForProjectRemovedFromACL(callerClient *APIClient, ctx context.Context, config *TestConfig, projectID string) {
+	Eventually(func() bool {
+		acl, err := callerClient.GetOrganizationACL(ctx, config.OrgID)
+		Expect(err).NotTo(HaveOccurred())
+
+		if acl.Projects == nil {
+			return true
+		}
+
+		for _, p := range *acl.Projects {
+			if p.Id == projectID {
+				return false
+			}
+		}
+
+		return true
+	}).WithTimeout(config.TestTimeout).WithPolling(2*time.Second).Should(BeTrue(),
+		"project %s should be removed from organization ACL", projectID)
+}
+
+// Oauth2ProviderPayloadBuilder builds OAuth2 provider payloads for testing.
+type Oauth2ProviderPayloadBuilder struct {
+	provider identityopenapi.Oauth2ProviderWrite
+}
+
+// NewOauth2ProviderPayload creates a new OAuth2 provider payload builder with a unique name.
+func NewOauth2ProviderPayload() *Oauth2ProviderPayloadBuilder {
+	providerType := identityopenapi.Google
+	suffix := uniqueName("test-provider")
+
+	return &Oauth2ProviderPayloadBuilder{
+		provider: identityopenapi.Oauth2ProviderWrite{
+			Metadata: coreopenapi.ResourceWriteMetadata{
+				Name: suffix,
+			},
+			Spec: identityopenapi.Oauth2ProviderSpec{
+				ClientID: suffix,
+				Issuer:   "https://accounts.google.com",
+				Type:     &providerType,
+			},
+		},
+	}
+}
+
+// WithName sets the provider name.
+func (b *Oauth2ProviderPayloadBuilder) WithName(name string) *Oauth2ProviderPayloadBuilder {
+	b.provider.Metadata.Name = name
+	return b
+}
+
+// WithClientID sets the client ID.
+func (b *Oauth2ProviderPayloadBuilder) WithClientID(clientID string) *Oauth2ProviderPayloadBuilder {
+	b.provider.Spec.ClientID = clientID
+	return b
+}
+
+// Build returns the typed OAuth2 provider struct.
+func (b *Oauth2ProviderPayloadBuilder) Build() identityopenapi.Oauth2ProviderWrite {
+	return b.provider
+}
+
+// CreateOauth2ProviderWithCleanup creates an OAuth2 provider and schedules automatic cleanup.
+func CreateOauth2ProviderWithCleanup(client *APIClient, ctx context.Context, config *TestConfig, payload identityopenapi.Oauth2ProviderWrite) (identityopenapi.Oauth2ProviderRead, string) {
+	var providerID string
+
+	DeferCleanup(func() {
+		if providerID == "" {
+			return
+		}
+
+		GinkgoWriter.Printf("Cleaning up oauth2provider: %s\n", providerID)
+
+		if err := client.DeleteOauth2Provider(ctx, config.OrgID, providerID); err != nil {
+			GinkgoWriter.Printf("Warning: Failed to delete oauth2provider %s: %v\n", providerID, err)
+		} else {
+			GinkgoWriter.Printf("Successfully deleted oauth2provider: %s\n", providerID)
+		}
+	})
+
+	created, err := client.CreateOauth2Provider(ctx, config.OrgID, payload)
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to create oauth2provider: %v", err))
+	}
+
+	providerID = created.Metadata.Id
+
+	GinkgoWriter.Printf("Created oauth2provider with ID: %s\n", providerID)
+
+	return *created, providerID
+}
+
 // CreateGroupWithCleanup creates a group and schedules automatic cleanup.
-// Accepts a typed struct for type safety (or use BuildTyped() from the builder).
+// Accepts a typed struct for type safety (or use Build() from the builder).
 func CreateGroupWithCleanup(client *APIClient, ctx context.Context, config *TestConfig, payload identityopenapi.GroupWrite) (identityopenapi.GroupRead, string) {
 	var groupID string
 

--- a/test/api/suites/acl_test.go
+++ b/test/api/suites/acl_test.go
@@ -97,6 +97,38 @@ var _ = Describe("Access Control Discovery", func() {
 	})
 
 	Context("When getting organization ACL", func() {
+		// The user role (not administrator) has project-scoped endpoint permissions,
+		// so only the user token produces ACL entries under Organization.Projects.
+		Describe("Given the caller is a member of groups assigned to projects", func() {
+			BeforeEach(func() {
+				if userClient == nil {
+					Skip("USER_AUTH_TOKEN is required for ACL projection testing")
+				}
+			})
+
+			It("should no longer include a project in the ACL after it is deleted", func() {
+				if config.UserGroupID == "" {
+					Skip("TEST_USER_GROUP_ID is not configured")
+				}
+
+				_, projectID := api.CreateProjectWithCleanup(adminClient, ctx, config,
+					api.NewProjectPayload().
+						WithGroupIDs([]string{config.UserGroupID}).
+						Build())
+
+				api.WaitForProjectProvisioned(adminClient, ctx, config, projectID)
+
+				api.WaitForProjectInACL(userClient, ctx, config, projectID)
+
+				Expect(adminClient.DeleteProject(ctx, config.OrgID, projectID)).To(Succeed())
+
+				api.WaitForProjectRemovedFromACL(userClient, ctx, config, projectID)
+
+				GinkgoWriter.Printf("Verified project %s no longer appears in ACL after deletion\n", projectID)
+			})
+
+		})
+
 		Describe("Given valid organization", func() {
 			It("should return organization-scoped ACL with endpoint permissions", func() {
 				// adminClient is used explicitly: org-ACL content reflects the caller's effective

--- a/test/api/suites/groups_test.go
+++ b/test/api/suites/groups_test.go
@@ -22,7 +22,6 @@ package suites
 
 import (
 	"errors"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,7 +35,7 @@ var _ = Describe("Group Management", func() {
 	Context("When creating groups", func() {
 		Describe("Given valid group data", func() {
 			It("should create a new group with complete metadata", func() {
-				payload := api.NewGroupPayload().BuildTyped()
+				payload := api.NewGroupPayload().Build()
 				group, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
 
 				Expect(groupID).NotTo(BeEmpty(), "Group ID should be returned")
@@ -66,7 +65,7 @@ var _ = Describe("Group Management", func() {
 			})
 
 			It("should create a group and retrieve it by ID", func() {
-				payload := api.NewGroupPayload().BuildTyped()
+				payload := api.NewGroupPayload().Build()
 				createdGroup, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
 
 				retrievedGroup, err := client.GetGroup(ctx, config.OrgID, groupID)
@@ -81,7 +80,7 @@ var _ = Describe("Group Management", func() {
 			})
 
 			It("should create a group and find it in the organization list", func() {
-				payload := api.NewGroupPayload().BuildTyped()
+				payload := api.NewGroupPayload().Build()
 				createdGroup, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
 
 				groups, err := client.ListGroups(ctx, config.OrgID)
@@ -101,11 +100,12 @@ var _ = Describe("Group Management", func() {
 
 				Expect(found).To(BeTrue(), "Created group should appear in organization group list")
 			})
+
 		})
 
 		Describe("Given invalid organization ID", func() {
 			It("should return error when creating group in non-existent organization", func() {
-				payload := api.NewGroupPayload().BuildTyped()
+				payload := api.NewGroupPayload().Build()
 
 				_, err := client.CreateGroup(ctx, "invalid-org-id", payload)
 
@@ -113,18 +113,18 @@ var _ = Describe("Group Management", func() {
 				GinkgoWriter.Printf("Expected error for invalid organization ID: %v\n", err)
 			})
 		})
+
 	})
 
 	Context("When reading groups", func() {
 		Describe("Given valid organization", func() {
 			It("should return all groups in the organization with complete metadata", func() {
+				api.CreateGroupWithCleanup(client, ctx, config, api.NewGroupPayload().Build())
+
 				groups, err := client.ListGroups(ctx, config.OrgID)
 
 				Expect(err).NotTo(HaveOccurred())
-
-				if len(groups) == 0 {
-					Skip("Organization has no groups (valid state)")
-				}
+				Expect(groups).NotTo(BeEmpty())
 
 				for _, group := range groups {
 					Expect(group.Metadata).NotTo(BeNil())
@@ -134,9 +134,11 @@ var _ = Describe("Group Management", func() {
 
 					Expect(group.Spec).NotTo(BeNil())
 
-					Expect(group.Metadata.ProvisioningStatus).NotTo(BeEmpty())
-					Expect(string(group.Metadata.ProvisioningStatus)).To(BeElementOf(
-						"provisioning", "provisioned", "deprovisioning", "error"))
+					Expect(group.Metadata.ProvisioningStatus).To(BeElementOf(
+						coreopenapi.ResourceProvisioningStatusProvisioning,
+						coreopenapi.ResourceProvisioningStatusProvisioned,
+						coreopenapi.ResourceProvisioningStatusDeprovisioning,
+						coreopenapi.ResourceProvisioningStatusError))
 
 					Expect(group.Metadata.HealthStatus).NotTo(BeEmpty())
 					Expect(group.Metadata.HealthStatus).To(BeElementOf(
@@ -180,11 +182,12 @@ var _ = Describe("Group Management", func() {
 	Context("When updating groups", func() {
 		Describe("Given existing group", func() {
 			It("should update group name successfully", func() {
-				payload := api.NewGroupPayload().BuildTyped()
+				payload := api.NewGroupPayload().Build()
 				originalGroup, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
 
-				updatedPayload := payload
-				updatedPayload.Metadata.Name = originalGroup.Metadata.Name + "-updated"
+				updatedPayload := api.NewGroupPayload().
+					WithName(originalGroup.Metadata.Name + "-updated").
+					Build()
 
 				err := client.UpdateGroup(ctx, config.OrgID, groupID, updatedPayload)
 
@@ -209,7 +212,7 @@ var _ = Describe("Group Management", func() {
 					Skip("No roles available in organization to test role assignment")
 				}
 
-				payload := api.NewGroupPayload().BuildTyped()
+				payload := api.NewGroupPayload().Build()
 				originalGroup, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
 
 				updatedPayload := payload
@@ -228,11 +231,12 @@ var _ = Describe("Group Management", func() {
 				GinkgoWriter.Printf("Updated group '%s': added role %s\n",
 					originalGroup.Metadata.Name, roles[0].Metadata.Name)
 			})
+
 		})
 
 		Describe("Given invalid group ID", func() {
 			It("should return error when updating non-existent group", func() {
-				payload := api.NewGroupPayload().BuildTyped()
+				payload := api.NewGroupPayload().Build()
 
 				err := client.UpdateGroup(ctx, config.OrgID, "00000000-0000-0000-0000-000000000000", payload)
 
@@ -243,40 +247,22 @@ var _ = Describe("Group Management", func() {
 				GinkgoWriter.Printf("Expected error for updating non-existent group: %v\n", err)
 			})
 		})
+
+		Describe("Given invalid organization ID", func() {
+			It("should return error when updating group in non-existent organization", func() {
+				payload := api.NewGroupPayload().Build()
+
+				err := client.UpdateGroup(ctx, "invalid-org-id", "00000000-0000-0000-0000-000000000000", payload)
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
 	})
 
 	Context("When deleting groups", func() {
 		Describe("Given existing group", func() {
-			It("should successfully create and delete a test group with verification", func() {
-				group, groupID := api.CreateGroupWithCleanup(client, ctx, config,
-					api.NewGroupPayload().
-						WithName("delete-test-group").
-						BuildTyped())
-
-				Expect(group.Metadata.Id).NotTo(BeEmpty())
-				Expect(group.Metadata.Id).To(Equal(groupID))
-				Expect(group.Metadata.Name).To(Equal("delete-test-group"))
-
-				retrievedGroup, err := client.GetGroup(ctx, config.OrgID, groupID)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(retrievedGroup).NotTo(BeNil())
-				Expect(retrievedGroup.Metadata.Id).To(Equal(groupID))
-				GinkgoWriter.Printf("Verified group exists: %s\n", groupID)
-
-				err = client.DeleteGroup(ctx, config.OrgID, groupID)
-				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Printf("Deleted test group: %s\n", groupID)
-
-				Eventually(func() bool {
-					_, err := client.GetGroup(ctx, config.OrgID, groupID)
-					return errors.Is(err, coreclient.ErrResourceNotFound)
-				}).WithTimeout(config.TestTimeout).WithPolling(2 * time.Second).Should(BeTrue())
-
-				GinkgoWriter.Printf("Verified group deletion: %s\n", groupID)
-			})
-
 			It("should delete group successfully", func() {
-				payload := api.NewGroupPayload().BuildTyped()
+				payload := api.NewGroupPayload().Build()
 				_, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
 
 				err := client.DeleteGroup(ctx, config.OrgID, groupID)
@@ -301,6 +287,14 @@ var _ = Describe("Group Management", func() {
 					"Should return 404 not found error for non-existent group")
 
 				GinkgoWriter.Printf("Expected error for deleting non-existent group: %v\n", err)
+			})
+		})
+
+		Describe("Given invalid organization ID", func() {
+			It("should return error when deleting group in non-existent organization", func() {
+				err := client.DeleteGroup(ctx, "invalid-org-id", "00000000-0000-0000-0000-000000000000")
+
+				Expect(err).To(HaveOccurred())
 			})
 		})
 	})

--- a/test/api/suites/oauth2providers_test.go
+++ b/test/api/suites/oauth2providers_test.go
@@ -1,0 +1,244 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:revive,testpackage // dot imports and package naming standard for Ginkgo
+package suites
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	coreclient "github.com/unikorn-cloud/core/pkg/testing/client"
+	"github.com/unikorn-cloud/identity/test/api"
+)
+
+var _ = Describe("OAuth2 Provider Management", func() {
+	Context("When listing OAuth2 providers", func() {
+		Describe("Given valid organization", func() {
+			It("should return all OAuth2 providers in the organization", func() {
+				api.CreateOauth2ProviderWithCleanup(client, ctx, config, api.NewOauth2ProviderPayload().Build())
+
+				providers, err := client.ListOauth2Providers(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(providers).NotTo(BeEmpty())
+
+				for _, p := range providers {
+					Expect(p.Metadata.Id).NotTo(BeEmpty())
+					Expect(p.Metadata.Name).NotTo(BeEmpty())
+					Expect(p.Spec.ClientID).NotTo(BeEmpty())
+				}
+
+				GinkgoWriter.Printf("Found %d OAuth2 providers in organization %s\n",
+					len(providers), config.OrgID)
+			})
+		})
+
+		Describe("Given invalid organization ID", func() {
+			It("should return error for non-existent organization", func() {
+				_, err := client.ListOauth2Providers(ctx, "invalid-org-id")
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("When creating OAuth2 providers", func() {
+		Describe("Given valid provider data", func() {
+			It("should create a provider and return complete metadata", func() {
+				payload := api.NewOauth2ProviderPayload().Build()
+				created, providerID := api.CreateOauth2ProviderWithCleanup(client, ctx, config, payload)
+
+				Expect(providerID).NotTo(BeEmpty())
+				Expect(created.Metadata.Id).To(Equal(providerID))
+				Expect(created.Metadata.Name).To(Equal(payload.Metadata.Name))
+				Expect(created.Spec.ClientID).To(Equal(payload.Spec.ClientID))
+
+				GinkgoWriter.Printf("Created OAuth2 provider: %s (ID: %s)\n",
+					created.Metadata.Name, providerID)
+			})
+
+			It("should create a provider and find it in the organization list", func() {
+				payload := api.NewOauth2ProviderPayload().Build()
+				created, providerID := api.CreateOauth2ProviderWithCleanup(client, ctx, config, payload)
+
+				providers, err := client.ListOauth2Providers(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var found bool
+
+				for _, p := range providers {
+					if p.Metadata.Id == providerID {
+						found = true
+						Expect(p.Metadata.Name).To(Equal(created.Metadata.Name))
+						Expect(p.Spec.ClientID).To(Equal(created.Spec.ClientID))
+
+						break
+					}
+				}
+
+				Expect(found).To(BeTrue(), "Created OAuth2 provider %s should appear in list", providerID)
+			})
+		})
+
+		Describe("Given invalid organization ID", func() {
+			It("should return error when creating in non-existent organization", func() {
+				payload := api.NewOauth2ProviderPayload().Build()
+
+				_, err := client.CreateOauth2Provider(ctx, "invalid-org-id", payload)
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("When updating OAuth2 providers", func() {
+		Describe("Given existing provider", func() {
+			It("should update provider name successfully", func() {
+				payload := api.NewOauth2ProviderPayload().Build()
+				original, providerID := api.CreateOauth2ProviderWithCleanup(client, ctx, config, payload)
+
+				updatedPayload := api.NewOauth2ProviderPayload().
+					WithName(original.Metadata.Name + "-updated").
+					Build()
+
+				err := client.UpdateOauth2Provider(ctx, config.OrgID, providerID, updatedPayload)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				providers, err := client.ListOauth2Providers(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var found bool
+
+				for _, p := range providers {
+					if p.Metadata.Id == providerID {
+						found = true
+						Expect(p.Metadata.Name).To(Equal(updatedPayload.Metadata.Name))
+						Expect(p.Metadata.Name).NotTo(Equal(original.Metadata.Name))
+
+						break
+					}
+				}
+
+				Expect(found).To(BeTrue(), "Updated OAuth2 provider should still appear in list")
+
+				GinkgoWriter.Printf("Updated OAuth2 provider name: %s -> %s\n",
+					original.Metadata.Name, updatedPayload.Metadata.Name)
+			})
+
+			It("should update provider client ID successfully", func() {
+				payload := api.NewOauth2ProviderPayload().Build()
+				_, providerID := api.CreateOauth2ProviderWithCleanup(client, ctx, config, payload)
+
+				updatedPayload := api.NewOauth2ProviderPayload().
+					WithClientID("updated-client-id").
+					Build()
+
+				err := client.UpdateOauth2Provider(ctx, config.OrgID, providerID, updatedPayload)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				providers, err := client.ListOauth2Providers(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var found bool
+
+				for _, p := range providers {
+					if p.Metadata.Id == providerID {
+						found = true
+						Expect(p.Spec.ClientID).To(Equal("updated-client-id"))
+
+						break
+					}
+				}
+
+				Expect(found).To(BeTrue(), "Updated OAuth2 provider should still appear in list")
+			})
+		})
+
+		Describe("Given invalid provider ID", func() {
+			It("should return not-found error", func() {
+				payload := api.NewOauth2ProviderPayload().Build()
+
+				err := client.UpdateOauth2Provider(ctx, config.OrgID, "00000000-0000-0000-0000-000000000000", payload)
+
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+		})
+	})
+
+	Context("When deleting OAuth2 providers", func() {
+		Describe("Given existing provider", func() {
+			It("should delete provider and verify it is gone from the list", func() {
+				payload := api.NewOauth2ProviderPayload().Build()
+				_, providerID := api.CreateOauth2ProviderWithCleanup(client, ctx, config, payload)
+
+				err := client.DeleteOauth2Provider(ctx, config.OrgID, providerID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				providers, err := client.ListOauth2Providers(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, p := range providers {
+					Expect(p.Metadata.Id).NotTo(Equal(providerID),
+						"Deleted OAuth2 provider should not appear in list")
+				}
+
+				GinkgoWriter.Printf("Verified OAuth2 provider %s is deleted\n", providerID)
+			})
+		})
+
+		Describe("Given invalid provider ID", func() {
+			It("should return not-found error", func() {
+				err := client.DeleteOauth2Provider(ctx, config.OrgID, "00000000-0000-0000-0000-000000000000")
+
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+		})
+	})
+})
+
+var _ = Describe("Global OAuth2 Provider Discovery", func() {
+	Context("When listing global OAuth2 providers", func() {
+		Describe("Given valid authentication", func() {
+			It("should return the platform-level provider list", func() {
+				providers, err := client.ListGlobalOauth2Providers(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, p := range providers {
+					Expect(p.Metadata.Id).NotTo(BeEmpty())
+					Expect(p.Metadata.Name).NotTo(BeEmpty())
+				}
+
+				GinkgoWriter.Printf("Found %d global OAuth2 provider(s)\n", len(providers))
+			})
+		})
+	})
+})

--- a/test/api/suites/organizations_test.go
+++ b/test/api/suites/organizations_test.go
@@ -31,6 +31,55 @@ import (
 	"github.com/unikorn-cloud/identity/test/api"
 )
 
+var _ = Describe("Organization Management", func() {
+	Context("When updating organizations", func() {
+		Describe("Given valid organization", func() {
+			It("should update the organization name and persist the change", func() {
+				original, err := client.GetOrganization(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				restorePayload := api.NewOrganizationPayload().FromRead(*original).Build()
+				updatedPayload := api.NewOrganizationPayload().
+					FromRead(*original).
+					WithName(original.Metadata.Name + "-updated").
+					Build()
+
+				DeferCleanup(func() {
+					Expect(client.UpdateOrganization(ctx, config.OrgID, restorePayload)).To(Succeed(),
+						"failed to restore organization name — org may be left in a mutated state")
+				})
+
+				err = client.UpdateOrganization(ctx, config.OrgID, updatedPayload)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				retrieved, err := client.GetOrganization(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(retrieved.Metadata.Name).To(Equal(updatedPayload.Metadata.Name))
+				Expect(retrieved.Metadata.Name).NotTo(Equal(original.Metadata.Name))
+
+				GinkgoWriter.Printf("Updated organization name: %s -> %s\n",
+					original.Metadata.Name, retrieved.Metadata.Name)
+			})
+		})
+
+		Describe("Given invalid organization ID", func() {
+			It("should return error for non-existent organization", func() {
+				original, err := client.GetOrganization(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				err = client.UpdateOrganization(ctx, "invalid-org-id",
+					api.NewOrganizationPayload().FromRead(*original).Build())
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+})
+
 var _ = Describe("Organization Discovery", func() {
 	Context("When listing organizations", func() {
 		Describe("Given valid authentication", func() {
@@ -95,61 +144,3 @@ var _ = Describe("Organization Discovery", func() {
 	})
 })
 
-var _ = Describe("Project Discovery", func() {
-	Context("When listing projects", func() {
-		Describe("Given valid organization", func() {
-			It("should return all projects in the organization", func() {
-				projects, err := client.ListProjects(ctx, config.OrgID)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(projects).NotTo(BeEmpty())
-
-				projectIDs := make([]string, len(projects))
-				for i, project := range projects {
-					Expect(project.Metadata).NotTo(BeNil())
-					Expect(project.Metadata.Id).NotTo(BeEmpty())
-					Expect(project.Metadata.Name).NotTo(BeEmpty())
-					projectIDs[i] = project.Metadata.Id
-				}
-
-				Expect(projectIDs).To(ContainElement(config.ProjectID), "Expected project ID %s to be present in the list", config.ProjectID)
-				GinkgoWriter.Printf("Found %d projects in organization %s (including test project: %s)\n", len(projects), config.OrgID, config.ProjectID)
-			})
-		})
-
-		Describe("Given invalid organization ID", func() {
-			It("should return error for non-existent organization", func() {
-				_, err := client.ListProjects(ctx, "invalid-org-id")
-
-				Expect(err).To(HaveOccurred())
-				GinkgoWriter.Printf("Expected error for invalid organization ID: %v\n", err)
-			})
-		})
-	})
-
-	Context("When getting project details", func() {
-		Describe("Given valid project ID", func() {
-			It("should return project details", func() {
-				project, err := client.GetProject(ctx, config.OrgID, config.ProjectID)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(project).NotTo(BeNil())
-				Expect(project.Metadata).NotTo(BeNil())
-				Expect(project.Metadata.Id).To(Equal(config.ProjectID))
-				Expect(project.Metadata.Name).NotTo(BeEmpty())
-
-				GinkgoWriter.Printf("Retrieved project: %s (ID: %s)\n", project.Metadata.Name, project.Metadata.Id)
-			})
-		})
-
-		Describe("Given invalid project ID", func() {
-			It("should return not found error", func() {
-				_, err := client.GetProject(ctx, config.OrgID, "invalid-project-id")
-
-				Expect(err).To(HaveOccurred())
-				Expect(errors.Is(err, coreclient.ErrUnexpectedStatusCode)).To(BeTrue())
-				GinkgoWriter.Printf("Expected error for invalid project ID: %v\n", err)
-			})
-		})
-	})
-})

--- a/test/api/suites/projects_test.go
+++ b/test/api/suites/projects_test.go
@@ -1,0 +1,317 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:revive,testpackage // dot imports and package naming standard for Ginkgo
+package suites
+
+import (
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	coreclient "github.com/unikorn-cloud/core/pkg/testing/client"
+	"github.com/unikorn-cloud/identity/test/api"
+)
+
+var _ = Describe("Project Management", func() {
+	Context("When creating projects", func() {
+		Describe("Given valid project data", func() {
+			It("should create a project and return complete metadata", func() {
+				payload := api.NewProjectPayload().Build()
+				created, projectID := api.CreateProjectWithCleanup(client, ctx, config, payload)
+
+				Expect(projectID).NotTo(BeEmpty())
+				Expect(created.Metadata.Id).To(Equal(projectID))
+				Expect(created.Metadata.Name).To(Equal(payload.Metadata.Name))
+				Expect(created.Metadata.OrganizationId).To(Equal(config.OrgID))
+				// Status is a transient initial value on create — just assert it is present.
+				Expect(created.Metadata.ProvisioningStatus).NotTo(BeEmpty())
+
+				GinkgoWriter.Printf("Created project %s (initial status: %s)\n",
+					projectID, created.Metadata.ProvisioningStatus)
+			})
+
+			It("should create a project and find it in the organization list", func() {
+				payload := api.NewProjectPayload().Build()
+				created, projectID := api.CreateProjectWithCleanup(client, ctx, config, payload)
+
+				api.WaitForProjectProvisioned(client, ctx, config, projectID)
+
+				projects, err := client.ListProjects(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var found bool
+
+				for _, p := range projects {
+					if p.Metadata.Id == projectID {
+						found = true
+						Expect(p.Metadata.Name).To(Equal(created.Metadata.Name))
+
+						break
+					}
+				}
+
+				Expect(found).To(BeTrue(), "Created project %s should appear in list", projectID)
+			})
+
+			It("should create a project and retrieve it by ID", func() {
+				payload := api.NewProjectPayload().Build()
+				created, projectID := api.CreateProjectWithCleanup(client, ctx, config, payload)
+
+				api.WaitForProjectProvisioned(client, ctx, config, projectID)
+
+				retrieved, err := client.GetProject(ctx, config.OrgID, projectID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(retrieved.Metadata.Id).To(Equal(created.Metadata.Id))
+				Expect(retrieved.Metadata.Name).To(Equal(created.Metadata.Name))
+			})
+
+			It("should create a project with group associations", func() {
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config,
+					api.NewGroupPayload().Build())
+
+				payload := api.NewProjectPayload().
+					WithGroupIDs([]string{groupID}).
+					Build()
+				_, projectID := api.CreateProjectWithCleanup(client, ctx, config, payload)
+
+				api.WaitForProjectProvisioned(client, ctx, config, projectID)
+
+				retrieved, err := client.GetProject(ctx, config.OrgID, projectID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(retrieved.Spec.GroupIDs).To(ContainElement(groupID),
+					"Project should have the assigned group")
+			})
+		})
+
+		Describe("Given invalid organization ID", func() {
+			It("should return error", func() {
+				payload := api.NewProjectPayload().Build()
+
+				_, err := client.CreateProject(ctx, "invalid-org-id", payload)
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("When updating projects", func() {
+		Describe("Given existing project", func() {
+			It("should update project name successfully", func() {
+				payload := api.NewProjectPayload().Build()
+				_, projectID := api.CreateProjectWithCleanup(client, ctx, config, payload)
+
+				api.WaitForProjectProvisioned(client, ctx, config, projectID)
+
+				updatedPayload := api.NewProjectPayload().
+					WithName(payload.Metadata.Name + "-updated").
+					Build()
+
+				err := client.UpdateProject(ctx, config.OrgID, projectID, updatedPayload)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				api.WaitForProjectProvisioned(client, ctx, config, projectID)
+
+				retrieved, err := client.GetProject(ctx, config.OrgID, projectID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(retrieved.Metadata.Name).To(Equal(updatedPayload.Metadata.Name))
+				Expect(retrieved.Metadata.Name).NotTo(Equal(payload.Metadata.Name))
+			})
+
+			It("should update project group associations", func() {
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config,
+					api.NewGroupPayload().Build())
+
+				payload := api.NewProjectPayload().Build()
+				_, projectID := api.CreateProjectWithCleanup(client, ctx, config, payload)
+
+				api.WaitForProjectProvisioned(client, ctx, config, projectID)
+
+				updatedPayload := api.NewProjectPayload().
+					WithGroupIDs([]string{groupID}).
+					Build()
+
+				err := client.UpdateProject(ctx, config.OrgID, projectID, updatedPayload)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				api.WaitForProjectProvisioned(client, ctx, config, projectID)
+
+				retrieved, err := client.GetProject(ctx, config.OrgID, projectID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(retrieved.Spec.GroupIDs).To(ContainElement(groupID))
+			})
+
+			It("should clear project group associations", func() {
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config,
+					api.NewGroupPayload().Build())
+
+				payload := api.NewProjectPayload().
+					WithGroupIDs([]string{groupID}).
+					Build()
+				_, projectID := api.CreateProjectWithCleanup(client, ctx, config, payload)
+
+				api.WaitForProjectProvisioned(client, ctx, config, projectID)
+
+				clearedPayload := api.NewProjectPayload().
+					WithGroupIDs([]string{}).
+					Build()
+
+				err := client.UpdateProject(ctx, config.OrgID, projectID, clearedPayload)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				api.WaitForProjectProvisioned(client, ctx, config, projectID)
+
+				retrieved, err := client.GetProject(ctx, config.OrgID, projectID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(retrieved.Spec.GroupIDs).To(BeEmpty())
+			})
+		})
+
+		Describe("Given invalid project ID", func() {
+			It("should return not-found error", func() {
+				payload := api.NewProjectPayload().Build()
+
+				err := client.UpdateProject(ctx, config.OrgID, "00000000-0000-0000-0000-000000000000", payload)
+
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+		})
+
+		Describe("Given invalid organization ID", func() {
+			It("should return error", func() {
+				payload := api.NewProjectPayload().Build()
+
+				err := client.UpdateProject(ctx, "invalid-org-id", "00000000-0000-0000-0000-000000000000", payload)
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("When deleting projects", func() {
+		Describe("Given existing project", func() {
+			It("should delete project and verify via polling", func() {
+				payload := api.NewProjectPayload().Build()
+				_, projectID := api.CreateProjectWithCleanup(client, ctx, config, payload)
+
+				api.WaitForProjectProvisioned(client, ctx, config, projectID)
+
+				err := client.DeleteProject(ctx, config.OrgID, projectID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() bool {
+					_, err := client.GetProject(ctx, config.OrgID, projectID)
+					return errors.Is(err, coreclient.ErrResourceNotFound)
+				}).WithTimeout(config.TestTimeout).WithPolling(2*time.Second).Should(BeTrue(),
+					"project %s should be deleted", projectID)
+
+				GinkgoWriter.Printf("Verified project %s is deleted\n", projectID)
+			})
+		})
+
+		Describe("Given invalid project ID", func() {
+			It("should return not-found error", func() {
+				err := client.DeleteProject(ctx, config.OrgID, "00000000-0000-0000-0000-000000000000")
+
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+		})
+
+		Describe("Given invalid organization ID", func() {
+			It("should return error", func() {
+				err := client.DeleteProject(ctx, "invalid-org-id", "00000000-0000-0000-0000-000000000000")
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+})
+
+var _ = Describe("Project Discovery", func() {
+	Context("When listing projects", func() {
+		Describe("Given valid organization", func() {
+			It("should return all projects in the organization", func() {
+				projects, err := client.ListProjects(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(projects).NotTo(BeEmpty())
+
+				projectIDs := make([]string, len(projects))
+				for i, project := range projects {
+					Expect(project.Metadata).NotTo(BeNil())
+					Expect(project.Metadata.Id).NotTo(BeEmpty())
+					Expect(project.Metadata.Name).NotTo(BeEmpty())
+					projectIDs[i] = project.Metadata.Id
+				}
+
+				Expect(projectIDs).To(ContainElement(config.ProjectID), "Expected project ID %s to be present in the list", config.ProjectID)
+				GinkgoWriter.Printf("Found %d projects in organization %s (including test project: %s)\n", len(projects), config.OrgID, config.ProjectID)
+			})
+		})
+
+		Describe("Given invalid organization ID", func() {
+			It("should return error for non-existent organization", func() {
+				_, err := client.ListProjects(ctx, "invalid-org-id")
+
+				Expect(err).To(HaveOccurred())
+				GinkgoWriter.Printf("Expected error for invalid organization ID: %v\n", err)
+			})
+		})
+	})
+
+	Context("When getting project details", func() {
+		Describe("Given valid project ID", func() {
+			It("should return project details", func() {
+				project, err := client.GetProject(ctx, config.OrgID, config.ProjectID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(project).NotTo(BeNil())
+				Expect(project.Metadata).NotTo(BeNil())
+				Expect(project.Metadata.Id).To(Equal(config.ProjectID))
+				Expect(project.Metadata.Name).NotTo(BeEmpty())
+
+				GinkgoWriter.Printf("Retrieved project: %s (ID: %s)\n", project.Metadata.Name, project.Metadata.Id)
+			})
+		})
+
+		Describe("Given invalid project ID", func() {
+			It("should return not found error", func() {
+				_, err := client.GetProject(ctx, config.OrgID, "invalid-project-id")
+
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+				GinkgoWriter.Printf("Expected error for invalid project ID: %v\n", err)
+			})
+		})
+	})
+})

--- a/test/api/suites/quotas_test.go
+++ b/test/api/suites/quotas_test.go
@@ -23,6 +23,8 @@ package suites
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
 )
 
 var _ = Describe("Quota Management", func() {
@@ -80,6 +82,29 @@ var _ = Describe("Quota Management", func() {
 
 				Expect(err).To(HaveOccurred())
 				GinkgoWriter.Printf("Expected error for invalid organization ID: %v\n", err)
+			})
+		})
+	})
+
+	// Quota update requires the platform-administrator role (global scope).
+	// The organization administrator role only has identity:quotas: [read].
+	Context("When updating organization quotas", func() {
+		Describe("Given an organization administrator", func() {
+			It("should be denied — quota update requires platform-administrator", func() {
+				current, err := client.GetQuotas(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(current.Quotas).NotTo(BeEmpty())
+
+				writes := make(identityopenapi.QuotaWriteList, len(current.Quotas))
+				for i, q := range current.Quotas {
+					writes[i] = identityopenapi.QuotaWrite{Kind: q.Kind, Quantity: q.Quantity}
+				}
+
+				_, err = client.SetQuotas(ctx, config.OrgID, identityopenapi.QuotasWrite{Quotas: writes})
+
+				Expect(err).To(HaveOccurred(),
+					"quota update should be denied for the administrator role")
 			})
 		})
 	})

--- a/test/api/suites/rbac_matrix_test.go
+++ b/test/api/suites/rbac_matrix_test.go
@@ -23,6 +23,9 @@ package suites
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/test/api"
 )
 
 var _ = Describe("RBAC Enforcement", func() {
@@ -74,13 +77,79 @@ var _ = Describe("RBAC Enforcement", func() {
 					Expect(sa.Metadata.OrganizationId).To(Equal(config.OrgID))
 				}
 			})
+
+			Describe("Given TEST_USER_SA_ID is configured", func() {
+				BeforeEach(func() {
+					if config.UserSAID == "" {
+						Skip("TEST_USER_SA_ID is not configured")
+					}
+				})
+
+				It("should include service accounts belonging to other principals", func() {
+					serviceAccounts, err := adminClient.ListServiceAccounts(ctx, config.OrgID)
+
+					Expect(err).NotTo(HaveOccurred())
+
+					var found bool
+
+					for _, sa := range serviceAccounts {
+						if sa.Metadata.Id == config.UserSAID {
+							found = true
+
+							break
+						}
+					}
+
+					Expect(found).To(BeTrue(),
+						"admin should see user service account %s in the full list", config.UserSAID)
+				})
+			})
 		})
+
+		Describe("Given a request to list users", func() {
+			It("should be permitted to list users", func() {
+				api.CreateUserWithCleanup(adminClient, ctx, config, api.NewUserPayload().Build())
+
+				users, err := adminClient.ListUsers(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(users).NotTo(BeEmpty())
+
+				for _, u := range users {
+					Expect(u.Metadata.Id).NotTo(BeEmpty())
+					Expect(u.Metadata.OrganizationId).To(Equal(config.OrgID))
+				}
+			})
+		})
+
+		Describe("Given a request to list projects", func() {
+			It("should be permitted to list all projects in the organization", func() {
+				projects, err := adminClient.ListProjects(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(projects).NotTo(BeEmpty())
+
+				var projectIDs []string
+
+				for _, p := range projects {
+					projectIDs = append(projectIDs, p.Metadata.Id)
+				}
+
+				Expect(projectIDs).To(ContainElement(config.ProjectID))
+			})
+		})
+
 	})
 
 	Context("When authenticated as a user", func() {
-		// Per CLAUDE.md, status-only assertions are acceptable for pure RBAC denial tests.
-		// The typed client returns an error on any non-2xx response, which is sufficient
-		// to verify that access was denied without needing to inspect the response body.
+		BeforeEach(func() {
+			if userClient == nil {
+				Skip("USER_AUTH_TOKEN is required for user RBAC tests")
+			}
+		})
+
+		// For denial tests, an error on any non-2xx response is sufficient to verify
+		// that access was denied without needing to inspect the response body.
 
 		Describe("Given a request to list groups", func() {
 			It("should be denied with a forbidden response", func() {
@@ -104,6 +173,167 @@ var _ = Describe("RBAC Enforcement", func() {
 				Expect(serviceAccounts).To(HaveLen(1))
 				Expect(serviceAccounts[0].Metadata.Id).To(Equal(config.UserSAID))
 				Expect(serviceAccounts[0].Metadata.OrganizationId).To(Equal(config.OrgID))
+			})
+		})
+
+		Describe("Given a request to create a group", func() {
+			It("should be denied with a forbidden response", func() {
+				_, err := userClient.CreateGroup(ctx, config.OrgID,
+					api.NewGroupPayload().Build())
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Given a request to update a group", func() {
+			It("should be denied with a forbidden response", func() {
+				_, groupID := api.CreateGroupWithCleanup(adminClient, ctx, config,
+					api.NewGroupPayload().Build())
+
+				err := userClient.UpdateGroup(ctx, config.OrgID, groupID,
+					api.NewGroupPayload().Build())
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Given a request to delete a group", func() {
+			It("should be denied with a forbidden response", func() {
+				_, groupID := api.CreateGroupWithCleanup(adminClient, ctx, config,
+					api.NewGroupPayload().Build())
+
+				err := userClient.DeleteGroup(ctx, config.OrgID, groupID)
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Given a request to create a service account", func() {
+			It("should be denied with a forbidden response", func() {
+				_, err := userClient.CreateServiceAccount(ctx, config.OrgID,
+					api.NewServiceAccountPayload().Build())
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Given a request to list users", func() {
+			It("should be denied with a forbidden response", func() {
+				_, err := userClient.ListUsers(ctx, config.OrgID)
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Given a request to set quotas", func() {
+			It("should be denied with a forbidden response", func() {
+				_, err := userClient.SetQuotas(ctx, config.OrgID,
+					identityopenapi.QuotasWrite{})
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Given a request to delete another principal's service account", func() {
+			It("should be denied with a forbidden response", func() {
+				_, saID := api.CreateServiceAccountWithCleanup(adminClient, ctx, config,
+					api.NewServiceAccountPayload().Build())
+
+				err := userClient.DeleteServiceAccount(ctx, config.OrgID, saID)
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Given a request to update the organization", func() {
+			It("should be denied with a forbidden response", func() {
+				original, err := client.GetOrganization(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				err = userClient.UpdateOrganization(ctx, config.OrgID,
+					api.NewOrganizationPayload().FromRead(*original).Build())
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Given a request to list projects", func() {
+			It("should return only the projects the user is a member of", func() {
+				projects, err := userClient.ListProjects(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var projectIDs []string
+
+				for _, p := range projects {
+					projectIDs = append(projectIDs, p.Metadata.Id)
+				}
+
+				Expect(projectIDs).To(ContainElement(config.ProjectID),
+					"user should see the test project they are a member of")
+			})
+		})
+
+		Describe("Given a request to get a project by ID", func() {
+			It("should return the project when the user is a member", func() {
+				project, err := userClient.GetProject(ctx, config.OrgID, config.ProjectID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(project.Metadata.Id).To(Equal(config.ProjectID))
+			})
+
+			It("should be denied access to a project the user is not a member of", func() {
+				// Create a project with no group assignments so the user has no membership.
+				_, projectID := api.CreateProjectWithCleanup(adminClient, ctx, config,
+					api.NewProjectPayload().Build())
+
+				// Wait for provisioning so a 404 is a real denial, not a race.
+				api.WaitForProjectProvisioned(adminClient, ctx, config, projectID)
+
+				_, err := userClient.GetProject(ctx, config.OrgID, projectID)
+
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should not include a project the user is not a member of in the list", func() {
+				_, projectID := api.CreateProjectWithCleanup(adminClient, ctx, config,
+					api.NewProjectPayload().Build())
+
+				api.WaitForProjectProvisioned(adminClient, ctx, config, projectID)
+
+				projects, err := userClient.ListProjects(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var projectIDs []string
+
+				for _, p := range projects {
+					projectIDs = append(projectIDs, p.Metadata.Id)
+				}
+
+				Expect(projectIDs).NotTo(ContainElement(projectID),
+					"user should not see a project they are not a member of")
+			})
+		})
+
+		Describe("Given a request to create an OAuth2 provider", func() {
+			It("should be denied with a forbidden response", func() {
+				_, err := userClient.CreateOauth2Provider(ctx, config.OrgID,
+					api.NewOauth2ProviderPayload().Build())
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Given a request to delete an OAuth2 provider", func() {
+			It("should be denied with a forbidden response", func() {
+				_, providerID := api.CreateOauth2ProviderWithCleanup(adminClient, ctx, config,
+					api.NewOauth2ProviderPayload().Build())
+
+				err := userClient.DeleteOauth2Provider(ctx, config.OrgID, providerID)
+
+				Expect(err).To(HaveOccurred())
 			})
 		})
 	})

--- a/test/api/suites/serviceaccounts_test.go
+++ b/test/api/suites/serviceaccounts_test.go
@@ -21,61 +21,42 @@ limitations under the License.
 package suites
 
 import (
+	"errors"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	coreopenapi "github.com/unikorn-cloud/core/pkg/openapi"
+	coreclient "github.com/unikorn-cloud/core/pkg/testing/client"
+	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/test/api"
 )
 
 var _ = Describe("Service Account Management", func() {
 	Context("When listing service accounts", func() {
 		Describe("Given valid organization", func() {
 			It("should return all service accounts in the organization with complete metadata", func() {
+				api.CreateServiceAccountWithCleanup(client, ctx, config, api.NewServiceAccountPayload().Build())
+
 				serviceAccounts, err := client.ListServiceAccounts(ctx, config.OrgID)
 
 				Expect(err).NotTo(HaveOccurred())
-
-				if len(serviceAccounts) == 0 {
-					Skip("Organization has no service accounts (valid state)")
-				}
+				Expect(serviceAccounts).NotTo(BeEmpty())
 
 				for _, sa := range serviceAccounts {
-					Expect(sa.Metadata).NotTo(BeNil(), "Service account metadata should not be nil")
-					Expect(sa.Metadata.Id).NotTo(BeEmpty(), "Service account ID should not be empty")
-					Expect(sa.Metadata.Name).NotTo(BeEmpty(), "Service account name should not be empty")
-					Expect(sa.Metadata.OrganizationId).To(Equal(config.OrgID),
-						"Service account organization ID should match requested organization")
-
-					Expect(sa.Spec).NotTo(BeNil(), "Service account spec should not be nil")
-
-					Expect(sa.Metadata.ProvisioningStatus).NotTo(BeEmpty(),
-						"Service account provisioning status should not be empty")
+					Expect(sa.Metadata.Id).NotTo(BeEmpty())
+					Expect(sa.Metadata.Name).NotTo(BeEmpty())
+					Expect(sa.Metadata.OrganizationId).To(Equal(config.OrgID))
 					Expect(sa.Metadata.ProvisioningStatus).To(BeElementOf(
 						coreopenapi.ResourceProvisioningStatusProvisioning,
 						coreopenapi.ResourceProvisioningStatusProvisioned,
 						coreopenapi.ResourceProvisioningStatusDeprovisioning,
-						coreopenapi.ResourceProvisioningStatusError),
-						"Service account provisioning status should be valid")
-
-					Expect(sa.Metadata.HealthStatus).NotTo(BeEmpty(),
-						"Service account health status should not be empty")
+						coreopenapi.ResourceProvisioningStatusError))
 					Expect(sa.Metadata.HealthStatus).To(BeElementOf(
 						coreopenapi.ResourceHealthStatusHealthy,
 						coreopenapi.ResourceHealthStatusDegraded,
-						coreopenapi.ResourceHealthStatusError),
-						"Service account health status should be valid")
-
-					GinkgoWriter.Printf("  Service Account: %s (ID: %s)\n",
-						sa.Metadata.Name, sa.Metadata.Id)
-					GinkgoWriter.Printf("    Groups: %d, Status: %s, Health: %s\n",
-						len(sa.Spec.GroupIDs),
-						sa.Metadata.ProvisioningStatus,
-						sa.Metadata.HealthStatus)
-
-					if !sa.Status.Expiry.IsZero() {
-						GinkgoWriter.Printf("    Expiry: %s\n",
-							sa.Status.Expiry.Format("2006-01-02 15:04:05"))
-					}
+						coreopenapi.ResourceHealthStatusError))
 				}
 
 				GinkgoWriter.Printf("Found %d service accounts in organization %s\n",
@@ -88,7 +69,318 @@ var _ = Describe("Service Account Management", func() {
 				_, err := client.ListServiceAccounts(ctx, "invalid-org-id")
 
 				Expect(err).To(HaveOccurred())
-				GinkgoWriter.Printf("Expected error for invalid organization ID: %v\n", err)
+			})
+		})
+	})
+
+	Context("When creating service accounts", func() {
+		Describe("Given valid service account data", func() {
+			It("should create a service account and return a one-time access token", func() {
+				payload := api.NewServiceAccountPayload().Build()
+				created, saID := api.CreateServiceAccountWithCleanup(client, ctx, config, payload)
+
+				Expect(saID).NotTo(BeEmpty())
+				Expect(created.Metadata.Id).To(Equal(saID))
+				Expect(created.Metadata.Name).To(Equal(payload.Metadata.Name))
+				Expect(created.Metadata.OrganizationId).To(Equal(config.OrgID))
+
+				// Token is only returned on create and rotate — this is the core invariant.
+				Expect(created.Status.AccessToken).NotTo(BeNil(),
+					"AccessToken must be present in create response")
+				Expect(*created.Status.AccessToken).NotTo(BeEmpty(),
+					"AccessToken must not be empty")
+				Expect(created.Status.Expiry).To(BeTemporally(">", time.Now()),
+					"Token expiry must be in the future")
+
+				GinkgoWriter.Printf("Created SA %s, token expiry: %s\n",
+					saID, created.Status.Expiry.Format(time.RFC3339))
+			})
+
+			It("should create a service account and find it in the list", func() {
+				payload := api.NewServiceAccountPayload().Build()
+				created, saID := api.CreateServiceAccountWithCleanup(client, ctx, config, payload)
+
+				serviceAccounts, err := client.ListServiceAccounts(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var found bool
+
+				for _, sa := range serviceAccounts {
+					if sa.Metadata.Id == saID {
+						found = true
+						Expect(sa.Metadata.Name).To(Equal(created.Metadata.Name))
+
+						break
+					}
+				}
+
+				Expect(found).To(BeTrue(), "Created service account %s should appear in list", saID)
+			})
+
+			It("should create a service account with group membership", func() {
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config,
+					api.NewGroupPayload().Build())
+
+				payload := api.NewServiceAccountPayload().
+					WithGroupIDs([]string{groupID}).
+					Build()
+				_, saID := api.CreateServiceAccountWithCleanup(client, ctx, config, payload)
+
+				// The server has no GET /serviceaccounts/{id} route; verify via list.
+				serviceAccounts, err := client.ListServiceAccounts(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var found *identityopenapi.ServiceAccountRead
+
+				for i := range serviceAccounts {
+					if serviceAccounts[i].Metadata.Id == saID {
+						found = &serviceAccounts[i]
+
+						break
+					}
+				}
+
+				Expect(found).NotTo(BeNil(), "Created service account should be in list")
+				Expect(found.Spec.GroupIDs).To(ContainElement(groupID),
+					"Service account should have the assigned group")
+			})
+
+			It("should reflect service account membership in the group when SA is created with a group", func() {
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config,
+					api.NewGroupPayload().Build())
+
+				payload := api.NewServiceAccountPayload().
+					WithGroupIDs([]string{groupID}).
+					Build()
+				_, saID := api.CreateServiceAccountWithCleanup(client, ctx, config, payload)
+
+				group, err := client.GetGroup(ctx, config.OrgID, groupID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(group.Spec.ServiceAccountIDs).To(ContainElement(saID),
+					"Group should reflect the service account added via SA creation")
+			})
+
+		})
+
+		Describe("Given invalid organization ID", func() {
+			It("should return error when creating in non-existent organization", func() {
+				payload := api.NewServiceAccountPayload().Build()
+
+				_, err := client.CreateServiceAccount(ctx, "invalid-org-id", payload)
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("When updating service accounts", func() {
+		Describe("Given existing service account", func() {
+			It("should update the service account name", func() {
+				payload := api.NewServiceAccountPayload().Build()
+				_, saID := api.CreateServiceAccountWithCleanup(client, ctx, config, payload)
+
+				updatedPayload := api.NewServiceAccountPayload().
+					WithName(payload.Metadata.Name + "-updated").
+					Build()
+
+				updated, err := client.UpdateServiceAccount(ctx, config.OrgID, saID, updatedPayload)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updated.Metadata.Name).To(Equal(updatedPayload.Metadata.Name))
+
+				// Verify the change persisted in the list.
+				serviceAccounts, err := client.ListServiceAccounts(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var found bool
+
+				for _, sa := range serviceAccounts {
+					if sa.Metadata.Id == saID {
+						found = true
+						Expect(sa.Metadata.Name).To(Equal(updatedPayload.Metadata.Name),
+							"Updated name should be reflected in list")
+
+						break
+					}
+				}
+
+				Expect(found).To(BeTrue(), "Updated service account should still be in list")
+			})
+
+			It("should not return access token in update response", func() {
+				payload := api.NewServiceAccountPayload().Build()
+				_, saID := api.CreateServiceAccountWithCleanup(client, ctx, config, payload)
+
+				updatedPayload := api.NewServiceAccountPayload().
+					WithName(payload.Metadata.Name + "-updated").
+					Build()
+
+				updated, err := client.UpdateServiceAccount(ctx, config.OrgID, saID, updatedPayload)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updated.Status.AccessToken).To(BeNil(),
+					"AccessToken must not be present in update response")
+			})
+
+			It("should update service account group membership", func() {
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config,
+					api.NewGroupPayload().Build())
+
+				payload := api.NewServiceAccountPayload().Build()
+				_, saID := api.CreateServiceAccountWithCleanup(client, ctx, config, payload)
+
+				updatedPayload := api.NewServiceAccountPayload().
+					WithGroupIDs([]string{groupID}).
+					Build()
+
+				_, err := client.UpdateServiceAccount(ctx, config.OrgID, saID, updatedPayload)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				// The server has no GET /serviceaccounts/{id} route; verify via list.
+				serviceAccounts, err := client.ListServiceAccounts(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var found *identityopenapi.ServiceAccountRead
+
+				for i := range serviceAccounts {
+					if serviceAccounts[i].Metadata.Id == saID {
+						found = &serviceAccounts[i]
+
+						break
+					}
+				}
+
+				Expect(found).NotTo(BeNil())
+				Expect(found.Spec.GroupIDs).To(ContainElement(groupID),
+					"Updated group membership should be reflected in list")
+			})
+
+			It("should clear service account group membership", func() {
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config,
+					api.NewGroupPayload().Build())
+
+				payload := api.NewServiceAccountPayload().
+					WithGroupIDs([]string{groupID}).
+					Build()
+				_, saID := api.CreateServiceAccountWithCleanup(client, ctx, config, payload)
+
+				clearedPayload := payload
+				clearedPayload.Spec.GroupIDs = []string{}
+
+				_, err := client.UpdateServiceAccount(ctx, config.OrgID, saID, clearedPayload)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				// The server has no GET /serviceaccounts/{id} route; verify via list.
+				serviceAccounts, err := client.ListServiceAccounts(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var found *identityopenapi.ServiceAccountRead
+
+				for i := range serviceAccounts {
+					if serviceAccounts[i].Metadata.Id == saID {
+						found = &serviceAccounts[i]
+
+						break
+					}
+				}
+
+				Expect(found).NotTo(BeNil())
+				Expect(found.Spec.GroupIDs).To(BeEmpty(),
+					"Group membership should be empty after clearing")
+			})
+		})
+
+		Describe("Given invalid service account ID", func() {
+			It("should return not-found error", func() {
+				payload := api.NewServiceAccountPayload().Build()
+
+				_, err := client.UpdateServiceAccount(ctx, config.OrgID, "00000000-0000-0000-0000-000000000000", payload)
+
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+		})
+	})
+
+	Context("When rotating service account tokens", func() {
+		Describe("Given existing service account", func() {
+			It("should rotate the token and return a new one-time access token", func() {
+				payload := api.NewServiceAccountPayload().Build()
+				created, saID := api.CreateServiceAccountWithCleanup(client, ctx, config, payload)
+
+				Expect(created.Status.AccessToken).NotTo(BeNil())
+				token1 := *created.Status.AccessToken
+
+				rotated, err := client.RotateServiceAccount(ctx, config.OrgID, saID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rotated.Status.AccessToken).NotTo(BeNil(),
+					"AccessToken must be present in rotate response")
+				Expect(*rotated.Status.AccessToken).NotTo(BeEmpty())
+				Expect(*rotated.Status.AccessToken).NotTo(Equal(token1),
+					"Rotated token must differ from the original")
+				Expect(rotated.Status.Expiry).To(BeTemporally(">", time.Now()),
+					"Rotated token expiry must be in the future")
+
+				GinkgoWriter.Printf("Rotated SA %s token successfully\n", saID)
+			})
+		})
+
+		Describe("Given invalid service account ID", func() {
+			It("should return not-found error", func() {
+				_, err := client.RotateServiceAccount(ctx, config.OrgID, "00000000-0000-0000-0000-000000000000")
+
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+		})
+	})
+
+	Context("When deleting service accounts", func() {
+		Describe("Given existing service account", func() {
+			It("should delete and verify the service account is gone", func() {
+				payload := api.NewServiceAccountPayload().Build()
+				_, saID := api.CreateServiceAccountWithCleanup(client, ctx, config, payload)
+
+				err := client.DeleteServiceAccount(ctx, config.OrgID, saID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				// Deletion is asynchronous; poll until the SA is absent from the list.
+				Eventually(func() bool {
+					serviceAccounts, err := client.ListServiceAccounts(ctx, config.OrgID)
+					if err != nil {
+						return false
+					}
+
+					for _, sa := range serviceAccounts {
+						if sa.Metadata.Id == saID {
+							return false
+						}
+					}
+
+					return true
+				}).WithTimeout(config.TestTimeout).WithPolling(2 * time.Second).Should(BeTrue(),
+					"deleted service account %s should be removed from list", saID)
+
+				GinkgoWriter.Printf("Verified service account %s is deleted\n", saID)
+			})
+		})
+
+		Describe("Given invalid service account ID", func() {
+			It("should return not-found error", func() {
+				err := client.DeleteServiceAccount(ctx, config.OrgID, "00000000-0000-0000-0000-000000000000")
+
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
 			})
 		})
 	})

--- a/test/api/suites/users_test.go
+++ b/test/api/suites/users_test.go
@@ -21,77 +21,44 @@ limitations under the License.
 package suites
 
 import (
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	coreopenapi "github.com/unikorn-cloud/core/pkg/openapi"
+	coreclient "github.com/unikorn-cloud/core/pkg/testing/client"
+	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/test/api"
 )
 
 var _ = Describe("User Management", func() {
 	Context("When listing users", func() {
 		Describe("Given valid organization", func() {
 			It("should return all users in the organization with complete metadata", func() {
+				api.CreateUserWithCleanup(client, ctx, config, api.NewUserPayload().Build())
+
 				users, err := client.ListUsers(ctx, config.OrgID)
 
 				Expect(err).NotTo(HaveOccurred())
-
-				if len(users) == 0 {
-					Skip("Organization has no users (expected in integration mode without an external OIDC provider)")
-				}
+				Expect(users).NotTo(BeEmpty())
 
 				for _, user := range users {
-					Expect(user.Metadata).NotTo(BeNil(), "User metadata should not be nil")
-					Expect(user.Metadata.Id).NotTo(BeEmpty(), "User ID should not be empty")
-					Expect(user.Metadata.OrganizationId).To(Equal(config.OrgID),
-						"User organization ID should match requested organization")
-
-					Expect(user.Spec).NotTo(BeNil(), "User spec should not be nil")
-					Expect(user.Spec.Subject).NotTo(BeEmpty(), "User subject (email) should not be empty")
-
-					if user.Spec.State != "" {
-						Expect(string(user.Spec.State)).To(BeElementOf("active", "pending", "inactive"),
-							"User state should be a valid state")
-					}
-
-					if len(user.Spec.GroupIDs) > 0 {
-						Expect(user.Spec.GroupIDs).NotTo(BeEmpty(),
-							"User should be a member of at least one group")
-
-						GinkgoWriter.Printf("  User: %s (subject: %s, groups: %d)\n",
-							user.Metadata.Id,
-							user.Spec.Subject,
-							len(user.Spec.GroupIDs))
-					}
-
-					Expect(user.Metadata.ProvisioningStatus).NotTo(BeEmpty(),
-						"User provisioning status should not be empty")
+					Expect(user.Metadata.Id).NotTo(BeEmpty())
+					Expect(user.Metadata.OrganizationId).To(Equal(config.OrgID))
+					Expect(user.Spec.Subject).NotTo(BeEmpty())
 					Expect(user.Metadata.ProvisioningStatus).To(BeElementOf(
 						coreopenapi.ResourceProvisioningStatusProvisioning,
-					coreopenapi.ResourceProvisioningStatusProvisioned,
-					coreopenapi.ResourceProvisioningStatusDeprovisioning,
-					coreopenapi.ResourceProvisioningStatusError),
-						"User provisioning status should be valid")
-
-					Expect(user.Metadata.HealthStatus).NotTo(BeEmpty(),
-						"User health status should not be empty")
+						coreopenapi.ResourceProvisioningStatusProvisioned,
+						coreopenapi.ResourceProvisioningStatusDeprovisioning,
+						coreopenapi.ResourceProvisioningStatusError))
 					Expect(user.Metadata.HealthStatus).To(BeElementOf(
-					coreopenapi.ResourceHealthStatusHealthy,
-					coreopenapi.ResourceHealthStatusDegraded,
-					coreopenapi.ResourceHealthStatusError),
-						"User health status should be valid")
+						coreopenapi.ResourceHealthStatusHealthy,
+						coreopenapi.ResourceHealthStatusDegraded,
+						coreopenapi.ResourceHealthStatusError))
 				}
 
 				GinkgoWriter.Printf("Found %d users in organization %s\n", len(users), config.OrgID)
-
-				stateCounts := make(map[string]int)
-				for _, user := range users {
-					if user.Spec.State != "" {
-						stateCounts[string(user.Spec.State)]++
-					}
-				}
-				for state, count := range stateCounts {
-					GinkgoWriter.Printf("  Users in state '%s': %d\n", state, count)
-				}
 			})
 		})
 
@@ -100,7 +67,273 @@ var _ = Describe("User Management", func() {
 				_, err := client.ListUsers(ctx, "invalid-org-id")
 
 				Expect(err).To(HaveOccurred())
-				GinkgoWriter.Printf("Expected error for invalid organization ID: %v\n", err)
+			})
+		})
+	})
+
+	Context("When creating users", func() {
+		Describe("Given valid user data", func() {
+			It("should create a user with subject and state", func() {
+				payload := api.NewUserPayload().Build()
+				created, userID := api.CreateUserWithCleanup(client, ctx, config, payload)
+
+				Expect(userID).NotTo(BeEmpty())
+				Expect(created.Metadata.Id).To(Equal(userID))
+				Expect(created.Metadata.OrganizationId).To(Equal(config.OrgID))
+				Expect(created.Spec.Subject).To(Equal(payload.Spec.Subject))
+				Expect(created.Spec.State).NotTo(BeEmpty())
+				Expect(created.Spec.GroupIDs).To(BeEmpty())
+
+				GinkgoWriter.Printf("Created user %s (subject: %s)\n", userID, created.Spec.Subject)
+			})
+
+			It("should create a user and find it in the organization list", func() {
+				payload := api.NewUserPayload().Build()
+				created, userID := api.CreateUserWithCleanup(client, ctx, config, payload)
+
+				users, err := client.ListUsers(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var found bool
+
+				for _, u := range users {
+					if u.Metadata.Id == userID {
+						found = true
+						Expect(u.Spec.Subject).To(Equal(created.Spec.Subject))
+
+						break
+					}
+				}
+
+				Expect(found).To(BeTrue(), "Created user %s should appear in list", userID)
+			})
+
+			It("should create a user with group membership", func() {
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config,
+					api.NewGroupPayload().Build())
+
+				payload := api.NewUserPayload().
+					WithGroupIDs([]string{groupID}).
+					Build()
+				_, userID := api.CreateUserWithCleanup(client, ctx, config, payload)
+
+				// GroupIDs are not included in create/update response bodies; verify via list.
+				users, err := client.ListUsers(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var found *identityopenapi.UserRead
+
+				for i := range users {
+					if users[i].Metadata.Id == userID {
+						found = &users[i]
+
+						break
+					}
+				}
+
+				Expect(found).NotTo(BeNil(), "Created user should be in list")
+				Expect(found.Spec.GroupIDs).To(ContainElement(groupID),
+					"User should have the assigned group")
+			})
+
+			It("should reflect user membership in the group when user is created with a group", func() {
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config,
+					api.NewGroupPayload().Build())
+
+				payload := api.NewUserPayload().
+					WithGroupIDs([]string{groupID}).
+					Build()
+				_, userID := api.CreateUserWithCleanup(client, ctx, config, payload)
+
+				group, err := client.GetGroup(ctx, config.OrgID, groupID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(group.Spec.UserIDs).NotTo(BeNil(),
+					"Group UserIDs should be populated after a user is added")
+				Expect(*group.Spec.UserIDs).To(ContainElement(userID),
+					"Group should reflect the user added via user creation")
+			})
+
+		})
+
+		Describe("Given a user created with suspended state", func() {
+			It("should reflect the suspended state immediately on read", func() {
+				payload := api.NewUserPayload().
+					WithState(identityopenapi.Suspended).
+					Build()
+				created, userID := api.CreateUserWithCleanup(client, ctx, config, payload)
+
+				Expect(created.Spec.State).To(Equal(identityopenapi.Suspended),
+					"User created with suspended state should be suspended immediately")
+
+				GinkgoWriter.Printf("Created user %s with suspended state\n", userID)
+			})
+		})
+
+		Describe("Given invalid organization ID", func() {
+			It("should return error when creating in non-existent organization", func() {
+				payload := api.NewUserPayload().Build()
+
+				_, err := client.CreateUser(ctx, "invalid-org-id", payload)
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("When updating users", func() {
+		Describe("Given existing user", func() {
+			It("should update user group membership", func() {
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config,
+					api.NewGroupPayload().Build())
+
+				payload := api.NewUserPayload().Build()
+				_, userID := api.CreateUserWithCleanup(client, ctx, config, payload)
+
+				updatedPayload := api.NewUserPayload().
+					WithGroupIDs([]string{groupID}).
+					Build()
+
+				_, err := client.UpdateUser(ctx, config.OrgID, userID, updatedPayload)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				// GroupIDs are not included in update response bodies; verify via list.
+				users, err := client.ListUsers(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var found *identityopenapi.UserRead
+
+				for i := range users {
+					if users[i].Metadata.Id == userID {
+						found = &users[i]
+
+						break
+					}
+				}
+
+				Expect(found).NotTo(BeNil())
+				Expect(found.Spec.GroupIDs).To(ContainElement(groupID),
+					"Updated group membership should be reflected in list")
+			})
+
+			It("should clear user group membership", func() {
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config,
+					api.NewGroupPayload().Build())
+
+				payload := api.NewUserPayload().
+					WithGroupIDs([]string{groupID}).
+					Build()
+				_, userID := api.CreateUserWithCleanup(client, ctx, config, payload)
+
+				clearedPayload := payload
+				clearedPayload.Spec.GroupIDs = []string{}
+
+				_, err := client.UpdateUser(ctx, config.OrgID, userID, clearedPayload)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				// GroupIDs are not included in update response bodies; verify via list.
+				users, err := client.ListUsers(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				var found *identityopenapi.UserRead
+
+				for i := range users {
+					if users[i].Metadata.Id == userID {
+						found = &users[i]
+
+						break
+					}
+				}
+
+				Expect(found).NotTo(BeNil())
+				Expect(found.Spec.GroupIDs).To(BeEmpty(),
+					"Group membership should be empty after clearing")
+			})
+
+			It("should suspend an active user", func() {
+				payload := api.NewUserPayload().
+					WithState(identityopenapi.Active).
+					Build()
+				_, userID := api.CreateUserWithCleanup(client, ctx, config, payload)
+
+				updatedPayload := payload
+				updatedPayload.Spec.State = identityopenapi.Suspended
+
+				updated, err := client.UpdateUser(ctx, config.OrgID, userID, updatedPayload)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updated.Spec.State).To(Equal(identityopenapi.Suspended),
+					"User state should be suspended after update")
+
+				GinkgoWriter.Printf("Suspended user %s\n", userID)
+			})
+
+			It("should reactivate a suspended user", func() {
+				payload := api.NewUserPayload().
+					WithState(identityopenapi.Suspended).
+					Build()
+				_, userID := api.CreateUserWithCleanup(client, ctx, config, payload)
+
+				updatedPayload := payload
+				updatedPayload.Spec.State = identityopenapi.Active
+
+				updated, err := client.UpdateUser(ctx, config.OrgID, userID, updatedPayload)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updated.Spec.State).To(Equal(identityopenapi.Active),
+					"User state should be active after reactivation")
+
+				GinkgoWriter.Printf("Reactivated user %s\n", userID)
+			})
+		})
+
+		Describe("Given invalid user ID", func() {
+			It("should return not-found error", func() {
+				payload := api.NewUserPayload().Build()
+
+				_, err := client.UpdateUser(ctx, config.OrgID, "00000000-0000-0000-0000-000000000000", payload)
+
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+		})
+	})
+
+	Context("When deleting users", func() {
+		Describe("Given existing user", func() {
+			It("should delete user and confirm it disappears from the list", func() {
+				payload := api.NewUserPayload().Build()
+				_, userID := api.CreateUserWithCleanup(client, ctx, config, payload)
+
+				err := client.DeleteUser(ctx, config.OrgID, userID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				users, err := client.ListUsers(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, u := range users {
+					Expect(u.Metadata.Id).NotTo(Equal(userID),
+						"Deleted user should not appear in list")
+				}
+
+				GinkgoWriter.Printf("Verified user %s is deleted\n", userID)
+			})
+		})
+
+		Describe("Given invalid user ID", func() {
+			It("should return not-found error", func() {
+				err := client.DeleteUser(ctx, config.OrgID, "00000000-0000-0000-0000-000000000000")
+
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
 			})
 		})
 	})


### PR DESCRIPTION
Expands integration test coverage from list-only to full CRUD for all major identity resources.

## Infrastructure

- `test/api`: typed client methods for create/update/delete on service accounts, users, projects, organizations, and quotas
- `test/api`: `CreateServiceAccountWithCleanup`, `CreateUserWithCleanup`, `CreateProjectWithCleanup` fixtures and payload builders

## New test coverage

- **Service accounts**: create returns one-time `AccessToken`; token absent on update; rotate returns a different token; group membership create/update/clear via list verification; async delete polling
- **Users**: create with subject and state; `Spec.State` asserted directly on create/update response body; group membership update/clear via list verification; suspend/reactivate; delete
- **Projects**: async create (202) with `WaitForProjectProvisioned`; group associations; update after provisioned; async delete via `GetProject` → `ErrResourceNotFound` polling
- **Organizations**: update name with deferred restore
- **Quotas**: `SetQuotas` denied for organization administrator (platform-administrator only)
- **Groups**: SA assignment via `UpdateGroup`; bidirectional membership reflection between groups, users, and service accounts
- **ACL**: all three project membership tests create their own projects via `adminClient` + `config.UserGroupID`; appearance and removal both use `Eventually` + `func() bool` polling to handle propagation lag
- **OAuth2 providers**: create, update, delete, list
- **RBAC matrix**: mutation denial for regular users (create/update/delete group, create SA, list users, set quotas, update org, delete another principal's SA, create/delete OAuth2 provider); user cannot access a project they are not a member of (GET denied, absent from list); admin permitted for list groups/roles/SAs/users/projects

## Notes

- `Spec.GroupIDs` not included in user/SA create or update response bodies — verified via list
- `GET /serviceaccounts/{id}` not exposed by server — list used for SA group membership and delete verification

Relates to INST-797.