### PR TITLE
Fix impersonated service account ACL dispatch

### DIFF
--- a/pkg/handler/common/fixtures/fixtures.go
+++ b/pkg/handler/common/fixtures/fixtures.go
@@ -46,6 +46,7 @@ func HandlerContextFixture(ctx context.Context, flags int) context.Context {
 	}
 
 	p := &principal.Principal{
+		Type:  openapi.User,
 		Actor: PrincipalActor,
 	}
 

--- a/pkg/middleware/openapi/openapi.go
+++ b/pkg/middleware/openapi/openapi.go
@@ -351,15 +351,24 @@ func (v *Validator) validateRequest(r *http.Request, route *routers.Route, param
 // generatePrincipal is called by non-system API services e.g. CLI/UI, and creates
 // principal information from the request itself.
 func (v *Validator) generatePrincipal(ctx context.Context, params map[string]string, userinfo *identityapi.Userinfo) context.Context {
-	var organizationIDs []string
+	var (
+		organizationIDs []string
+		principalType   = identityapi.User
+	)
+
 	if userinfo.HttpsunikornCloudOrgauthz != nil {
 		organizationIDs = userinfo.HttpsunikornCloudOrgauthz.OrgIds
+
+		if userinfo.HttpsunikornCloudOrgauthz.Acctype == identityapi.Service {
+			principalType = identityapi.Service
+		}
 	}
 
 	p := &principal.Principal{
 		OrganizationID:  params["organizationID"],
 		OrganizationIDs: organizationIDs,
 		ProjectID:       params["projectID"],
+		Type:            principalType,
 		Actor:           userinfo.Sub,
 	}
 

--- a/pkg/middleware/openapi/openapi_test.go
+++ b/pkg/middleware/openapi/openapi_test.go
@@ -185,6 +185,7 @@ func addPrincipalHeader(t *testing.T, r *http.Request) {
 	t.Helper()
 
 	p := &principal.Principal{
+		Type:  identityapi.User,
 		Actor: userActor,
 	}
 
@@ -214,10 +215,19 @@ func addAuthorizationHeader(t *testing.T, r *http.Request) {
 
 // authInfoFixture creates a fixture to be returned from the Authorizer interface
 // on successful authentication.
-func authInfoFixture(actor string) *authorization.Info {
+func authInfoFixture(actor string, accountType identityapi.AuthClaimsAcctype) *authorization.Info {
+	authz := &identityapi.AuthClaims{
+		Acctype: accountType,
+	}
+
+	if accountType == "" {
+		authz = nil
+	}
+
 	return &authorization.Info{
 		Userinfo: &identityapi.Userinfo{
-			Sub: actor,
+			Sub:                       actor,
+			HttpsunikornCloudOrgauthz: authz,
 		},
 	}
 }
@@ -256,7 +266,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // validate checks all the correct bits are set, and the actor and principal
 // actors are correct.  The former is the parameter as that can change based
 // on calling context.
-func (h *handler) validate(t *testing.T, actor string) {
+func (h *handler) validate(t *testing.T, actor string, principalType identityapi.AuthClaimsAcctype) {
 	t.Helper()
 
 	// Check the authentication information is good for auditing.
@@ -270,6 +280,10 @@ func (h *handler) validate(t *testing.T, actor string) {
 	// Check the principal information is good for further auditing and accounting.
 	require.NotNil(t, h.principal)
 	require.Equal(t, userActor, h.principal.Actor)
+
+	if principalType != "" {
+		require.Equal(t, principalType, h.principal.Type)
+	}
 }
 
 // getSchema loads and validates the test schema that is defined for this
@@ -352,11 +366,23 @@ func TestUserToServiceAuthenticationFailure(t *testing.T) {
 func TestUserToServiceAuthenticationSuccess(t *testing.T) {
 	t.Parallel()
 
+	testUserToServiceAuthenticationSuccess(t, identityapi.User)
+}
+
+func TestUserToServiceAuthenticationSuccessServiceAccountPrincipal(t *testing.T) {
+	t.Parallel()
+
+	testUserToServiceAuthenticationSuccess(t, identityapi.Service)
+}
+
+func testUserToServiceAuthenticationSuccess(t *testing.T, principalType identityapi.AuthClaimsAcctype) {
+	t.Helper()
+
 	c := gomock.NewController(t)
 	defer c.Finish()
 
 	authorizer := mock.NewMockAuthorizer(c)
-	authorizer.EXPECT().Authorize(gomock.Any()).Return(authInfoFixture(userActor), nil)
+	authorizer.EXPECT().Authorize(gomock.Any()).Return(authInfoFixture(userActor, principalType), nil)
 	authorizer.EXPECT().GetACL(gomock.Any(), gomock.Any()).Return(&identityapi.Acl{}, nil)
 
 	h := &handler{}
@@ -372,7 +398,7 @@ func TestUserToServiceAuthenticationSuccess(t *testing.T) {
 	m.ServeHTTP(w, r)
 
 	require.Equal(t, http.StatusOK, w.Result().StatusCode)
-	h.validate(t, userActor)
+	h.validate(t, userActor, principalType)
 }
 
 // TestServiceToServiceMalformedCertificate tests the response when a client certificate is
@@ -500,7 +526,7 @@ func TestServiceToServiceAuthenticationSuccessLegacy(t *testing.T) {
 	m.ServeHTTP(w, r)
 
 	require.Equal(t, http.StatusOK, w.Result().StatusCode)
-	h.validate(t, serviceActor)
+	h.validate(t, serviceActor, "")
 }
 
 func TestServiceToServiceAuthenticationSuccess(t *testing.T) {
@@ -526,7 +552,7 @@ func TestServiceToServiceAuthenticationSuccess(t *testing.T) {
 	m.ServeHTTP(w, r)
 
 	require.Equal(t, http.StatusOK, w.Result().StatusCode)
-	h.validate(t, serviceActor)
+	h.validate(t, serviceActor, "")
 }
 
 func TestServiceToServiceImpersonationRequiresActor(t *testing.T) {

--- a/pkg/principal/types.go
+++ b/pkg/principal/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 
 package principal
 
+import "github.com/unikorn-cloud/identity/pkg/openapi"
+
 // Principal records information about what user insigated a request.
 type Principal struct {
 	// OrganizationID of the originating request (optional).
@@ -25,6 +27,8 @@ type Principal struct {
 	OrganizationIDs []string `json:"organizationIds,omitempty"`
 	// ProjectID of the originating request (optional).
 	ProjectID string `json:"projectId,omitempty"`
+	// Type of the originating actor. This reuses the OpenAPI auth claim values.
+	Type openapi.AuthClaimsAcctype `json:"type,omitempty"`
 	// Actor of the originating request, this may be an email address
 	// for an end-user, a service identifier for a system service, or
 	// the service account name.

--- a/pkg/rbac/groups_test.go
+++ b/pkg/rbac/groups_test.go
@@ -937,6 +937,14 @@ func getACLForSystemAccount(t *testing.T, rbacClient *rbac.RBAC, serviceCN strin
 	return rbacClient.GetACL(ctx, testOrgID)
 }
 
+func impersonatedPrincipal(subject string, accountType openapi.AuthClaimsAcctype) *principal.Principal {
+	return &principal.Principal{
+		Actor:           subject,
+		Type:            accountType,
+		OrganizationIDs: []string{testOrgID},
+	}
+}
+
 // TestSystemAccountWithPrincipalUsesUserACL verifies that a system account carrying an
 // impersonated principal gets the end-user's ACL, not the system account's global role.
 // TestSystemAccountWithPrincipalUsesUserACL verifies that a system account carrying an
@@ -986,10 +994,7 @@ func TestSystemAccountWithPrincipalUsesUserACL(t *testing.T) {
 
 			aclDirect := getACLForUser(t, f.rbac, tc.subject)
 
-			aclImpersonated, err := getACLForSystemAccount(t, f.rbac, "compute-service", &principal.Principal{
-				Actor:           tc.subject,
-				OrganizationIDs: []string{testOrgID},
-			}, true)
+			aclImpersonated, err := getACLForSystemAccount(t, f.rbac, "compute-service", impersonatedPrincipal(tc.subject, openapi.User), true)
 			require.NoError(t, err)
 
 			assert.Equal(t, aclDirect, aclImpersonated, "impersonated ACL should equal the user's direct ACL when the service has superset permissions")
@@ -1020,7 +1025,73 @@ func TestSystemAccountWithEmptyActorFallsBackToSystemACL(t *testing.T) {
 	_, err := getACLForSystemAccount(t, f.rbac, "compute-service", &principal.Principal{
 		OrganizationID:  testOrgID,
 		OrganizationIDs: []string{testOrgID},
+		Type:            openapi.User,
 		Actor:           "",
 	}, true)
 	require.Error(t, err)
+}
+
+func TestSystemAccountWithServiceAccountPrincipalUsesServiceACL(t *testing.T) {
+	t.Parallel()
+
+	f, c := setupTestEnvironment(t)
+
+	superServiceRole := &unikornv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      "role-super-service",
+		},
+		Spec: unikornv1.RoleSpec{
+			Scopes: unikornv1.RoleScopes{
+				Global: []unikornv1.RoleScope{
+					{Name: "org:read", Operations: []unikornv1.Operation{unikornv1.Read}},
+					{Name: "project:deploy", Operations: []unikornv1.Operation{unikornv1.Create, unikornv1.Update}},
+					{Name: "project:read", Operations: []unikornv1.Operation{unikornv1.Read}},
+				},
+			},
+		},
+	}
+	require.NoError(t, c.Create(t.Context(), superServiceRole))
+
+	f.rbac = rbac.New(c, testNamespace, &rbac.Options{
+		SystemAccountRoleIDs: map[string]string{"compute-service": "role-super-service"},
+	})
+
+	aclDirect := getACLForServiceAccount(t, f.rbac, f.serviceAccountAlphaID, testOrgID, []string{testOrgID})
+	aclImpersonated, err := getACLForSystemAccount(t, f.rbac, "compute-service", impersonatedPrincipal(f.serviceAccountAlphaID, openapi.Service), true)
+	require.NoError(t, err)
+
+	assert.Equal(t, aclDirect, aclImpersonated)
+}
+
+func TestSystemAccountWithMissingPrincipalTypeFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	f, c := setupTestEnvironment(t)
+
+	superServiceRole := &unikornv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      "role-super-service",
+		},
+		Spec: unikornv1.RoleSpec{
+			Scopes: unikornv1.RoleScopes{
+				Global: []unikornv1.RoleScope{
+					{Name: "org:read", Operations: []unikornv1.Operation{unikornv1.Read}},
+				},
+			},
+		},
+	}
+	require.NoError(t, c.Create(t.Context(), superServiceRole))
+
+	f.rbac = rbac.New(c, testNamespace, &rbac.Options{
+		SystemAccountRoleIDs: map[string]string{"compute-service": "role-super-service"},
+	})
+
+	_, err := getACLForSystemAccount(t, f.rbac, "compute-service", &principal.Principal{
+		Actor:           f.serviceAccountAlphaID,
+		OrganizationIDs: []string{testOrgID},
+	}, true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, rbac.ErrInvalidPrincipalType)
 }

--- a/pkg/rbac/impersonation_test.go
+++ b/pkg/rbac/impersonation_test.go
@@ -70,6 +70,7 @@ func impersonate(t *testing.T, f fixture, userSubject string) *openapi.Acl {
 	t.Helper()
 
 	acl, err := getACLForSystemAccount(t, f.rbac, impersonationServiceCN, &principal.Principal{
+		Type:            openapi.User,
 		Actor:           userSubject,
 		OrganizationIDs: []string{testOrgID},
 	}, true)

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -44,6 +44,7 @@ var (
 	ErrNoAuthz                = goerrors.New("no authorization data in userinfo")
 	ErrWrongOrganizationCount = goerrors.New("expected exactly one organization ID")
 	ErrNotInOrganization      = goerrors.New("subject not a member of organization")
+	ErrInvalidPrincipalType   = goerrors.New("invalid impersonated principal type")
 )
 
 type Options struct {
@@ -838,10 +839,12 @@ func (r *RBAC) getSystemAccountACL(ctx context.Context, subject, organizationID 
 		organizationIDs = []string{p.OrganizationID}
 	}
 
-	userACL, err := r.processUserAccountACL(ctx, p.Actor, organizationID, &openapi.AuthClaims{
-		Acctype: openapi.User,
+	principalACLClaims := &openapi.AuthClaims{
+		Acctype: p.Type,
 		OrgIds:  organizationIDs,
-	})
+	}
+
+	principalACL, err := r.processImpersonatedPrincipalACL(ctx, p, organizationID, principalACLClaims)
 	if err != nil {
 		return nil, err
 	}
@@ -851,7 +854,20 @@ func (r *RBAC) getSystemAccountACL(ctx context.Context, subject, organizationID 
 		return nil, err
 	}
 
-	return intersectACL(userACL, serviceACL), nil
+	return intersectACL(principalACL, serviceACL), nil
+}
+
+func (r *RBAC) processImpersonatedPrincipalACL(ctx context.Context, p *principal.Principal, organizationID string, authz *openapi.AuthClaims) (*openapi.Acl, error) {
+	switch p.Type {
+	case openapi.User:
+		return r.processUserAccountACL(ctx, p.Actor, organizationID, authz)
+	case openapi.Service:
+		return r.processServiceAccountACL(ctx, p.Actor, organizationID, authz)
+	case openapi.System:
+		return nil, fmt.Errorf("%w: %q", ErrInvalidPrincipalType, p.Type)
+	default:
+		return nil, fmt.Errorf("%w: %q", ErrInvalidPrincipalType, p.Type)
+	}
 }
 
 // GetACL returns a granular set of permissions for a user based on their scope.

--- a/test/contracts/provider/region/middleware.go
+++ b/test/contracts/provider/region/middleware.go
@@ -76,6 +76,7 @@ func MockACLMiddleware(_ []string) func(http.Handler) http.Handler {
 
 			// Inject mock principal info (required for SetIdentityMetadata)
 			principalInfo := &principal.Principal{
+				Type:           openapi.User,
 				Actor:          "test-user",
 				OrganizationID: orgID,
 			}


### PR DESCRIPTION
## Summary

Identity currently propagates an impersonated principal with only actor and scope information. When a system service makes an internal ACL request with impersonation enabled, RBAC assumes the propagated actor is always a user and unconditionally routes the impersonated branch through `processUserAccountACL`. That breaks service-account-rooted flows because the impersonated subject is looked up as a `User` and fails when no `User` object exists.

This change carries the existing auth-claim account type through principal propagation and uses it to dispatch impersonated ACL resolution correctly.

## Changes

- add a `type` field to `principal.Principal` using the existing `openapi.AuthClaimsAcctype` values
- set the propagated principal type in the OpenAPI middleware when generating a principal from bearer-token authentication
- route impersonated system-account ACL resolution by propagated principal type:
  - `user` -> `processUserAccountACL`
  - `service` -> `processServiceAccountACL`
- fail closed for missing, unknown, or `system` impersonated principal types
- update supporting fixtures and tests so propagated principals are typed consistently
- add regression coverage for impersonated service-account ACL resolution and the missing-type failure path

## Validation

- `GOCACHE=/tmp/gocache go test ./pkg/middleware/openapi ./pkg/rbac`
- `GOCACHE=/tmp/gocache go test ./pkg/handler/common ./test/contracts/provider/region`
- `GOCACHE=/tmp/gocache make validate`
- `GOCACHE=/tmp/gocache make lint`

## Not Run

- integration tests
