### PR TITLE
fix(ci): restore self-contained KinD infra bootstrap

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -42,11 +42,6 @@ jobs:
         cluster_name: identity-${{ github.run_id }}
         config: hack/ci/kind-config.yaml
 
-    - name: Start cloud-provider-kind
-      run: |
-        go install sigs.k8s.io/cloud-provider-kind@latest
-        sudo $(go env GOPATH)/bin/cloud-provider-kind &
-
     - name: Install cluster infrastructure
       env:
         KIND_CLUSTER: identity-${{ github.run_id }}

--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -46,7 +46,7 @@ auto-detect which one you are using and adjust accordingly.
 | Port exposure | `cloud-provider-kind` LoadBalancer IPs (routable on host) | Lima port forwarding |
 | Infra setup | `make integration-infra` | `make integration-infra` |
 
-`cloud-provider-kind` must be running as a daemon before `make integration-infra`. See [hack/ci/README.md](../hack/ci/README.md#running-locally) for setup instructions.
+`make integration-infra` bootstraps `cloud-provider-kind` automatically when running against KinD. See [hack/ci/README.md](../hack/ci/README.md#running-locally) for local setup instructions.
 
 ## Prerequisites
 

--- a/hack/ci/README.md
+++ b/hack/ci/README.md
@@ -71,15 +71,9 @@ sudo mkdir -p /etc/resolver && echo "nameserver 8.8.8.8" | sudo tee /etc/resolve
 make kind-cluster       # creates the KinD cluster
 ```
 
-Then in a separate terminal, start `cloud-provider-kind` and leave it running:
-
 ```sh
-go install sigs.k8s.io/cloud-provider-kind@latest
-sudo $(go env GOPATH)/bin/cloud-provider-kind
-```
-
-```sh
-make integration-infra  # cert-manager, ingress-nginx, unikorn-core — idempotent
+make integration-infra  # bootstraps cloud-provider-kind if needed, then installs
+                        # cert-manager, ingress-nginx, unikorn-core — idempotent
 ```
 
 **Run the tests:**

--- a/hack/ci/setup-infra
+++ b/hack/ci/setup-infra
@@ -18,12 +18,33 @@ fi
 
 echo "==> Cluster context: ${CONTEXT} (KinD: ${IS_KIND})"
 
-# ── cloud-provider-kind preflight ─────────────────────────────────────────────
+# ── cloud-provider-kind bootstrap ─────────────────────────────────────────────
 if [[ "${IS_KIND}" == true ]]; then
   if ! pgrep -f cloud-provider-kind > /dev/null; then
-    echo "ERROR: cloud-provider-kind is not running." >&2
-    echo "       Start it with: sudo cloud-provider-kind" >&2
-    echo "       Install with:  go install sigs.k8s.io/cloud-provider-kind@latest" >&2
+    echo "==> Installing cloud-provider-kind..."
+    GOBIN=$(go env GOBIN)
+    if [[ -z "${GOBIN}" ]]; then
+      GOBIN="$(go env GOPATH)/bin"
+    fi
+
+    go install sigs.k8s.io/cloud-provider-kind@latest
+
+    echo "==> Starting cloud-provider-kind..."
+    sudo "${GOBIN}/cloud-provider-kind" > /tmp/cloud-provider-kind.log 2>&1 &
+
+    for _ in $(seq 1 30); do
+      if pgrep -f cloud-provider-kind > /dev/null; then
+        break
+      fi
+
+      sleep 1
+    done
+  fi
+
+  if ! pgrep -f cloud-provider-kind > /dev/null; then
+    echo "ERROR: cloud-provider-kind failed to start." >&2
+    echo "       See /tmp/cloud-provider-kind.log for details." >&2
+    echo "       You can also start it manually with: sudo $(go env GOPATH)/bin/cloud-provider-kind" >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary

Recent KinD integration changes introduced a new runtime dependency on `cloud-provider-kind` for LoadBalancer address assignment, but left startup of that dependency outside `hack/ci/setup-infra`.

That changed the effective contract of the integration infrastructure target in an important way:

- local callers could create a KinD cluster successfully and then fail inside `make integration-infra` because `cloud-provider-kind` was not already installed and running
- downstream services that reuse identity's KinD setup via delegated `integration-infra` execution inherited the same requirement and needed to duplicate provider startup in their own workflows
- the setup script no longer owned the prerequisites required for the KinD path it was configuring

## Problem

`hack/ci/setup-infra` is the abstraction boundary that callers rely on for cluster prerequisite setup. Once the KinD path depends on `cloud-provider-kind`, forcing every caller to bootstrap that dependency out of band weakens that boundary.

In practice this creates two regressions:

1. Local execution regresses because developers can no longer rely on `make integration-infra` to prepare the KinD environment end to end.
2. Inherited execution regresses because downstream services that intentionally delegate cluster setup to identity now need identity-specific bootstrap logic in their own CI workflows just to satisfy a preflight check.

That is the wrong ownership split. If `cloud-provider-kind` is a prerequisite of the KinD infrastructure setup path, the setup script itself should ensure that prerequisite exists.

## Fix

This change restores the intended contract by moving `cloud-provider-kind` bootstrap into `hack/ci/setup-infra`.

When KinD is detected, the script now:

- checks whether `cloud-provider-kind` is already running
- installs it if necessary
- starts it if necessary
- waits briefly for the process to appear before continuing
- fails only if bootstrap still does not succeed

With that logic in place, the explicit `cloud-provider-kind` startup step in the integration workflow becomes redundant and is removed.

## Result

After this change, KinD infrastructure setup is self-contained again:

- the identity integration workflow can create a KinD cluster and call `make integration-infra` without bespoke provider bootstrap
- local developers get the same behaviour from the same target
- downstream services that reuse identity's setup script regain the inherited execution path they were expecting, without having to mirror identity-specific provider startup in their own workflows

This keeps the provider bootstrap logic in one place and restores `hack/ci/setup-infra` as the single owner of KinD prerequisite setup.