### PR TITLE
fix(oauth2,rbac): repair broken self-service onboarding flow

### DIFF
--- a/pkg/oauth2/oauth2.go
+++ b/pkg/oauth2/oauth2.go
@@ -54,6 +54,7 @@ import (
 	"github.com/unikorn-cloud/identity/pkg/oauth2/errors"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/oidc"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/providers"
+	"github.com/unikorn-cloud/identity/pkg/principal"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/types"
 	"github.com/unikorn-cloud/identity/pkg/openapi"
 	"github.com/unikorn-cloud/identity/pkg/rbac"
@@ -1175,6 +1176,10 @@ func (a *Authenticator) Onboard(w http.ResponseWriter, r *http.Request) {
 
 	ctx = authorization.NewContext(ctx, info)
 
+	ctx = principal.NewContext(ctx, &principal.Principal{
+		Actor: state.IDToken.Email.Email,
+	})
+
 	var err error
 
 	ctx, err = a.rbac.NewSuperContext(ctx)
@@ -1217,6 +1222,7 @@ func (a *Authenticator) Onboard(w http.ResponseWriter, r *http.Request) {
 
 	organization, err := organizations.New(a.client, a.namespace).Create(ctx, organizationRequest)
 	if err != nil {
+		log.FromContext(ctx).Error(err, "onboard: failed to create organization")
 		redirector.raise(ErrorServerError, "failed to create organization")
 		return
 	}
@@ -1255,6 +1261,7 @@ func (a *Authenticator) Onboard(w http.ResponseWriter, r *http.Request) {
 
 	group, err := groups.New(a.client, a.namespace, a.issuer).Create(ctx, organization.Metadata.Id, groupRequest)
 	if err != nil {
+		log.FromContext(ctx).Error(err, "onboard: failed to create group", "organizationID", organization.Metadata.Id)
 		redirector.raise(ErrorServerError, "failed to create group")
 		return
 	}

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -891,18 +891,18 @@ func (r *RBAC) NewSuperContext(ctx context.Context) (context.Context, error) {
 		return nil, err
 	}
 
-	var globalACL openapi.AclEndpoints
+	var globalACL *openapi.AclEndpoints
 
 	for _, id := range r.options.PlatformAdministratorRoleIDs {
 		if role, ok := roles[id]; ok {
-			addScopesToEndpointList(&globalACL, role.Spec.Scopes.Global)
+			globalACL = addScopesToEndpointList(globalACL, role.Spec.Scopes.Global)
 		}
 	}
 
 	acl := &openapi.Acl{}
 
-	if len(globalACL) != 0 {
-		acl.Global = &globalACL
+	if globalACL != nil {
+		acl.Global = globalACL
 	}
 
 	return NewContext(ctx, acl), nil


### PR DESCRIPTION
## Summary

The browser-based self-service onboarding flow (`POST /oauth2/v2/onboard`) has been broken since **v1.14.0-rc1**. Any user attempting to create an account on a fresh cluster through the UI hits two sequential failures that prevent org, group, and user creation.

This went undetected because existing environments were set up before the onboarding rewrite, or users were created via `kubectl-unikorn` / direct CRD creation rather than the browser flow.

## Bug 1: `NewSuperContext` builds an empty ACL

**File:** `pkg/rbac/rbac.go` — `NewSuperContext` (introduced in #224)

When a user submits the onboarding form, the server calls `NewSuperContext` to create a privileged context carrying all `platform-administrator` permissions. It calls `addScopesToEndpointList` to build the permissions list, but discards the return value:

```go
var globalACL openapi.AclEndpoints
addScopesToEndpointList(&globalACL, role.Spec.Scopes.Global)  // return value discarded
```

`addScopesToEndpointList` copies the incoming slice into a local variable, appends to it, and returns a pointer to the new slice — it does not modify through the incoming pointer. This is the same pattern as Go's built-in `append`. Since the return value is discarded, `globalACL` stays empty and the super context is created with zero permissions.

The function was originally void (#94, `RBAC Done Properly`) and later refactored to return a pointer. All call sites in the main RBAC codepath (lines 307, 325, 350) were updated to capture the return value. `NewSuperContext`, added afterwards in #224, was not.

**Symptom:** `failed to create group` — the `AllowRole` check rejects the administrator role grant because the super context has no permissions.

**Fix:** Capture the return value, matching every other call site.

## Bug 2: `Onboard` doesn't inject a principal into the context

**File:** `pkg/oauth2/oauth2.go` — `Onboard` method (introduced in #224, broken by #278)

The `Onboard` method sets up authorization info and an RBAC super context, but every resource creation goes through `common.SetIdentityMetadata`, which also requires a `principal` in the context to annotate who created the resource:

```go
// SetIdentityMetadata requires all three:
authorization.FromContext(ctx)   // ✅ set by Onboard
principal.FromContext(ctx)       // ❌ never set — fails here
```

The normal API request pipeline injects the principal via middleware (`principal.Injector`), so regular API calls work fine. The onboarding flow bypasses the middleware stack and was never updated when #278 (`Principal Propagation`) added the `principal.FromContext` requirement to `SetIdentityMetadata`.

**Symptom:** `failed to create organization` — the first thing the user sees after entering their company name.

**Fix:** Inject the principal before creating resources.

## Bonus: error logging

Both error paths in `Onboard` silently discarded the underlying error — `redirector.raise` only sends a generic message to the browser, and nothing was logged server-side. Added `log.FromContext(ctx).Error(...)` calls so these are visible in future.

## Test plan

- [x] Deploy to local Colima cluster with a fresh identity namespace (no existing users/orgs)
- [x] Complete the full onboarding flow through the browser UI — org, group, and user all created successfully
- [x] `make test-unit` — all test suites pass
- [x] QA verification of ACL endpoints, userinfo claims, group subjects CRUD, group migration, and RBAC matrix per the Phase 1 QA plan