### PR TITLE
fix(oauth2): return access-denied for suspended user org lookups

### DIFF
--- a/pkg/oauth2/oauth2.go
+++ b/pkg/oauth2/oauth2.go
@@ -1775,6 +1775,19 @@ func (a *Authenticator) GetUserinfo(ctx context.Context, r *http.Request, token 
 		return nil, nil, coreerrors.AccessDenied(r, "token validation failed").WithError(err)
 	}
 
+	// For federated (human) tokens, verify the user is still active.
+	// A suspended or deleted user whose cached token reaches this path
+	// should receive an access-denied response rather than a 500.
+	if claims.Type == TokenTypeFederated {
+		if _, err := a.rbac.GetActiveUser(ctx, claims.Subject); err != nil {
+			if goerrors.Is(err, rbac.ErrResourceReference) {
+				return nil, nil, coreerrors.AccessDenied(r, "user is not active").WithError(err)
+			}
+
+			return nil, nil, fmt.Errorf("%w: failed to query user status", err)
+		}
+	}
+
 	userinfo := &openapi.Userinfo{
 		Sub: claims.Subject,
 	}


### PR DESCRIPTION
## Summary

- `GetUserinfo` only validated the JWT token but did not check whether the user was still active in the system. A suspended or deleted user whose cached token reached the userinfo endpoint would succeed (or, for downstream org lookups, produce a 500 instead of an appropriate error).
- Added a `GetActiveUser` check for federated (human) tokens that returns an OAuth2 access-denied response when `rbac.ErrResourceReference` is encountered (user not found or not active).
- Infrastructure errors from the user lookup still propagate as internal errors.

## Test plan

- [ ] Verify `make lint` passes (Go lint: 0 issues; helm lint failure is pre-existing)
- [ ] Verify `pkg/oauth2` unit tests pass
- [ ] Manual/integration: issue a token for an active user, suspend the user, then call the userinfo endpoint — should return 401 access-denied instead of 200 or 500