### PR TITLE
Add SSH CA read access to compute-service

### DIFF
--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -232,6 +232,7 @@ roles:
         region:servers:v2: [create,read,update,delete]
         region:securitygroups: [create,read,update,delete]
         region:securitygroups:v2: [read]
+        region:sshcertificateauthorities:v2: [read]
   storage-service:
     decription: Storage service
     protected: true


### PR DESCRIPTION
The compute service checks SSH certificate authority references while impersonating the user. That RBAC decision is the boolean intersection of the service role and the impersonated user permissions, so compute-service also needs read access to region:sshcertificateauthorities:v2 or the check fails even when the user is allowed to reference the project-scoped CA.
