### PR TITLE
Update Core Dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spjmurray/go-util v0.1.3
 	github.com/stretchr/testify v1.11.1
-	github.com/unikorn-cloud/core v1.14.0-rc1.0.20260409152316-fa69a2543e80
+	github.com/unikorn-cloud/core v1.14.0-rc1.0.20260415101853-f48436d47c7a
 	go.opentelemetry.io/otel v1.43.0
 	go.uber.org/mock v0.5.2
 	golang.org/x/oauth2 v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v1.14.0-rc1.0.20260409152316-fa69a2543e80 h1:45PSF1FZtE456XumL8px0Hm5dY+fRZInEDeShgMiowg=
-github.com/unikorn-cloud/core v1.14.0-rc1.0.20260409152316-fa69a2543e80/go.mod h1:xbPBXjhgOp2O0HSx+utFwmVkxheAHp7z+h1RCyBEswE=
+github.com/unikorn-cloud/core v1.14.0-rc1.0.20260415101853-f48436d47c7a h1:0zxJ8omAxlu4OUHdTut+8Qm/nBQElWZ6jqi2a0KTiLw=
+github.com/unikorn-cloud/core v1.14.0-rc1.0.20260415101853-f48436d47c7a/go.mod h1:xbPBXjhgOp2O0HSx+utFwmVkxheAHp7z+h1RCyBEswE=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Pulls in a fix for mTLS clients that polls for credential rotation on a
period basis, rather than caching, which results in clients that stop
working eventually.
