### PR TITLE
feat(passport): add mTLS impersonation support to token exchange

### DIFF
--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -248,6 +248,60 @@ func createProject(ctx context.Context, ac *openapi.ClientWithResponses, orgID, 
 	return id
 }
 
+// createUser creates a user in the given groups and returns its ID.
+func createUser(ctx context.Context, ac *openapi.ClientWithResponses, orgID, subject string, groupIDs []string) string {
+	logf("Creating user %q...", subject)
+
+	resp, err := ac.PostApiV1OrganizationsOrganizationIDUsersWithResponse(ctx, orgID, openapi.UserWrite{
+		Spec: openapi.UserSpec{
+			Subject:  subject,
+			State:    openapi.Active,
+			GroupIDs: groupIDs,
+		},
+	})
+	if err != nil {
+		fatalf("failed to create user %q: %v", subject, err)
+	}
+
+	if resp.JSON201 == nil {
+		fatalf("create user %q returned %s", subject, resp.Status())
+	}
+
+	id := resp.JSON201.Metadata.Id
+	logf("  user %q ID: %s", subject, id)
+
+	return id
+}
+
+// writeCertFiles writes the cert and key PEM to disk next to the CA bundle so
+// the integration suite can load them via IDENTITY_IMPERSONATE_CLIENT_*_PATH.
+// Paths are returned absolute.
+func writeCertFiles(caCertPath string, certPEM, keyPEM []byte) (string, string) {
+	dir := filepath.Dir(caCertPath)
+
+	certPath := filepath.Join(dir, "impersonator-cert.pem")
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		fatalf("failed to write impersonator cert: %v", err)
+	}
+
+	keyPath := filepath.Join(dir, "impersonator-key.pem")
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		fatalf("failed to write impersonator key: %v", err)
+	}
+
+	absCert, err := filepath.Abs(certPath)
+	if err != nil {
+		fatalf("failed to resolve impersonator cert path: %v", err)
+	}
+
+	absKey, err := filepath.Abs(keyPath)
+	if err != nil {
+		fatalf("failed to resolve impersonator key path: %v", err)
+	}
+
+	return absCert, absKey
+}
+
 // createServiceAccount creates a service account in the given groups and returns its ID and token.
 func createServiceAccount(ctx context.Context, ac *openapi.ClientWithResponses, orgID, name string, groupIDs []string) (string, string) {
 	logf("Creating service account %q...", name)
@@ -410,6 +464,22 @@ func main() {
 	adminSAID, adminToken := createServiceAccount(ctx, ac, orgID, "ci-admin-sa", []string{adminGroupID})
 	userSAID, userToken := createServiceAccount(ctx, ac, orgID, "ci-user-sa", []string{userGroupID})
 
+	// ── Impersonation fixtures ────────────────────────────────────────────────
+	// Issue a second mTLS cert for the impersonation system account. Its CN
+	// (ci-impersonator) maps to ci-impersonator-role in test-values.yaml.
+	// The passport-exchange integration suite uses this cert to call
+	// /oauth2/v2/exchange with X-Impersonate: true.
+	logf("Issuing mTLS client certificate for ci-impersonator...")
+
+	imperCertPEM, imperKeyPEM := issueCert(ctx, k8s, *namespace, "ci-impersonator", "ci-impersonator")
+	imperCertPath, imperKeyPath := writeCertFiles(*caCertPath, imperCertPEM, imperKeyPEM)
+
+	// Pre-provision a user in the org to be impersonated. Membership in
+	// ci-user-group gives them a project-scoped ACL that will be intersected
+	// with ci-impersonator-role's global read-only scope at exchange time.
+	const impersonatedSubject = "ci-impersonated-user@example.com"
+	impersonatedUserID := createUser(ctx, ac, orgID, impersonatedSubject, []string{userGroupID})
+
 	// ── Output .env fragment to stdout ────────────────────────────────────────
 	fmt.Printf("IDENTITY_BASE_URL=%s\n", *baseURL)
 	fmt.Printf("IDENTITY_CA_CERT=%s\n", *caCertPath)
@@ -422,4 +492,8 @@ func main() {
 	fmt.Printf("TEST_USER_SA_ID=%s\n", userSAID)
 	fmt.Printf("ADMIN_AUTH_TOKEN=%s\n", adminToken)
 	fmt.Printf("USER_AUTH_TOKEN=%s\n", userToken)
+	fmt.Printf("IDENTITY_IMPERSONATE_CLIENT_CERT_PATH=%s\n", imperCertPath)
+	fmt.Printf("IDENTITY_IMPERSONATE_CLIENT_KEY_PATH=%s\n", imperKeyPath)
+	fmt.Printf("TEST_IMPERSONATION_USER_ID=%s\n", impersonatedUserID)
+	fmt.Printf("TEST_IMPERSONATION_USER_SUBJECT=%s\n", impersonatedSubject)
 }

--- a/hack/ci/test-values.yaml
+++ b/hack/ci/test-values.yaml
@@ -2,3 +2,18 @@
 # Passed to hack/ci/install via --values.
 systemAccounts:
   ci-fixtures: platform-administrator
+  # CI-only mTLS system account used by the passport exchange
+  # integration suite. CN maps to a deliberately narrow role so the
+  # confused-deputy intersection is observable in tests.
+  ci-impersonator: ci-impersonator-role
+
+# Purpose-built CI role for the impersonation tests. Kept under
+# additionalRoles so it cannot collide with a shipped role of the same
+# name.
+additionalRoles:
+  ci-impersonator-role:
+    description: CI impersonation service (read-only projects)
+    protected: true
+    scopes:
+      global:
+        identity:projects: [read]

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -213,7 +213,14 @@ func (h *Handler) PostOauth2V2Token(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) PostOauth2V2Exchange(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusNotImplemented)
+	result, err := h.oauth2.Exchange(r.Context(), r)
+	if err != nil {
+		oauth2errors.HandleError(w, r, err)
+		return
+	}
+
+	h.setUncacheableNoStore(w)
+	util.WriteJSONResponse(w, r, http.StatusOK, result)
 }
 
 func (h *Handler) GetOauth2V2Userinfo(w http.ResponseWriter, r *http.Request) {

--- a/pkg/middleware/openapi/openapi.go
+++ b/pkg/middleware/openapi/openapi.go
@@ -20,9 +20,6 @@ package openapi
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
-	goerrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,7 +31,6 @@ import (
 	"github.com/getkin/kin-openapi/routers"
 	"github.com/spf13/pflag"
 
-	"github.com/unikorn-cloud/core/pkg/client"
 	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
 	"github.com/unikorn-cloud/core/pkg/server/errors"
 	"github.com/unikorn-cloud/core/pkg/server/middleware"
@@ -51,10 +47,6 @@ import (
 
 const (
 	OperationIgnoreRequestBodyTag = "unikorn-cloud.org/ignore-request-body"
-)
-
-var (
-	ErrHeader = goerrors.New("header error")
 )
 
 type Options struct {
@@ -326,60 +318,11 @@ func (v *Validator) generatePrincipal(ctx context.Context, params map[string]str
 	return principal.NewContext(ctx, p)
 }
 
-// extractPrincipal makes available the identity information for the user
-// that actually insigated the request so it can be propagated to and used
-// by any service.  This is called only by other system services as
-// identified by the use of mTLS.
-func extractPrincipal(ctx context.Context, r *http.Request) (context.Context, error) {
-	header := r.Header.Get(principal.Header)
-	if header == "" {
-		return nil, fmt.Errorf("%w: principal header not present", ErrHeader)
-	}
-
-	data, err := base64.RawURLEncoding.DecodeString(header)
-	if err != nil {
-		// TODO: fallback, delete me... I am VERY slow.
-		// Use the certificate of the service that actually called us.
-		// The one in the context is used to propagate token binding information.
-		certRaw, err := util.GetClientCertificateHeader(r.Header)
-		if err != nil {
-			return nil, err
-		}
-
-		certificate, err := util.GetClientCertificate(certRaw)
-		if err != nil {
-			return nil, err
-		}
-
-		p := &principal.Principal{}
-
-		if err := client.VerifyAndDecode(p, header, certificate); err != nil {
-			return nil, err
-		}
-
-		return principal.NewContext(ctx, p), nil
-	}
-
-	p := &principal.Principal{}
-
-	if err := json.Unmarshal(data, p); err != nil {
-		return nil, err
-	}
-
-	ctx = principal.NewContext(ctx, p)
-
-	if r.Header.Get(principal.ImpersonateHeader) == "true" {
-		ctx = principal.NewImpersonateContext(ctx)
-	}
-
-	return ctx, nil
-}
-
 // extractOrGeneratePrincipal extracts the principal if mTLS is in use, for service to service
 // API calls, otherwise it generates it from the available information.
 func (v *Validator) extractOrGeneratePrincipal(ctx context.Context, r *http.Request, params map[string]string, userinfo *identityapi.Userinfo) (context.Context, error) {
 	if util.HasClientCertificateHeader(r.Header) {
-		newCtx, err := extractPrincipal(ctx, r)
+		newCtx, err := principal.ExtractFromRequest(ctx, r)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/oauth2/passport.go
+++ b/pkg/oauth2/passport.go
@@ -33,6 +33,8 @@ import (
 	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/errors"
 	"github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/principal"
+	"github.com/unikorn-cloud/identity/pkg/util"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -81,21 +83,47 @@ type PassportClaims struct {
 	ACL *openapi.Acl `json:"acl"`
 }
 
-// Exchange validates a source access token, resolves identity and ACL,
-// and returns a signed passport JWT.
+// Exchange validates a caller's credentials, resolves identity and ACL, and
+// returns a signed passport JWT. Two authentication modes are accepted:
+//
+//   - Bearer: an end-user access token in the Authorization header.
+//   - mTLS + impersonation: a service client cert plus an X-Impersonate: true
+//     header and an X-Principal header carrying the impersonated user. This
+//     mints a passport on the user's behalf with an ACL intersected against
+//     the calling service's own ACL (confused-deputy prevention).
+//
+// A service calling over mTLS WITHOUT the impersonation header is refused:
+// autonomous service-to-service traffic does not receive a passport.
 func (a *Authenticator) Exchange(ctx context.Context, r *http.Request) (*openapi.ExchangeResult, error) {
+	log := log.FromContext(ctx)
+
+	options, err := parseExchangeRequest(r)
+	if err != nil {
+		log.Info("passport exchange failed: malformed request body")
+
+		return nil, err
+	}
+
+	if !hasHTTPAuthorization(r) {
+		return a.exchangeImpersonated(ctx, r, options)
+	}
+
+	return a.exchangeBearer(ctx, r, options)
+}
+
+// hasHTTPAuthorization reports whether the request carries a bearer token.
+func hasHTTPAuthorization(r *http.Request) bool {
+	return r.Header.Get("Authorization") != ""
+}
+
+// exchangeBearer is the end-user path: the caller presents an access token
+// which is introspected to produce the passport.
+func (a *Authenticator) exchangeBearer(ctx context.Context, r *http.Request, options *openapi.ExchangeRequestOptions) (*openapi.ExchangeResult, error) {
 	log := log.FromContext(ctx)
 
 	token, err := extractBearerToken(r)
 	if err != nil {
 		log.Info("passport exchange failed: missing or invalid authorization header")
-
-		return nil, err
-	}
-
-	options, err := parseExchangeRequest(r)
-	if err != nil {
-		log.Info("passport exchange failed: malformed request body")
 
 		return nil, err
 	}
@@ -140,6 +168,161 @@ func (a *Authenticator) Exchange(ctx context.Context, r *http.Request) (*openapi
 		return nil, err
 	}
 
+	var email string
+	if userinfo.Email != nil {
+		email = *userinfo.Email
+	}
+
+	return a.mintPassport(ctx, passportIdentity{
+		subject: userinfo.Sub,
+		actor:   userinfo.Sub,
+		acctype: authz.Acctype,
+		email:   email,
+		orgIDs:  authz.OrgIds,
+	}, organizationID, projectID, acl)
+}
+
+// resolveImpersonation validates the mTLS client certificate and impersonation
+// headers, extracting the service identity and the impersonated principal. All
+// negative paths fail closed with the appropriate OAuth2 error.
+func resolveImpersonation(ctx context.Context, r *http.Request) (context.Context, string, *principal.Principal, error) {
+	log := log.FromContext(ctx)
+
+	certRaw, err := util.GetClientCertificateHeader(r.Header)
+	if err != nil {
+		log.Info("passport exchange failed: no bearer token and no client certificate")
+
+		return nil, "", nil, errors.OAuth2AccessDenied("authorization required").WithError(err)
+	}
+
+	cert, err := util.GetClientCertificate(certRaw)
+	if err != nil {
+		log.Info("passport exchange failed: invalid client certificate")
+
+		return nil, "", nil, errors.OAuth2AccessDenied("invalid client certificate").WithError(err)
+	}
+
+	serviceIdentity := cert.Subject.CommonName
+
+	if r.Header.Get(principal.ImpersonateHeader) != "true" {
+		log.Info("passport exchange denied: mTLS caller without impersonation flag",
+			"serviceIdentity", serviceIdentity,
+		)
+
+		return nil, serviceIdentity, nil, errors.OAuth2InvalidRequest("impersonation flag required for mTLS exchange")
+	}
+
+	impersonatedCtx, err := principal.ExtractFromRequest(ctx, r)
+	if err != nil {
+		log.Info("passport exchange denied: invalid principal header",
+			"serviceIdentity", serviceIdentity,
+			"error", err.Error(),
+		)
+
+		return nil, serviceIdentity, nil, errors.OAuth2AccessDenied("invalid principal header").WithError(err)
+	}
+
+	// Belt and braces: principal.ExtractFromRequest only propagates the
+	// impersonation flag when the header is present and literally "true".
+	if !principal.ImpersonateFromContext(impersonatedCtx) {
+		log.Info("passport exchange denied: impersonation context not established",
+			"serviceIdentity", serviceIdentity,
+		)
+
+		return nil, serviceIdentity, nil, errors.OAuth2AccessDenied("impersonation context not established")
+	}
+
+	p, err := principal.FromContext(impersonatedCtx)
+	if err != nil || p == nil || p.Actor == "" {
+		log.Info("passport exchange denied: impersonation principal missing actor",
+			"serviceIdentity", serviceIdentity,
+		)
+
+		return nil, serviceIdentity, nil, errors.OAuth2AccessDenied("principal actor required")
+	}
+
+	return impersonatedCtx, serviceIdentity, p, nil
+}
+
+// exchangeImpersonated is the service-to-user path: a system service presents
+// its mTLS client certificate plus the impersonated principal via headers.
+// Any ambiguity in the principal fails closed — the passport is only minted
+// when the impersonation signal is explicit and the actor unambiguous.
+func (a *Authenticator) exchangeImpersonated(ctx context.Context, r *http.Request, options *openapi.ExchangeRequestOptions) (*openapi.ExchangeResult, error) {
+	log := log.FromContext(ctx)
+
+	impersonatedCtx, serviceIdentity, p, err := resolveImpersonation(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Present the CALLING SERVICE as the authenticated subject so rbac.GetACL
+	// takes the system-account + impersonation branch and returns the
+	// intersection of the user's and service's ACLs.
+	authCtx := authorization.NewContext(impersonatedCtx, &authorization.Info{
+		SystemAccount: true,
+		Userinfo: &openapi.Userinfo{
+			Sub: serviceIdentity,
+			HttpsunikornCloudOrgauthz: &openapi.AuthClaims{
+				Acctype: openapi.System,
+			},
+		},
+	})
+
+	organizationID, projectID := requestedScope(options)
+
+	if err := validateImpersonatedOrganizationScope(p, organizationID); err != nil {
+		log.Info("passport exchange denied: organization not in principal scope",
+			"serviceIdentity", serviceIdentity,
+			"actor", p.Actor,
+			"organizationID", organizationID,
+		)
+
+		return nil, err
+	}
+
+	acl, err := a.rbac.GetACL(authCtx, organizationID)
+	if err != nil {
+		log.Error(err, "passport exchange failed: intersected ACL computation failed",
+			"serviceIdentity", serviceIdentity,
+			"actor", p.Actor,
+			"organizationID", organizationID,
+		)
+
+		return nil, fmt.Errorf("%w: failed to compute ACL", err)
+	}
+
+	if err := a.validateProjectScope(ctx, acl, organizationID, projectID); err != nil {
+		return nil, err
+	}
+
+	return a.mintPassport(ctx, passportIdentity{
+		subject:         p.Actor,
+		actor:           p.Actor,
+		acctype:         openapi.User,
+		orgIDs:          p.OrganizationIDs,
+		impersonated:    true,
+		serviceIdentity: serviceIdentity,
+	}, organizationID, projectID, acl)
+}
+
+// passportIdentity bundles the subject details used to mint a passport, letting
+// the bearer and mTLS flows share a single signing helper.
+type passportIdentity struct {
+	subject         string
+	actor           string
+	acctype         openapi.AuthClaimsAcctype
+	email           string
+	orgIDs          []string
+	impersonated    bool
+	serviceIdentity string
+}
+
+// mintPassport builds the passport claims from the provided identity and the
+// authorised scope, signs the JWT, logs the issuance, and returns the result.
+func (a *Authenticator) mintPassport(ctx context.Context, id passportIdentity, organizationID, projectID string, acl *openapi.Acl) (*openapi.ExchangeResult, error) {
+	log := log.FromContext(ctx)
+
 	now := time.Now()
 	passportID := uuid.New().String()
 
@@ -147,23 +330,20 @@ func (a *Authenticator) Exchange(ctx context.Context, r *http.Request) (*openapi
 		Claims: jwt.Claims{
 			ID:        passportID,
 			Issuer:    PassportIssuer,
-			Subject:   userinfo.Sub,
+			Subject:   id.subject,
 			IssuedAt:  jwt.NewNumericDate(now),
 			NotBefore: jwt.NewNumericDate(now),
 			Expiry:    jwt.NewNumericDate(now.Add(PassportTTL)),
 		},
 		Type:      PassportType,
-		Acctype:   authz.Acctype,
+		Acctype:   id.acctype,
 		Source:    PassportSourceUNI,
-		OrgIDs:    authz.OrgIds,
+		Email:     id.email,
+		OrgIDs:    id.orgIDs,
 		OrgID:     organizationID,
 		ProjectID: projectID,
-		Actor:     userinfo.Sub,
+		Actor:     id.actor,
 		ACL:       acl,
-	}
-
-	if userinfo.Email != nil {
-		claims.Email = *userinfo.Email
 	}
 
 	passport, err := a.jwtIssuer.EncodeJWT(ctx, claims)
@@ -175,19 +355,42 @@ func (a *Authenticator) Exchange(ctx context.Context, r *http.Request) (*openapi
 		return nil, fmt.Errorf("failed to mint passport: %w", err)
 	}
 
-	log.Info("passport exchanged",
-		"acctype", authz.Acctype,
+	logKVs := []any{
+		"acctype", id.acctype,
 		"source", PassportSourceUNI,
 		"organizationID", organizationID,
 		"passportID", passportID,
-	)
-
-	result := &openapi.ExchangeResult{
-		Passport:  passport,
-		ExpiresIn: int(PassportTTL.Seconds()),
 	}
 
-	return result, nil
+	if id.impersonated {
+		logKVs = append(logKVs,
+			"impersonated", true,
+			"serviceIdentity", id.serviceIdentity,
+			"actor", id.actor,
+		)
+	}
+
+	log.Info("passport exchanged", logKVs...)
+
+	return &openapi.ExchangeResult{
+		Passport:  passport,
+		ExpiresIn: int(PassportTTL.Seconds()),
+	}, nil
+}
+
+// validateImpersonatedOrganizationScope rejects exchanges scoped to an
+// organization the impersonated principal does not belong to. Impersonation
+// can only narrow — it must not widen — access.
+func validateImpersonatedOrganizationScope(p *principal.Principal, organizationID string) error {
+	if organizationID == "" {
+		return nil
+	}
+
+	if !slices.Contains(p.OrganizationIDs, organizationID) {
+		return errors.OAuth2AccessDenied("organization not in scope")
+	}
+
+	return nil
 }
 
 func validateOrganizationScope(authz *openapi.AuthClaims, organizationID string) error {

--- a/pkg/oauth2/passport.go
+++ b/pkg/oauth2/passport.go
@@ -26,10 +26,14 @@ import (
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
 
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/errors"
 	"github.com/unikorn-cloud/identity/pkg/openapi"
 
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -113,6 +117,11 @@ func (a *Authenticator) Exchange(ctx context.Context, r *http.Request) (*openapi
 		organizationID = *options.OrganizationId
 	}
 
+	var projectID string
+	if options.ProjectId != nil {
+		projectID = *options.ProjectId
+	}
+
 	acl, err := a.rbac.GetACL(authCtx, organizationID)
 	if err != nil {
 		log.Error(err, "passport exchange failed: ACL computation failed",
@@ -122,6 +131,10 @@ func (a *Authenticator) Exchange(ctx context.Context, r *http.Request) (*openapi
 		)
 
 		return nil, fmt.Errorf("%w: failed to compute ACL", err)
+	}
+
+	if err := a.validateProjectScope(ctx, acl, organizationID, projectID); err != nil {
+		return nil, err
 	}
 
 	now := time.Now()
@@ -136,28 +149,18 @@ func (a *Authenticator) Exchange(ctx context.Context, r *http.Request) (*openapi
 			NotBefore: jwt.NewNumericDate(now),
 			Expiry:    jwt.NewNumericDate(now.Add(PassportTTL)),
 		},
-		Type:    PassportType,
-		Acctype: authz.Acctype,
-		Source:  PassportSourceUNI,
-		OrgIDs:  authz.OrgIds,
-		Actor:   userinfo.Sub,
-		ACL:     acl,
+		Type:      PassportType,
+		Acctype:   authz.Acctype,
+		Source:    PassportSourceUNI,
+		OrgIDs:    authz.OrgIds,
+		OrgID:     organizationID,
+		ProjectID: projectID,
+		Actor:     userinfo.Sub,
+		ACL:       acl,
 	}
 
 	if userinfo.Email != nil {
 		claims.Email = *userinfo.Email
-	}
-
-	if options.OrganizationId != nil {
-		claims.OrgID = *options.OrganizationId
-	}
-
-	if options.ProjectId != nil {
-		if !projectInACL(*options.ProjectId, acl) {
-			return nil, errors.OAuth2AccessDenied("project not in scope")
-		}
-
-		claims.ProjectID = *options.ProjectId
 	}
 
 	passport, err := a.jwtIssuer.EncodeJWT(ctx, claims)
@@ -237,4 +240,80 @@ func projectInACL(projectID string, acl *openapi.Acl) bool {
 	}
 
 	return false
+}
+
+// hasBroaderScope returns true if the ACL carries a global or organization-level
+// grant that, per the scope-confinement rule, implicitly covers project scope.
+func hasBroaderScope(acl *openapi.Acl, organizationID string) bool {
+	if acl == nil {
+		return false
+	}
+
+	if acl.Global != nil && len(*acl.Global) > 0 {
+		return true
+	}
+
+	if organizationID == "" || acl.Organization == nil || acl.Organization.Id != organizationID {
+		return false
+	}
+
+	return acl.Organization.Endpoints != nil && len(*acl.Organization.Endpoints) > 0
+}
+
+// validateProjectScope authorises the passport's requested project scope.
+// A request is accepted if the project is present in the subject's ACL, or
+// if a broader (global/organization) grant covers it — in which case the
+// project must be verified to belong to the requested organization to prevent
+// scope injection via untrusted request parameters.
+func (a *Authenticator) validateProjectScope(ctx context.Context, acl *openapi.Acl, organizationID, projectID string) error {
+	if projectID == "" {
+		return nil
+	}
+
+	if projectInACL(projectID, acl) {
+		return nil
+	}
+
+	if !hasBroaderScope(acl, organizationID) {
+		return errors.OAuth2AccessDenied("project not in scope")
+	}
+
+	ok, err := a.projectInOrganization(ctx, organizationID, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to verify project membership: %w", err)
+	}
+
+	if !ok {
+		return errors.OAuth2AccessDenied("project not in scope")
+	}
+
+	return nil
+}
+
+// projectInOrganization reports whether a project with the given ID exists in
+// the organization's backing namespace.
+func (a *Authenticator) projectInOrganization(ctx context.Context, organizationID, projectID string) (bool, error) {
+	var org unikornv1.Organization
+	if err := a.client.Get(ctx, client.ObjectKey{Namespace: a.namespace, Name: organizationID}, &org); err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	if org.Status.Namespace == "" {
+		return false, nil
+	}
+
+	var project unikornv1.Project
+	if err := a.client.Get(ctx, client.ObjectKey{Namespace: org.Status.Namespace, Name: projectID}, &project); err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
 }

--- a/pkg/oauth2/passport.go
+++ b/pkg/oauth2/passport.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oauth2
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/google/uuid"
+
+	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
+	"github.com/unikorn-cloud/identity/pkg/oauth2/errors"
+	"github.com/unikorn-cloud/identity/pkg/openapi"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// PassportTTL is the lifetime of a passport token.
+	PassportTTL = 2 * time.Minute
+
+	// PassportType distinguishes passport tokens from access tokens.
+	PassportType = "passport"
+
+	// PassportIssuer is the issuer claim value for passport tokens.
+	PassportIssuer = "uni-identity"
+
+	// PassportSourceUNI indicates the source token was a UNI access token.
+	PassportSourceUNI = "uni"
+)
+
+// PassportClaims defines the JWT claims for a passport token.
+type PassportClaims struct {
+	jwt.Claims `json:",inline"`
+
+	// Type distinguishes passports from access tokens.
+	Type string `json:"typ"`
+	// Acctype is the account type: "user", "service", or "system".
+	Acctype openapi.AuthClaimsAcctype `json:"acctype"`
+	// Source identifies which IdP issued the original token.
+	Source string `json:"source"`
+	// Email is the user's email address, if available.
+	Email string `json:"email,omitempty"`
+	// OrgIDs is the list of organization IDs the subject is authorized for.
+	//nolint:tagliatelle
+	OrgIDs []string `json:"org_ids"`
+	// OrgID is the current organization context from the exchange request.
+	//nolint:tagliatelle
+	OrgID string `json:"org_id,omitempty"`
+	// ProjectID is the current project context from the exchange request.
+	//nolint:tagliatelle
+	ProjectID string `json:"project_id,omitempty"`
+	// Actor is the end-user identifier for principal propagation and audit.
+	Actor string `json:"actor"`
+	// ACL is the organization-scoped ACL structure.
+	ACL *openapi.Acl `json:"acl"`
+}
+
+// Exchange validates a source access token, resolves identity and ACL,
+// and returns a signed passport JWT.
+func (a *Authenticator) Exchange(ctx context.Context, r *http.Request) (*openapi.ExchangeResult, error) {
+	log := log.FromContext(ctx)
+
+	token, err := extractBearerToken(r)
+	if err != nil {
+		log.Info("passport exchange failed: missing or invalid authorization header")
+
+		return nil, err
+	}
+
+	options, err := parseExchangeRequest(r)
+	if err != nil {
+		log.Info("passport exchange failed: malformed request body")
+
+		return nil, err
+	}
+
+	userinfo, _, err := a.GetUserinfo(ctx, r, token)
+	if err != nil {
+		log.Info("passport exchange failed: token validation failed")
+
+		return nil, err
+	}
+
+	authz := userinfo.HttpsunikornCloudOrgauthz
+
+	// Set up authorization context so rbac.GetACL can read it.
+	authCtx := authorization.NewContext(ctx, &authorization.Info{
+		Token:    token,
+		Userinfo: userinfo,
+	})
+
+	var organizationID string
+	if options.OrganizationId != nil {
+		organizationID = *options.OrganizationId
+	}
+
+	acl, err := a.rbac.GetACL(authCtx, organizationID)
+	if err != nil {
+		log.Error(err, "passport exchange failed: ACL computation failed",
+			"subject", userinfo.Sub,
+			"acctype", authz.Acctype,
+			"organizationID", organizationID,
+		)
+
+		return nil, fmt.Errorf("%w: failed to compute ACL", err)
+	}
+
+	now := time.Now()
+	passportID := uuid.New().String()
+
+	claims := &PassportClaims{
+		Claims: jwt.Claims{
+			ID:        passportID,
+			Issuer:    PassportIssuer,
+			Subject:   userinfo.Sub,
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			Expiry:    jwt.NewNumericDate(now.Add(PassportTTL)),
+		},
+		Type:    PassportType,
+		Acctype: authz.Acctype,
+		Source:  PassportSourceUNI,
+		OrgIDs:  authz.OrgIds,
+		Actor:   userinfo.Sub,
+		ACL:     acl,
+	}
+
+	if userinfo.Email != nil {
+		claims.Email = *userinfo.Email
+	}
+
+	if options.OrganizationId != nil {
+		claims.OrgID = *options.OrganizationId
+	}
+
+	if options.ProjectId != nil {
+		claims.ProjectID = *options.ProjectId
+	}
+
+	passport, err := a.jwtIssuer.EncodeJWT(ctx, claims)
+	if err != nil {
+		log.Error(err, "passport exchange failed: signing failed",
+			"subject", userinfo.Sub,
+			"passportID", passportID,
+		)
+
+		return nil, fmt.Errorf("failed to mint passport: %w", err)
+	}
+
+	log.Info("passport exchanged",
+		"subject", userinfo.Sub,
+		"acctype", authz.Acctype,
+		"source", PassportSourceUNI,
+		"organizationID", organizationID,
+		"passportID", passportID,
+	)
+
+	result := &openapi.ExchangeResult{
+		Passport:  passport,
+		ExpiresIn: int(PassportTTL.Seconds()),
+	}
+
+	return result, nil
+}
+
+// extractBearerToken extracts the Bearer token from the Authorization header.
+func extractBearerToken(r *http.Request) (string, error) {
+	header := r.Header.Get("Authorization")
+	if header == "" {
+		return "", errors.OAuth2AccessDenied("authorization header not set")
+	}
+
+	parts := strings.Split(header, " ")
+	if len(parts) != 2 {
+		return "", errors.OAuth2InvalidRequest("authorization header malformed")
+	}
+
+	if !strings.EqualFold(parts[0], "bearer") {
+		return "", errors.OAuth2InvalidRequest("authorization scheme not allowed")
+	}
+
+	return parts[1], nil
+}
+
+// parseExchangeRequest parses the form-encoded request body into ExchangeRequestOptions.
+func parseExchangeRequest(r *http.Request) (*openapi.ExchangeRequestOptions, error) {
+	if err := r.ParseForm(); err != nil {
+		return nil, errors.OAuth2InvalidRequest("failed to parse form data: " + err.Error())
+	}
+
+	options := &openapi.ExchangeRequestOptions{}
+
+	if v := r.Form.Get("organizationId"); v != "" {
+		options.OrganizationId = &v
+	}
+
+	if v := r.Form.Get("projectId"); v != "" {
+		options.ProjectId = &v
+	}
+
+	return options, nil
+}

--- a/pkg/oauth2/passport.go
+++ b/pkg/oauth2/passport.go
@@ -79,18 +79,17 @@ type PassportClaims struct {
 	ProjectID string `json:"project_id,omitempty"`
 	// Actor is the end-user identifier for principal propagation and audit.
 	Actor string `json:"actor"`
-	// ACL is the organization-scoped ACL structure.
-	ACL *openapi.Acl `json:"acl"`
 }
 
-// Exchange validates a caller's credentials, resolves identity and ACL, and
-// returns a signed passport JWT. Two authentication modes are accepted:
+// Exchange validates a caller's credentials, resolves identity, and returns a
+// signed passport JWT. Two authentication modes are accepted:
 //
 //   - Bearer: an end-user access token in the Authorization header.
 //   - mTLS + impersonation: a service client cert plus an X-Impersonate: true
 //     header and an X-Principal header carrying the impersonated user. This
-//     mints a passport on the user's behalf with an ACL intersected against
-//     the calling service's own ACL (confused-deputy prevention).
+//     mints a passport on the user's behalf; the requested org/project scope
+//     is authorised against the user ∩ service ACL intersection (confused-
+//     deputy prevention), but the ACL itself is not embedded in the passport.
 //
 // A service calling over mTLS WITHOUT the impersonation header is refused:
 // autonomous service-to-service traffic does not receive a passport.
@@ -179,7 +178,7 @@ func (a *Authenticator) exchangeBearer(ctx context.Context, r *http.Request, opt
 		acctype: authz.Acctype,
 		email:   email,
 		orgIDs:  authz.OrgIds,
-	}, organizationID, projectID, acl)
+	}, organizationID, projectID)
 }
 
 // resolveImpersonation validates the mTLS client certificate and impersonation
@@ -258,7 +257,9 @@ func (a *Authenticator) exchangeImpersonated(ctx context.Context, r *http.Reques
 
 	// Present the CALLING SERVICE as the authenticated subject so rbac.GetACL
 	// takes the system-account + impersonation branch and returns the
-	// intersection of the user's and service's ACLs.
+	// intersection of the user's and service's ACLs. The intersection is used
+	// only to authorise the requested project scope below — it is not embedded
+	// in the passport.
 	authCtx := authorization.NewContext(impersonatedCtx, &authorization.Info{
 		SystemAccount: true,
 		Userinfo: &openapi.Userinfo{
@@ -303,7 +304,7 @@ func (a *Authenticator) exchangeImpersonated(ctx context.Context, r *http.Reques
 		orgIDs:          p.OrganizationIDs,
 		impersonated:    true,
 		serviceIdentity: serviceIdentity,
-	}, organizationID, projectID, acl)
+	}, organizationID, projectID)
 }
 
 // passportIdentity bundles the subject details used to mint a passport, letting
@@ -320,7 +321,7 @@ type passportIdentity struct {
 
 // mintPassport builds the passport claims from the provided identity and the
 // authorised scope, signs the JWT, logs the issuance, and returns the result.
-func (a *Authenticator) mintPassport(ctx context.Context, id passportIdentity, organizationID, projectID string, acl *openapi.Acl) (*openapi.ExchangeResult, error) {
+func (a *Authenticator) mintPassport(ctx context.Context, id passportIdentity, organizationID, projectID string) (*openapi.ExchangeResult, error) {
 	log := log.FromContext(ctx)
 
 	now := time.Now()
@@ -343,7 +344,6 @@ func (a *Authenticator) mintPassport(ctx context.Context, id passportIdentity, o
 		OrgID:     organizationID,
 		ProjectID: projectID,
 		Actor:     id.actor,
-		ACL:       acl,
 	}
 
 	passport, err := a.jwtIssuer.EncodeJWT(ctx, claims)

--- a/pkg/oauth2/passport.go
+++ b/pkg/oauth2/passport.go
@@ -18,6 +18,7 @@ package oauth2
 
 import (
 	"context"
+	goerrors "errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -27,6 +28,7 @@ import (
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
 
+	coreerrors "github.com/unikorn-cloud/core/pkg/server/errors"
 	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/errors"
@@ -102,7 +104,7 @@ func (a *Authenticator) Exchange(ctx context.Context, r *http.Request) (*openapi
 	if err != nil {
 		log.Info("passport exchange failed: token validation failed")
 
-		return nil, err
+		return nil, normalizeExchangeUserinfoError(err)
 	}
 
 	authz := userinfo.HttpsunikornCloudOrgauthz
@@ -212,6 +214,19 @@ func requestedScope(options *openapi.ExchangeRequestOptions) (string, string) {
 	}
 
 	return organizationID, projectID
+}
+
+func normalizeExchangeUserinfoError(err error) error {
+	var oauthErr *errors.Error
+	if goerrors.As(err, &oauthErr) {
+		return err
+	}
+
+	if coreerrors.IsAccessDenied(err) {
+		return errors.OAuth2AccessDenied("token validation failed").WithError(err)
+	}
+
+	return err
 }
 
 // extractBearerToken extracts the Bearer token from the Authorization header.

--- a/pkg/oauth2/passport.go
+++ b/pkg/oauth2/passport.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -112,20 +113,20 @@ func (a *Authenticator) Exchange(ctx context.Context, r *http.Request) (*openapi
 		Userinfo: userinfo,
 	})
 
-	var organizationID string
-	if options.OrganizationId != nil {
-		organizationID = *options.OrganizationId
-	}
+	organizationID, projectID := requestedScope(options)
 
-	var projectID string
-	if options.ProjectId != nil {
-		projectID = *options.ProjectId
+	if err := validateOrganizationScope(authz, organizationID); err != nil {
+		log.Info("passport exchange denied: organization not in scope",
+			"acctype", authz.Acctype,
+			"organizationID", organizationID,
+		)
+
+		return nil, err
 	}
 
 	acl, err := a.rbac.GetACL(authCtx, organizationID)
 	if err != nil {
 		log.Error(err, "passport exchange failed: ACL computation failed",
-			"subject", userinfo.Sub,
 			"acctype", authz.Acctype,
 			"organizationID", organizationID,
 		)
@@ -166,7 +167,6 @@ func (a *Authenticator) Exchange(ctx context.Context, r *http.Request) (*openapi
 	passport, err := a.jwtIssuer.EncodeJWT(ctx, claims)
 	if err != nil {
 		log.Error(err, "passport exchange failed: signing failed",
-			"subject", userinfo.Sub,
 			"passportID", passportID,
 		)
 
@@ -174,7 +174,6 @@ func (a *Authenticator) Exchange(ctx context.Context, r *http.Request) (*openapi
 	}
 
 	log.Info("passport exchanged",
-		"subject", userinfo.Sub,
 		"acctype", authz.Acctype,
 		"source", PassportSourceUNI,
 		"organizationID", organizationID,
@@ -187,6 +186,32 @@ func (a *Authenticator) Exchange(ctx context.Context, r *http.Request) (*openapi
 	}
 
 	return result, nil
+}
+
+func validateOrganizationScope(authz *openapi.AuthClaims, organizationID string) error {
+	if organizationID == "" {
+		return nil
+	}
+
+	if authz == nil || !slices.Contains(authz.OrgIds, organizationID) {
+		return errors.OAuth2AccessDenied("organization not in scope")
+	}
+
+	return nil
+}
+
+func requestedScope(options *openapi.ExchangeRequestOptions) (string, string) {
+	var organizationID string
+	if options.OrganizationId != nil {
+		organizationID = *options.OrganizationId
+	}
+
+	var projectID string
+	if options.ProjectId != nil {
+		projectID = *options.ProjectId
+	}
+
+	return organizationID, projectID
 }
 
 // extractBearerToken extracts the Bearer token from the Authorization header.

--- a/pkg/oauth2/passport.go
+++ b/pkg/oauth2/passport.go
@@ -153,6 +153,10 @@ func (a *Authenticator) Exchange(ctx context.Context, r *http.Request) (*openapi
 	}
 
 	if options.ProjectId != nil {
+		if !projectInACL(*options.ProjectId, acl) {
+			return nil, errors.OAuth2AccessDenied("project not in scope")
+		}
+
 		claims.ProjectID = *options.ProjectId
 	}
 
@@ -218,4 +222,19 @@ func parseExchangeRequest(r *http.Request) (*openapi.ExchangeRequestOptions, err
 	}
 
 	return options, nil
+}
+
+// projectInACL returns true if projectID appears in the ACL's project list.
+func projectInACL(projectID string, acl *openapi.Acl) bool {
+	if acl == nil || acl.Projects == nil {
+		return false
+	}
+
+	for _, p := range *acl.Projects {
+		if p.Id == projectID {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/oauth2/passport_mtls_test.go
+++ b/pkg/oauth2/passport_mtls_test.go
@@ -1,0 +1,524 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oauth2_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/core/pkg/constants"
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/identity/pkg/handler"
+	handlercommon "github.com/unikorn-cloud/identity/pkg/handler/common"
+	"github.com/unikorn-cloud/identity/pkg/jose"
+	josetesting "github.com/unikorn-cloud/identity/pkg/jose/testing"
+	"github.com/unikorn-cloud/identity/pkg/oauth2"
+	oauth2errors "github.com/unikorn-cloud/identity/pkg/oauth2/errors"
+	"github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/principal"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
+	"github.com/unikorn-cloud/identity/pkg/userdb"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// setupPassportTestEnvWithRBAC builds a passport test environment with a
+// custom RBAC options struct, letting tests register system accounts for
+// impersonation scenarios.
+func setupPassportTestEnvWithRBAC(t *testing.T, rbacOpts *rbac.Options, objects ...client.Object) *passportTestEnv {
+	t.Helper()
+
+	cli := fake.NewClientBuilder().WithScheme(getScheme(t)).WithObjects(objects...).Build()
+
+	josetesting.RotateCertificate(t, cli)
+
+	jwtIssuer := jose.NewJWTIssuer(cli, josetesting.Namespace, &jose.Options{
+		IssuerSecretName: josetesting.KeySecretName,
+		RotationPeriod:   josetesting.RefreshPeriod,
+	})
+
+	ctx := t.Context()
+	require.NoError(t, jwtIssuer.Run(ctx, &josetesting.FakeCoordinationClientGetter{}))
+
+	userDatabase := userdb.NewUserDatabase(cli, josetesting.Namespace)
+	rbacInst := rbac.New(cli, josetesting.Namespace, rbacOpts)
+
+	issuerVal := handlercommon.IssuerValue{
+		URL:      "https://test.com",
+		Hostname: "test.com",
+	}
+
+	authenticator := oauth2.New(&oauth2.Options{
+		AccessTokenDuration:      accessTokenDuration,
+		RefreshTokenDuration:     refreshTokenDuration,
+		TokenLeewayDuration:      accessTokenDuration,
+		TokenCacheSize:           1024,
+		CodeCacheSize:            1024,
+		AccountCreationCacheSize: 1024,
+	}, josetesting.Namespace, issuerVal, cli, jwtIssuer, userDatabase, rbacInst)
+
+	time.Sleep(2 * josetesting.RefreshPeriod)
+
+	return &passportTestEnv{
+		authenticator: authenticator,
+		jwtIssuer:     jwtIssuer,
+		client:        cli,
+	}
+}
+
+// testClientCert generates a self-signed certificate with the given Common Name
+// suitable for populating the Ssl-Client-Cert header. The returned PEM is already
+// URL-encoded to match the format produced by the nginx ingress.
+func testClientCert(t *testing.T, commonName string) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	return url.QueryEscape(string(certPEM))
+}
+
+// impersonatedExchangeRequest builds an mTLS+impersonation exchange request.
+// When principalValue is empty, no X-Principal header is set; when raw is true,
+// principalValue is used verbatim rather than base64-encoded.
+type impersonatedRequest struct {
+	commonName     string
+	principal      *principal.Principal
+	principalRaw   string
+	impersonateHdr string // value for X-Impersonate; empty string omits the header
+	omitCert       bool
+	options        *openapi.ExchangeRequestOptions
+}
+
+func buildImpersonatedRequest(t *testing.T, r impersonatedRequest) *http.Request {
+	t.Helper()
+
+	form := url.Values{}
+
+	if r.options != nil {
+		if r.options.OrganizationId != nil {
+			form.Set("organizationId", *r.options.OrganizationId)
+		}
+
+		if r.options.ProjectId != nil {
+			form.Set("projectId", *r.options.ProjectId)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "https://test.com/oauth2/v2/exchange",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	if !r.omitCert {
+		req.Header.Set("Ssl-Client-Cert", testClientCert(t, r.commonName))
+		req.Header.Set("Ssl-Client-Verify", "SUCCESS")
+	}
+
+	switch {
+	case r.principalRaw != "":
+		req.Header.Set(principal.Header, r.principalRaw)
+	case r.principal != nil:
+		data, err := json.Marshal(r.principal)
+		require.NoError(t, err)
+		req.Header.Set(principal.Header, base64.RawURLEncoding.EncodeToString(data))
+	}
+
+	if r.impersonateHdr != "" {
+		req.Header.Set(principal.ImpersonateHeader, r.impersonateHdr)
+	}
+
+	return req
+}
+
+// impersonationServiceCN is the Common Name of the service cert used in these
+// tests. It's registered as a system account in setupPassportImpersonationEnv.
+const impersonationServiceCN = "test-impersonating-service"
+
+// setupPassportImpersonationEnv provisions the minimum RBAC objects needed for
+// the impersonation happy path: a registered system account whose role grants
+// project:read globally, a user in an organization with a group granting
+// project:read + project:write, and the matching project.
+//
+// After intersection with the service's project:read-only global scope, the
+// user's project:write should be stripped.
+func setupPassportImpersonationEnv(t *testing.T) *passportTestEnv {
+	t.Helper()
+
+	const (
+		orgID            = "org1"
+		userSubject      = "alice@example.com"
+		userName         = "user-alice"
+		groupID          = "alice-group"
+		roleUserID       = "role-user"
+		roleServiceID    = "role-impersonating-service"
+		projectAlphaID   = "project-alpha"
+		projectAlphaName = "project-alpha"
+	)
+
+	_ = projectAlphaName // used below by reference
+
+	orgNamespace := josetesting.Namespace + "-org1"
+
+	return setupPassportTestEnvWithRBAC(t,
+		&rbac.Options{
+			SystemAccountRoleIDs: map[string]string{impersonationServiceCN: roleServiceID},
+		},
+		&unikornv1.Organization{
+			ObjectMeta: metav1.ObjectMeta{Namespace: josetesting.Namespace, Name: orgID},
+			Status:     unikornv1.OrganizationStatus{Namespace: orgNamespace},
+		},
+		&unikornv1.User{
+			ObjectMeta: metav1.ObjectMeta{Namespace: josetesting.Namespace, Name: userName},
+			Spec: unikornv1.UserSpec{
+				Subject: userSubject,
+				State:   unikornv1.UserStateActive,
+			},
+		},
+		&unikornv1.OrganizationUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "org1-alice",
+				Labels: map[string]string{
+					constants.UserLabel:         userName,
+					constants.OrganizationLabel: orgID,
+				},
+			},
+			Spec: unikornv1.OrganizationUserSpec{State: unikornv1.UserStateActive},
+		},
+		// User role: project:read AND project:write.
+		&unikornv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Namespace: josetesting.Namespace, Name: roleUserID},
+			Spec: unikornv1.RoleSpec{
+				Scopes: unikornv1.RoleScopes{
+					Project: []unikornv1.RoleScope{
+						{Name: "project", Operations: []unikornv1.Operation{unikornv1.Read, unikornv1.Update}},
+					},
+				},
+			},
+		},
+		// Service role: project:read only globally. After intersection, user's
+		// write permission must be stripped.
+		&unikornv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Namespace: josetesting.Namespace, Name: roleServiceID},
+			Spec: unikornv1.RoleSpec{
+				Scopes: unikornv1.RoleScopes{
+					Global: []unikornv1.RoleScope{
+						{Name: "project", Operations: []unikornv1.Operation{unikornv1.Read}},
+					},
+				},
+			},
+		},
+		&unikornv1.Group{
+			ObjectMeta: metav1.ObjectMeta{Namespace: orgNamespace, Name: groupID},
+			Spec: unikornv1.GroupSpec{
+				Subjects: []unikornv1.GroupSubject{{ID: userSubject}},
+				RoleIDs:  []string{roleUserID},
+			},
+		},
+		&unikornv1.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: orgNamespace,
+				Name:      projectAlphaID,
+				Labels:    map[string]string{constants.OrganizationLabel: orgID},
+			},
+			Spec: unikornv1.ProjectSpec{
+				GroupIDs: []string{groupID},
+			},
+		},
+	)
+}
+
+// TestExchangeImpersonation_HappyPath confirms that a service calling with a
+// client cert + X-Impersonate: true + valid X-Principal receives a passport
+// minted for the impersonated user, not the service.
+func TestExchangeImpersonation_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportImpersonationEnv(t)
+
+	orgID := "org1"
+
+	req := buildImpersonatedRequest(t, impersonatedRequest{
+		commonName: impersonationServiceCN,
+		principal: &principal.Principal{
+			Actor:           "alice@example.com",
+			OrganizationIDs: []string{orgID},
+		},
+		impersonateHdr: "true",
+		options: &openapi.ExchangeRequestOptions{
+			OrganizationId: &orgID,
+		},
+	})
+
+	result, err := env.authenticator.Exchange(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	claims := parsePassport(t, env, result.Passport)
+
+	assert.Equal(t, "passport", claims.Type)
+	assert.Equal(t, "alice@example.com", claims.Subject,
+		"passport subject must be the impersonated user, not the service CN")
+	assert.Equal(t, "alice@example.com", claims.Actor,
+		"passport actor must be the impersonated user, not the service CN")
+	assert.Equal(t, openapi.User, claims.Acctype,
+		"passport acctype must reflect the impersonated user, not the service")
+	assert.Equal(t, orgID, claims.OrgID)
+	assert.ElementsMatch(t, []string{orgID}, claims.OrgIDs)
+	assert.Empty(t, claims.Email, "impersonation has no token-backed email")
+	require.NotNil(t, claims.ACL)
+}
+
+// TestExchangeImpersonation_WithoutImpersonateHeader confirms that an mTLS
+// call without X-Impersonate: true is refused. Services acting autonomously
+// must not receive a passport.
+func TestExchangeImpersonation_WithoutImpersonateHeader(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportImpersonationEnv(t)
+
+	req := buildImpersonatedRequest(t, impersonatedRequest{
+		commonName: impersonationServiceCN,
+		principal: &principal.Principal{
+			Actor:           "alice@example.com",
+			OrganizationIDs: []string{"org1"},
+		},
+		// impersonateHdr deliberately omitted.
+	})
+
+	_, err := env.authenticator.Exchange(t.Context(), req)
+	require.Error(t, err)
+
+	var oauthErr *oauth2errors.Error
+
+	require.ErrorAs(t, err, &oauthErr)
+	assert.Contains(t, err.Error(), "impersonation flag required")
+}
+
+// TestExchangeImpersonation_ImpersonateHeaderFalse confirms that X-Impersonate
+// values other than the literal "true" are rejected. The current extractor
+// accepts only "true"; this locks that in at the exchange endpoint too.
+func TestExchangeImpersonation_ImpersonateHeaderFalse(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportImpersonationEnv(t)
+
+	req := buildImpersonatedRequest(t, impersonatedRequest{
+		commonName: impersonationServiceCN,
+		principal: &principal.Principal{
+			Actor:           "alice@example.com",
+			OrganizationIDs: []string{"org1"},
+		},
+		impersonateHdr: "false",
+	})
+
+	_, err := env.authenticator.Exchange(t.Context(), req)
+	require.Error(t, err)
+
+	var oauthErr *oauth2errors.Error
+
+	require.ErrorAs(t, err, &oauthErr)
+}
+
+// TestExchangeImpersonation_MalformedPrincipalHeader confirms that an
+// undecodable principal header is rejected with access_denied (fail closed).
+func TestExchangeImpersonation_MalformedPrincipalHeader(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportImpersonationEnv(t)
+
+	req := buildImpersonatedRequest(t, impersonatedRequest{
+		commonName:     impersonationServiceCN,
+		principalRaw:   "!!not-base64-or-json!!",
+		impersonateHdr: "true",
+	})
+
+	_, err := env.authenticator.Exchange(t.Context(), req)
+	require.Error(t, err)
+
+	var oauthErr *oauth2errors.Error
+
+	require.ErrorAs(t, err, &oauthErr)
+}
+
+// TestExchangeImpersonation_EmptyActor confirms that an impersonation request
+// with a principal whose Actor is empty is rejected. The ticket explicitly
+// calls out that ambiguous principals must fail closed.
+func TestExchangeImpersonation_EmptyActor(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportImpersonationEnv(t)
+
+	req := buildImpersonatedRequest(t, impersonatedRequest{
+		commonName:     impersonationServiceCN,
+		principal:      &principal.Principal{OrganizationIDs: []string{"org1"}},
+		impersonateHdr: "true",
+	})
+
+	_, err := env.authenticator.Exchange(t.Context(), req)
+	require.Error(t, err)
+
+	var oauthErr *oauth2errors.Error
+
+	require.ErrorAs(t, err, &oauthErr)
+	assert.Contains(t, err.Error(), "principal actor required")
+}
+
+// TestExchangeImpersonation_OrgNotInPrincipalScope confirms that a requested
+// organization scope outside the impersonated user's org list is refused.
+// Impersonation must never broaden the user's reach.
+func TestExchangeImpersonation_OrgNotInPrincipalScope(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportImpersonationEnv(t)
+
+	otherOrg := "some-other-org"
+
+	req := buildImpersonatedRequest(t, impersonatedRequest{
+		commonName: impersonationServiceCN,
+		principal: &principal.Principal{
+			Actor:           "alice@example.com",
+			OrganizationIDs: []string{"org1"},
+		},
+		impersonateHdr: "true",
+		options: &openapi.ExchangeRequestOptions{
+			OrganizationId: &otherOrg,
+		},
+	})
+
+	_, err := env.authenticator.Exchange(t.Context(), req)
+	require.Error(t, err)
+
+	var oauthErr *oauth2errors.Error
+
+	require.ErrorAs(t, err, &oauthErr)
+	assert.Contains(t, err.Error(), "organization not in scope")
+}
+
+// TestExchangeImpersonation_ACLIntersectedAgainstService confirms that the
+// passport's ACL is the intersection of the service's ACL and the user's ACL.
+// The service role here grants only project:Read globally, but the user has
+// project:Read+Update in their org. Only project:Read should survive.
+func TestExchangeImpersonation_ACLIntersectedAgainstService(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportImpersonationEnv(t)
+
+	orgID := "org1"
+
+	req := buildImpersonatedRequest(t, impersonatedRequest{
+		commonName: impersonationServiceCN,
+		principal: &principal.Principal{
+			Actor:           "alice@example.com",
+			OrganizationIDs: []string{orgID},
+		},
+		impersonateHdr: "true",
+		options: &openapi.ExchangeRequestOptions{
+			OrganizationId: &orgID,
+		},
+	})
+
+	result, err := env.authenticator.Exchange(t.Context(), req)
+	require.NoError(t, err)
+
+	claims := parsePassport(t, env, result.Passport)
+	require.NotNil(t, claims.ACL)
+	require.NotNil(t, claims.ACL.Projects)
+
+	// Find the alpha project and verify only Read survived the intersection.
+	var alphaOps []openapi.AclOperation
+
+	for _, p := range *claims.ACL.Projects {
+		if p.Id == "project-alpha" {
+			for _, ep := range p.Endpoints {
+				if ep.Name == "project" {
+					alphaOps = ep.Operations
+				}
+			}
+		}
+	}
+
+	require.NotEmpty(t, alphaOps, "expected project scope for project-alpha in intersected ACL")
+	assert.Contains(t, alphaOps, openapi.Read)
+	assert.NotContains(t, alphaOps, openapi.Update,
+		"project:Update was granted to user but not service — must be stripped")
+}
+
+// TestExchangeImpersonation_NoCertFails confirms that a request with no bearer
+// token and no client cert is refused — there is no credential to authenticate.
+func TestExchangeImpersonation_NoCertFails(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportImpersonationEnv(t)
+
+	req := buildImpersonatedRequest(t, impersonatedRequest{
+		omitCert: true,
+		principal: &principal.Principal{
+			Actor:           "alice@example.com",
+			OrganizationIDs: []string{"org1"},
+		},
+		impersonateHdr: "true",
+	})
+
+	_, err := env.authenticator.Exchange(t.Context(), req)
+	require.Error(t, err)
+
+	var oauthErr *oauth2errors.Error
+
+	require.ErrorAs(t, err, &oauthErr)
+}
+
+// Silence the "unused" linter for imports that are only referenced by
+// constructing handler / jose types inline above.
+var _ = handler.NotFound

--- a/pkg/oauth2/passport_mtls_test.go
+++ b/pkg/oauth2/passport_mtls_test.go
@@ -317,7 +317,6 @@ func TestExchangeImpersonation_HappyPath(t *testing.T) {
 	assert.Equal(t, orgID, claims.OrgID)
 	assert.ElementsMatch(t, []string{orgID}, claims.OrgIDs)
 	assert.Empty(t, claims.Email, "impersonation has no token-backed email")
-	require.NotNil(t, claims.ACL)
 }
 
 // TestExchangeImpersonation_WithoutImpersonateHeader confirms that an mTLS
@@ -444,55 +443,6 @@ func TestExchangeImpersonation_OrgNotInPrincipalScope(t *testing.T) {
 
 	require.ErrorAs(t, err, &oauthErr)
 	assert.Contains(t, err.Error(), "organization not in scope")
-}
-
-// TestExchangeImpersonation_ACLIntersectedAgainstService confirms that the
-// passport's ACL is the intersection of the service's ACL and the user's ACL.
-// The service role here grants only project:Read globally, but the user has
-// project:Read+Update in their org. Only project:Read should survive.
-func TestExchangeImpersonation_ACLIntersectedAgainstService(t *testing.T) {
-	t.Parallel()
-
-	env := setupPassportImpersonationEnv(t)
-
-	orgID := "org1"
-
-	req := buildImpersonatedRequest(t, impersonatedRequest{
-		commonName: impersonationServiceCN,
-		principal: &principal.Principal{
-			Actor:           "alice@example.com",
-			OrganizationIDs: []string{orgID},
-		},
-		impersonateHdr: "true",
-		options: &openapi.ExchangeRequestOptions{
-			OrganizationId: &orgID,
-		},
-	})
-
-	result, err := env.authenticator.Exchange(t.Context(), req)
-	require.NoError(t, err)
-
-	claims := parsePassport(t, env, result.Passport)
-	require.NotNil(t, claims.ACL)
-	require.NotNil(t, claims.ACL.Projects)
-
-	// Find the alpha project and verify only Read survived the intersection.
-	var alphaOps []openapi.AclOperation
-
-	for _, p := range *claims.ACL.Projects {
-		if p.Id == "project-alpha" {
-			for _, ep := range p.Endpoints {
-				if ep.Name == "project" {
-					alphaOps = ep.Operations
-				}
-			}
-		}
-	}
-
-	require.NotEmpty(t, alphaOps, "expected project scope for project-alpha in intersected ACL")
-	assert.Contains(t, alphaOps, openapi.Read)
-	assert.NotContains(t, alphaOps, openapi.Update,
-		"project:Update was granted to user but not service — must be stripped")
 }
 
 // TestExchangeImpersonation_NoCertFails confirms that a request with no bearer

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package oauth2_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -31,6 +32,7 @@ import (
 
 	"github.com/unikorn-cloud/core/pkg/constants"
 	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/identity/pkg/handler"
 	handlercommon "github.com/unikorn-cloud/identity/pkg/handler/common"
 	"github.com/unikorn-cloud/identity/pkg/jose"
 	josetesting "github.com/unikorn-cloud/identity/pkg/jose/testing"
@@ -575,6 +577,39 @@ func TestExchangeInvalidToken(t *testing.T) {
 
 	_, err := env.authenticator.Exchange(t.Context(), req)
 	require.Error(t, err)
+
+	var oauthErr *oauth2errors.Error
+
+	require.ErrorAs(t, err, &oauthErr)
+	assert.Contains(t, err.Error(), "token validation failed")
+}
+
+func TestExchangeHandlerInvalidTokenReturnsUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportTestEnv(t)
+
+	h, err := handler.New(nil, nil, "", env.jwtIssuer, env.authenticator, nil, nil, nil)
+	require.NoError(t, err)
+
+	req := exchangeRequest(t, "invalid-token-value", nil)
+	recorder := httptest.NewRecorder()
+
+	h.PostOauth2V2Exchange(recorder, req)
+
+	resp := recorder.Result()
+
+	t.Cleanup(func() {
+		require.NoError(t, resp.Body.Close())
+	})
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	var oauthResp openapi.Oauth2Error
+
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&oauthResp))
+	assert.Equal(t, openapi.AccessDenied, oauthResp.Error)
+	assert.Contains(t, oauthResp.ErrorDescription, "token validation failed")
 }
 
 func TestExchangeMalformedBody(t *testing.T) {

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -212,6 +212,110 @@ func TestExchangeFederatedUser(t *testing.T) {
 func TestExchangeWithOrgScope(t *testing.T) {
 	t.Parallel()
 
+	orgNamespace := josetesting.Namespace + "-org1"
+
+	env := setupPassportTestEnv(t,
+		&unikornv1.Organization{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "org1",
+			},
+			Status: unikornv1.OrganizationStatus{
+				Namespace: orgNamespace,
+			},
+		},
+		&unikornv1.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "test-user",
+			},
+			Spec: unikornv1.UserSpec{
+				Subject: "user@example.com",
+				State:   unikornv1.UserStateActive,
+			},
+		},
+		&unikornv1.OrganizationUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "org1-user",
+				Labels: map[string]string{
+					constants.UserLabel:         "test-user",
+					constants.OrganizationLabel: "org1",
+				},
+			},
+			Spec: unikornv1.OrganizationUserSpec{
+				State: unikornv1.UserStateActive,
+			},
+		},
+		&unikornv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "test-role",
+			},
+			Spec: unikornv1.RoleSpec{
+				Scopes: unikornv1.RoleScopes{
+					Project: []unikornv1.RoleScope{
+						{Name: "compute", Operations: []unikornv1.Operation{unikornv1.Read}},
+					},
+				},
+			},
+		},
+		&unikornv1.Group{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: orgNamespace,
+				Name:      "test-group",
+			},
+			Spec: unikornv1.GroupSpec{
+				Subjects: []unikornv1.GroupSubject{
+					{ID: "user@example.com"},
+				},
+				RoleIDs: []string{"test-role"},
+			},
+		},
+		&unikornv1.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: orgNamespace,
+				Name:      "project1",
+				Labels: map[string]string{
+					constants.OrganizationLabel: "org1",
+				},
+			},
+			Spec: unikornv1.ProjectSpec{
+				GroupIDs: []string{"test-group"},
+			},
+		},
+	)
+
+	token := issueTestToken(t, env, &oauth2.IssueInfo{
+		Issuer:   "https://test.com",
+		Audience: "test.com",
+		Subject:  "user@example.com",
+		Type:     oauth2.TokenTypeFederated,
+		Federated: &oauth2.FederatedClaims{
+			UserID: "test-user",
+			Scope:  oauth2.NewScope("openid email"),
+		},
+	})
+
+	orgID := "org1"
+	projectID := "project1"
+	req := exchangeRequest(t, token, &openapi.ExchangeRequestOptions{
+		OrganizationId: &orgID,
+		ProjectId:      &projectID,
+	})
+
+	result, err := env.authenticator.Exchange(t.Context(), req)
+	require.NoError(t, err)
+
+	claims := parsePassport(t, env, result.Passport)
+
+	assert.Equal(t, "org1", claims.OrgID)
+	assert.Equal(t, "project1", claims.ProjectID)
+}
+
+func TestExchangeInvalidProjectID(t *testing.T) {
+	t.Parallel()
+
 	env := setupPassportTestEnv(t,
 		&unikornv1.Organization{
 			ObjectMeta: metav1.ObjectMeta{
@@ -259,19 +363,15 @@ func TestExchangeWithOrgScope(t *testing.T) {
 	})
 
 	orgID := "org1"
-	projectID := "project1"
+	bogusProject := "nonexistent-project"
 	req := exchangeRequest(t, token, &openapi.ExchangeRequestOptions{
 		OrganizationId: &orgID,
-		ProjectId:      &projectID,
+		ProjectId:      &bogusProject,
 	})
 
-	result, err := env.authenticator.Exchange(t.Context(), req)
-	require.NoError(t, err)
-
-	claims := parsePassport(t, env, result.Passport)
-
-	assert.Equal(t, "org1", claims.OrgID)
-	assert.Equal(t, "project1", claims.ProjectID)
+	_, err := env.authenticator.Exchange(t.Context(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project not in scope")
 }
 
 func TestExchangeServiceAccount(t *testing.T) {

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/unikorn-cloud/identity/pkg/jose"
 	josetesting "github.com/unikorn-cloud/identity/pkg/jose/testing"
 	"github.com/unikorn-cloud/identity/pkg/oauth2"
+	oauth2errors "github.com/unikorn-cloud/identity/pkg/oauth2/errors"
 	"github.com/unikorn-cloud/identity/pkg/openapi"
 	"github.com/unikorn-cloud/identity/pkg/rbac"
 	"github.com/unikorn-cloud/identity/pkg/userdb"
@@ -374,6 +375,69 @@ func TestExchangeInvalidProjectID(t *testing.T) {
 	assert.Contains(t, err.Error(), "project not in scope")
 }
 
+func TestExchangeInvalidOrganizationID(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportTestEnv(t,
+		&unikornv1.Organization{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "org1",
+			},
+			Status: unikornv1.OrganizationStatus{
+				Namespace: josetesting.Namespace + "-org1",
+			},
+		},
+		&unikornv1.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "test-user",
+			},
+			Spec: unikornv1.UserSpec{
+				Subject: "user@example.com",
+				State:   unikornv1.UserStateActive,
+			},
+		},
+		&unikornv1.OrganizationUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "org1-user",
+				Labels: map[string]string{
+					constants.UserLabel:         "test-user",
+					constants.OrganizationLabel: "org1",
+				},
+			},
+			Spec: unikornv1.OrganizationUserSpec{
+				State: unikornv1.UserStateActive,
+			},
+		},
+	)
+
+	token := issueTestToken(t, env, &oauth2.IssueInfo{
+		Issuer:   "https://test.com",
+		Audience: "test.com",
+		Subject:  "user@example.com",
+		Type:     oauth2.TokenTypeFederated,
+		Federated: &oauth2.FederatedClaims{
+			UserID: "test-user",
+			Scope:  oauth2.NewScope("openid email"),
+		},
+	})
+
+	orgID := "org2"
+	req := exchangeRequest(t, token, &openapi.ExchangeRequestOptions{
+		OrganizationId: &orgID,
+	})
+
+	_, err := env.authenticator.Exchange(t.Context(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "organization not in scope")
+
+	var oauthErr *oauth2errors.Error
+
+	require.ErrorAs(t, err, &oauthErr)
+}
+
 func TestExchangeServiceAccount(t *testing.T) {
 	t.Parallel()
 
@@ -430,6 +494,64 @@ func TestExchangeServiceAccount(t *testing.T) {
 	assert.Equal(t, openapi.Service, claims.Acctype)
 	assert.Equal(t, "test-sa", claims.Subject)
 	assert.ElementsMatch(t, []string{"test-org"}, claims.OrgIDs)
+}
+
+func TestExchangeServiceAccountWrongOrganization(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportTestEnv(t,
+		&unikornv1.Organization{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "test-org",
+			},
+			Status: unikornv1.OrganizationStatus{
+				Namespace: josetesting.Namespace + "-org",
+			},
+		},
+		&unikornv1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace + "-org",
+				Name:      "test-sa",
+			},
+			Spec: unikornv1.ServiceAccountSpec{},
+		},
+	)
+
+	info := &oauth2.IssueInfo{
+		Issuer:   "https://test.com",
+		Audience: "test.com",
+		Subject:  "test-sa",
+		Type:     oauth2.TokenTypeServiceAccount,
+		ServiceAccount: &oauth2.ServiceAccountClaims{
+			OrganizationID: "test-org",
+		},
+	}
+
+	tokens, err := env.authenticator.Issue(t.Context(), info)
+	require.NoError(t, err)
+
+	sa := &unikornv1.ServiceAccount{}
+	require.NoError(t, env.client.Get(t.Context(), client.ObjectKey{
+		Namespace: josetesting.Namespace + "-org",
+		Name:      "test-sa",
+	}, sa))
+
+	sa.Spec.AccessToken = tokens.AccessToken
+	require.NoError(t, env.client.Update(t.Context(), sa))
+
+	wrongOrgID := "other-org"
+	req := exchangeRequest(t, tokens.AccessToken, &openapi.ExchangeRequestOptions{
+		OrganizationId: &wrongOrgID,
+	})
+
+	_, err = env.authenticator.Exchange(t.Context(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "organization not in scope")
+
+	var oauthErr *oauth2errors.Error
+
+	require.ErrorAs(t, err, &oauthErr)
 }
 
 func TestExchangeMissingAuthHeader(t *testing.T) {

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -565,7 +565,12 @@ func TestExchangeMissingAuthHeader(t *testing.T) {
 
 	_, err := env.authenticator.Exchange(t.Context(), req)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "authorization header not set")
+
+	// With no Authorization header and no mTLS cert, the request fails the
+	// mTLS branch: there is no credential to authenticate.
+	var oauthErr *oauth2errors.Error
+
+	require.ErrorAs(t, err, &oauthErr)
 }
 
 func TestExchangeInvalidToken(t *testing.T) {

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -1,0 +1,434 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oauth2_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	gojose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/core/pkg/constants"
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	handlercommon "github.com/unikorn-cloud/identity/pkg/handler/common"
+	"github.com/unikorn-cloud/identity/pkg/jose"
+	josetesting "github.com/unikorn-cloud/identity/pkg/jose/testing"
+	"github.com/unikorn-cloud/identity/pkg/oauth2"
+	"github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
+	"github.com/unikorn-cloud/identity/pkg/userdb"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// passportTestEnv bundles the test dependencies needed to exercise the exchange endpoint.
+type passportTestEnv struct {
+	authenticator *oauth2.Authenticator
+	jwtIssuer     *jose.JWTIssuer
+	client        client.Client
+}
+
+func setupPassportTestEnv(t *testing.T, objects ...client.Object) *passportTestEnv {
+	t.Helper()
+
+	cli := fake.NewClientBuilder().WithScheme(getScheme(t)).WithObjects(objects...).Build()
+
+	josetesting.RotateCertificate(t, cli)
+
+	jwtIssuer := jose.NewJWTIssuer(cli, josetesting.Namespace, &jose.Options{
+		IssuerSecretName: josetesting.KeySecretName,
+		RotationPeriod:   josetesting.RefreshPeriod,
+	})
+
+	ctx := t.Context()
+	require.NoError(t, jwtIssuer.Run(ctx, &josetesting.FakeCoordinationClientGetter{}))
+
+	userDatabase := userdb.NewUserDatabase(cli, josetesting.Namespace)
+	rbacInst := rbac.New(cli, josetesting.Namespace, &rbac.Options{})
+
+	issuerVal := handlercommon.IssuerValue{
+		URL:      "https://test.com",
+		Hostname: "test.com",
+	}
+
+	authenticator := oauth2.New(&oauth2.Options{
+		AccessTokenDuration:      accessTokenDuration,
+		RefreshTokenDuration:     refreshTokenDuration,
+		TokenLeewayDuration:      accessTokenDuration,
+		TokenCacheSize:           1024,
+		CodeCacheSize:            1024,
+		AccountCreationCacheSize: 1024,
+	}, josetesting.Namespace, issuerVal, cli, jwtIssuer, userDatabase, rbacInst)
+
+	time.Sleep(2 * josetesting.RefreshPeriod)
+
+	return &passportTestEnv{
+		authenticator: authenticator,
+		jwtIssuer:     jwtIssuer,
+		client:        cli,
+	}
+}
+
+func issueTestToken(t *testing.T, env *passportTestEnv, info *oauth2.IssueInfo) string {
+	t.Helper()
+
+	tokens, err := env.authenticator.Issue(t.Context(), info)
+	require.NoError(t, err)
+
+	return tokens.AccessToken
+}
+
+func exchangeRequest(t *testing.T, token string, body *openapi.ExchangeRequestOptions) *http.Request {
+	t.Helper()
+
+	form := url.Values{}
+
+	if body != nil {
+		if body.OrganizationId != nil {
+			form.Set("organizationId", *body.OrganizationId)
+		}
+
+		if body.ProjectId != nil {
+			form.Set("projectId", *body.ProjectId)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "https://test.com/oauth2/v2/exchange",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return req
+}
+
+// parsePassport parses and verifies a passport JWT using the test JWKS.
+func parsePassport(t *testing.T, env *passportTestEnv, passportToken string) *oauth2.PassportClaims {
+	t.Helper()
+
+	claims := &oauth2.PassportClaims{}
+	require.NoError(t, env.jwtIssuer.DecodeJWT(t.Context(), passportToken, claims))
+
+	return claims
+}
+
+func TestExchangeFederatedUser(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportTestEnv(t,
+		&unikornv1.Organization{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "org1",
+			},
+			Status: unikornv1.OrganizationStatus{
+				Namespace: josetesting.Namespace + "-org1",
+			},
+		},
+		&unikornv1.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "test-user",
+			},
+			Spec: unikornv1.UserSpec{
+				Subject: "user@example.com",
+				State:   unikornv1.UserStateActive,
+			},
+		},
+		&unikornv1.OrganizationUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "org1-user",
+				Labels: map[string]string{
+					constants.UserLabel:         "test-user",
+					constants.OrganizationLabel: "org1",
+				},
+			},
+			Spec: unikornv1.OrganizationUserSpec{
+				State: unikornv1.UserStateActive,
+			},
+		},
+	)
+
+	token := issueTestToken(t, env, &oauth2.IssueInfo{
+		Issuer:   "https://test.com",
+		Audience: "test.com",
+		Subject:  "user@example.com",
+		Type:     oauth2.TokenTypeFederated,
+		Federated: &oauth2.FederatedClaims{
+			UserID: "test-user",
+			Scope:  oauth2.NewScope("openid email"),
+		},
+	})
+
+	req := exchangeRequest(t, token, nil)
+
+	result, err := env.authenticator.Exchange(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 120, result.ExpiresIn)
+	assert.NotEmpty(t, result.Passport)
+
+	claims := parsePassport(t, env, result.Passport)
+
+	assert.Equal(t, "passport", claims.Type)
+	assert.Equal(t, "uni-identity", claims.Issuer)
+	assert.Equal(t, "user@example.com", claims.Subject)
+	assert.Equal(t, openapi.User, claims.Acctype)
+	assert.Equal(t, "uni", claims.Source)
+	assert.Equal(t, "user@example.com", claims.Email)
+	assert.Equal(t, "user@example.com", claims.Actor)
+	assert.ElementsMatch(t, []string{"org1"}, claims.OrgIDs)
+	assert.NotNil(t, claims.ACL)
+
+	// Verify timing: exp should be iat + 120s.
+	assert.Equal(t, claims.IssuedAt.Time().Add(oauth2.PassportTTL), claims.Expiry.Time())
+}
+
+func TestExchangeWithOrgScope(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportTestEnv(t,
+		&unikornv1.Organization{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "org1",
+			},
+			Status: unikornv1.OrganizationStatus{
+				Namespace: josetesting.Namespace + "-org1",
+			},
+		},
+		&unikornv1.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "test-user",
+			},
+			Spec: unikornv1.UserSpec{
+				Subject: "user@example.com",
+				State:   unikornv1.UserStateActive,
+			},
+		},
+		&unikornv1.OrganizationUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "org1-user",
+				Labels: map[string]string{
+					constants.UserLabel:         "test-user",
+					constants.OrganizationLabel: "org1",
+				},
+			},
+			Spec: unikornv1.OrganizationUserSpec{
+				State: unikornv1.UserStateActive,
+			},
+		},
+	)
+
+	token := issueTestToken(t, env, &oauth2.IssueInfo{
+		Issuer:   "https://test.com",
+		Audience: "test.com",
+		Subject:  "user@example.com",
+		Type:     oauth2.TokenTypeFederated,
+		Federated: &oauth2.FederatedClaims{
+			UserID: "test-user",
+			Scope:  oauth2.NewScope("openid email"),
+		},
+	})
+
+	orgID := "org1"
+	projectID := "project1"
+	req := exchangeRequest(t, token, &openapi.ExchangeRequestOptions{
+		OrganizationId: &orgID,
+		ProjectId:      &projectID,
+	})
+
+	result, err := env.authenticator.Exchange(t.Context(), req)
+	require.NoError(t, err)
+
+	claims := parsePassport(t, env, result.Passport)
+
+	assert.Equal(t, "org1", claims.OrgID)
+	assert.Equal(t, "project1", claims.ProjectID)
+}
+
+func TestExchangeServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportTestEnv(t,
+		&unikornv1.Organization{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "test-org",
+			},
+			Status: unikornv1.OrganizationStatus{
+				Namespace: josetesting.Namespace + "-org",
+			},
+		},
+		&unikornv1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace + "-org",
+				Name:      "test-sa",
+			},
+			Spec: unikornv1.ServiceAccountSpec{},
+		},
+	)
+
+	info := &oauth2.IssueInfo{
+		Issuer:   "https://test.com",
+		Audience: "test.com",
+		Subject:  "test-sa",
+		Type:     oauth2.TokenTypeServiceAccount,
+		ServiceAccount: &oauth2.ServiceAccountClaims{
+			OrganizationID: "test-org",
+		},
+	}
+
+	tokens, err := env.authenticator.Issue(t.Context(), info)
+	require.NoError(t, err)
+
+	// Service accounts need the access token stored on the CRD for verification.
+	sa := &unikornv1.ServiceAccount{}
+	require.NoError(t, env.client.Get(t.Context(), client.ObjectKey{
+		Namespace: josetesting.Namespace + "-org",
+		Name:      "test-sa",
+	}, sa))
+
+	sa.Spec.AccessToken = tokens.AccessToken
+	require.NoError(t, env.client.Update(t.Context(), sa))
+
+	req := exchangeRequest(t, tokens.AccessToken, nil)
+
+	result, err := env.authenticator.Exchange(t.Context(), req)
+	require.NoError(t, err)
+
+	claims := parsePassport(t, env, result.Passport)
+
+	assert.Equal(t, "passport", claims.Type)
+	assert.Equal(t, openapi.Service, claims.Acctype)
+	assert.Equal(t, "test-sa", claims.Subject)
+	assert.ElementsMatch(t, []string{"test-org"}, claims.OrgIDs)
+}
+
+func TestExchangeMissingAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportTestEnv(t)
+
+	req := httptest.NewRequest(http.MethodPost, "https://test.com/oauth2/v2/exchange", nil)
+
+	_, err := env.authenticator.Exchange(t.Context(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authorization header not set")
+}
+
+func TestExchangeInvalidToken(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportTestEnv(t)
+
+	req := exchangeRequest(t, "invalid-token-value", nil)
+
+	_, err := env.authenticator.Exchange(t.Context(), req)
+	require.Error(t, err)
+}
+
+func TestExchangeMalformedBody(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportTestEnv(t,
+		&unikornv1.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "test-user",
+			},
+			Spec: unikornv1.UserSpec{
+				Subject: "user@example.com",
+				State:   unikornv1.UserStateActive,
+			},
+		},
+	)
+
+	token := issueTestToken(t, env, &oauth2.IssueInfo{
+		Issuer:   "https://test.com",
+		Audience: "test.com",
+		Subject:  "user@example.com",
+		Type:     oauth2.TokenTypeFederated,
+		Federated: &oauth2.FederatedClaims{
+			UserID: "test-user",
+			Scope:  oauth2.NewScope("openid email"),
+		},
+	})
+
+	// Invalid percent-encoding triggers a ParseForm error.
+	req := httptest.NewRequest(http.MethodPost, "https://test.com/oauth2/v2/exchange",
+		strings.NewReader("organizationId=%zz"))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	_, err := env.authenticator.Exchange(t.Context(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse form data")
+}
+
+func TestPassportSignatureVerifiesAgainstJWKS(t *testing.T) {
+	t.Parallel()
+
+	env := setupPassportTestEnv(t,
+		&unikornv1.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: josetesting.Namespace,
+				Name:      "test-user",
+			},
+			Spec: unikornv1.UserSpec{
+				Subject: "user@example.com",
+				State:   unikornv1.UserStateActive,
+			},
+		},
+	)
+	// No org needed — federated user with no orgs still gets a valid passport.
+
+	token := issueTestToken(t, env, &oauth2.IssueInfo{
+		Issuer:   "https://test.com",
+		Audience: "test.com",
+		Subject:  "user@example.com",
+		Type:     oauth2.TokenTypeFederated,
+		Federated: &oauth2.FederatedClaims{
+			UserID: "test-user",
+			Scope:  oauth2.NewScope("openid email"),
+		},
+	})
+
+	req := exchangeRequest(t, token, nil)
+
+	result, err := env.authenticator.Exchange(t.Context(), req)
+	require.NoError(t, err)
+
+	// Verify the passport is a valid JWS with ES512.
+	parsed, err := jwt.ParseSigned(result.Passport, []gojose.SignatureAlgorithm{gojose.ES512})
+	require.NoError(t, err)
+	assert.Len(t, parsed.Headers, 1)
+	assert.Equal(t, string(gojose.ES512), parsed.Headers[0].Algorithm)
+}

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -206,7 +206,6 @@ func TestExchangeFederatedUser(t *testing.T) {
 	assert.Equal(t, "user@example.com", claims.Email)
 	assert.Equal(t, "user@example.com", claims.Actor)
 	assert.ElementsMatch(t, []string{"org1"}, claims.OrgIDs)
-	assert.NotNil(t, claims.ACL)
 
 	// Verify timing: exp should be iat + 120s.
 	assert.Equal(t, claims.IssuedAt.Time().Add(oauth2.PassportTTL), claims.Expiry.Time())

--- a/pkg/principal/extract.go
+++ b/pkg/principal/extract.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package principal
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	goerrors "errors"
+	"fmt"
+	"net/http"
+
+	coreclient "github.com/unikorn-cloud/core/pkg/client"
+	"github.com/unikorn-cloud/identity/pkg/util"
+)
+
+var (
+	// ErrHeader signals a missing or malformed principal header.
+	ErrHeader = goerrors.New("header error")
+)
+
+// ExtractFromRequest decodes the X-Principal header into a Principal and stores
+// it in the context. When X-Impersonate: true is also set, the returned context
+// additionally carries the impersonation signal so downstream RBAC resolves
+// against the propagated user rather than the calling service's system account.
+//
+// This helper assumes the caller has already established mTLS trust — it must
+// only be invoked when the request is authenticated via a client certificate,
+// otherwise the headers it parses can be spoofed by an untrusted actor.
+func ExtractFromRequest(ctx context.Context, r *http.Request) (context.Context, error) {
+	header := r.Header.Get(Header)
+	if header == "" {
+		return nil, fmt.Errorf("%w: principal header not present", ErrHeader)
+	}
+
+	data, err := base64.RawURLEncoding.DecodeString(header)
+	if err != nil {
+		// TODO: fallback, delete me... I am VERY slow.
+		// Use the certificate of the service that actually called us.
+		// The one in the context is used to propagate token binding information.
+		certRaw, err := util.GetClientCertificateHeader(r.Header)
+		if err != nil {
+			return nil, err
+		}
+
+		certificate, err := util.GetClientCertificate(certRaw)
+		if err != nil {
+			return nil, err
+		}
+
+		p := &Principal{}
+
+		if err := coreclient.VerifyAndDecode(p, header, certificate); err != nil {
+			return nil, err
+		}
+
+		return NewContext(ctx, p), nil
+	}
+
+	p := &Principal{}
+
+	if err := json.Unmarshal(data, p); err != nil {
+		return nil, err
+	}
+
+	ctx = NewContext(ctx, p)
+
+	if r.Header.Get(ImpersonateHeader) == "true" {
+		ctx = NewImpersonateContext(ctx)
+	}
+
+	return ctx, nil
+}

--- a/pkg/principal/extract_test.go
+++ b/pkg/principal/extract_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package principal_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/identity/pkg/principal"
+)
+
+func encodePrincipal(t *testing.T, p *principal.Principal) string {
+	t.Helper()
+
+	data, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func newRequest(t *testing.T, headers map[string]string) *http.Request {
+	t.Helper()
+
+	r, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://example/v2/exchange", http.NoBody)
+	require.NoError(t, err)
+
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+
+	return r
+}
+
+func TestExtractFromRequest_MissingHeaderReturnsErrHeader(t *testing.T) {
+	t.Parallel()
+
+	r := newRequest(t, nil)
+
+	_, err := principal.ExtractFromRequest(t.Context(), r)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, principal.ErrHeader, "expected ErrHeader, got %v", err)
+}
+
+func TestExtractFromRequest_ValidPrincipalWithoutImpersonate(t *testing.T) {
+	t.Parallel()
+
+	p := &principal.Principal{
+		Actor:           "alice@example.com",
+		OrganizationIDs: []string{"org-a", "org-b"},
+		OrganizationID:  "org-a",
+	}
+
+	r := newRequest(t, map[string]string{
+		principal.Header: encodePrincipal(t, p),
+	})
+
+	ctx, err := principal.ExtractFromRequest(t.Context(), r)
+	require.NoError(t, err)
+
+	got, err := principal.FromContext(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, p.Actor, got.Actor)
+	assert.Equal(t, p.OrganizationIDs, got.OrganizationIDs)
+	assert.Equal(t, p.OrganizationID, got.OrganizationID)
+
+	assert.False(t, principal.ImpersonateFromContext(ctx), "impersonation must not be set without header")
+}
+
+func TestExtractFromRequest_ImpersonateHeaderTrueSetsFlag(t *testing.T) {
+	t.Parallel()
+
+	p := &principal.Principal{Actor: "alice@example.com"}
+
+	r := newRequest(t, map[string]string{
+		principal.Header:            encodePrincipal(t, p),
+		principal.ImpersonateHeader: "true",
+	})
+
+	ctx, err := principal.ExtractFromRequest(t.Context(), r)
+	require.NoError(t, err)
+
+	assert.True(t, principal.ImpersonateFromContext(ctx))
+}
+
+func TestExtractFromRequest_ImpersonateHeaderOtherValuesDoNotSetFlag(t *testing.T) {
+	t.Parallel()
+
+	p := &principal.Principal{Actor: "alice@example.com"}
+
+	cases := []string{"false", "1", "TRUE", "", "yes"}
+
+	for _, value := range cases {
+		t.Run("value="+value, func(t *testing.T) {
+			t.Parallel()
+
+			r := newRequest(t, map[string]string{
+				principal.Header:            encodePrincipal(t, p),
+				principal.ImpersonateHeader: value,
+			})
+
+			ctx, err := principal.ExtractFromRequest(t.Context(), r)
+			require.NoError(t, err)
+
+			assert.False(t, principal.ImpersonateFromContext(ctx),
+				"only literal 'true' should enable impersonation, got %q", value)
+		})
+	}
+}
+
+func TestExtractFromRequest_MalformedJSONInDecodedPrincipalReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Valid base64 but the decoded bytes aren't valid JSON.
+	r := newRequest(t, map[string]string{
+		principal.Header: base64.RawURLEncoding.EncodeToString([]byte("not-json")),
+	})
+
+	_, err := principal.ExtractFromRequest(t.Context(), r)
+
+	require.Error(t, err)
+	// Surface the JSON decode failure — caller treats any error from this
+	// helper as a fail-closed signal.
+	assert.NotErrorIs(t, err, principal.ErrHeader,
+		"JSON decode error must not be reported as missing-header")
+}
+
+func TestExtractFromRequest_InvalidBase64WithoutClientCertFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	// Non-base64 header falls through to the cert-verified fallback path.
+	// Without a client cert header it must fail — critically, it must not
+	// silently succeed or return an empty principal.
+	r := newRequest(t, map[string]string{
+		principal.Header: "!!not-base64!!",
+	})
+
+	_, err := principal.ExtractFromRequest(t.Context(), r)
+
+	require.Error(t, err)
+}

--- a/test/.env.example
+++ b/test/.env.example
@@ -32,3 +32,16 @@ ADMIN_AUTH_TOKEN=
 # Bearer token for the user service account
 # (project-scoped; limited org-level access)
 USER_AUTH_TOKEN=
+
+# mTLS client credentials for the impersonation service account.
+# The certificate CN must match an entry in --system-account-roles-ids so
+# the server maps it to an RBAC role. Used by the passport-exchange
+# integration suite to post to /oauth2/v2/exchange with X-Impersonate: true.
+IDENTITY_IMPERSONATE_CLIENT_CERT_PATH=
+IDENTITY_IMPERSONATE_CLIENT_KEY_PATH=
+
+# Pre-provisioned user impersonated by the mTLS exchange tests. The suite
+# sends X-Principal for this user and expects the minted passport's actor
+# to match.
+TEST_IMPERSONATION_USER_ID=
+TEST_IMPERSONATION_USER_SUBJECT=

--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -414,6 +414,5 @@ func (c *APIClient) ExchangePassport(ctx context.Context, options *identityopena
 func (c *APIClient) ExchangePassportRaw(ctx context.Context, expectedStatus int, options *identityopenapi.ExchangeRequestOptions) (*http.Response, []byte, error) {
 	path := c.exchangePath(options)
 
-	//nolint:bodyclose // DoRequest handles response body closing internally
 	return c.DoRequest(ctx, http.MethodPost, path, nil, expectedStatus)
 }

--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/onsi/ginkgo/v2"
 
@@ -358,4 +359,61 @@ func (c *APIClient) GetQuotas(ctx context.Context, orgID string) (*identityopena
 	}
 
 	return &quotas, nil
+}
+
+// exchangePath builds the exchange endpoint path with optional query parameters.
+// Query parameters are used because the core DoRequest hardcodes Content-Type
+// to application/json for request bodies, but ParseForm reads query params
+// regardless of Content-Type.
+func (c *APIClient) exchangePath(options *identityopenapi.ExchangeRequestOptions) string {
+	path := c.endpoints.Exchange()
+
+	if options == nil {
+		return path
+	}
+
+	params := url.Values{}
+
+	if options.OrganizationId != nil {
+		params.Set("organizationId", *options.OrganizationId)
+	}
+
+	if options.ProjectId != nil {
+		params.Set("projectId", *options.ProjectId)
+	}
+
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	return path
+}
+
+// ExchangePassport exchanges an access token for a passport JWT.
+// The options parameter is optional; pass nil for an unscoped exchange.
+func (c *APIClient) ExchangePassport(ctx context.Context, options *identityopenapi.ExchangeRequestOptions) (*identityopenapi.ExchangeResult, error) {
+	path := c.exchangePath(options)
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	_, respBody, err := c.DoRequest(ctx, http.MethodPost, path, nil, http.StatusOK)
+	if err != nil {
+		return nil, fmt.Errorf("exchanging passport: %w", err)
+	}
+
+	var result identityopenapi.ExchangeResult
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("unmarshaling exchange result: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ExchangePassportRaw performs a raw exchange request returning the HTTP response
+// and body bytes. Use this for testing error scenarios where the response may not
+// be a valid ExchangeResult.
+func (c *APIClient) ExchangePassportRaw(ctx context.Context, expectedStatus int, options *identityopenapi.ExchangeRequestOptions) (*http.Response, []byte, error) {
+	path := c.exchangePath(options)
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	return c.DoRequest(ctx, http.MethodPost, path, nil, expectedStatus)
 }

--- a/test/api/config.go
+++ b/test/api/config.go
@@ -32,6 +32,18 @@ type TestConfig struct {
 	AdminGroupID string
 	UserGroupID  string
 	UserSAID     string
+
+	// Impersonation service account user — a pre-provisioned user in OrgID
+	// whose passport the mTLS client will impersonate during exchange tests.
+	ImpersonationUserID      string
+	ImpersonationUserSubject string
+
+	// mTLS impersonation client — identifies a CI service account (cert CN)
+	// that maps to a role in --system-account-roles-ids. Populated by the
+	// CI fixtures alongside the bearer-token service accounts.
+	ImpersonationCertPath string
+	ImpersonationKeyPath  string
+	CACertPath            string
 }
 
 // LoadTestConfig loads configuration from environment variables and .env files using viper.
@@ -70,13 +82,18 @@ func LoadTestConfig() (*TestConfig, error) {
 			LogRequests:     v.GetBool("LOG_REQUESTS"),
 			LogResponses:    v.GetBool("LOG_RESPONSES"),
 		},
-		AdminToken:   firstNonEmpty(v.GetString("ADMIN_AUTH_TOKEN"), v.GetString("API_AUTH_TOKEN")),
-		UserToken:    v.GetString("USER_AUTH_TOKEN"),
-		OrgID:        v.GetString("TEST_ORG_ID"),
-		ProjectID:    v.GetString("TEST_PROJECT_ID"),
-		AdminGroupID: v.GetString("TEST_ADMIN_GROUP_ID"),
-		UserGroupID:  v.GetString("TEST_USER_GROUP_ID"),
-		UserSAID:     v.GetString("TEST_USER_SA_ID"),
+		AdminToken:               firstNonEmpty(v.GetString("ADMIN_AUTH_TOKEN"), v.GetString("API_AUTH_TOKEN")),
+		UserToken:                v.GetString("USER_AUTH_TOKEN"),
+		OrgID:                    v.GetString("TEST_ORG_ID"),
+		ProjectID:                v.GetString("TEST_PROJECT_ID"),
+		AdminGroupID:             v.GetString("TEST_ADMIN_GROUP_ID"),
+		UserGroupID:              v.GetString("TEST_USER_GROUP_ID"),
+		UserSAID:                 v.GetString("TEST_USER_SA_ID"),
+		ImpersonationUserID:      v.GetString("TEST_IMPERSONATION_USER_ID"),
+		ImpersonationUserSubject: v.GetString("TEST_IMPERSONATION_USER_SUBJECT"),
+		ImpersonationCertPath:    v.GetString("IDENTITY_IMPERSONATE_CLIENT_CERT_PATH"),
+		ImpersonationKeyPath:     v.GetString("IDENTITY_IMPERSONATE_CLIENT_KEY_PATH"),
+		CACertPath:               v.GetString("IDENTITY_CA_CERT"),
 	}
 
 	// Validate required fields

--- a/test/api/endpoints.go
+++ b/test/api/endpoints.go
@@ -99,3 +99,8 @@ func (e *Endpoints) GetQuotas(orgID string) string {
 	return fmt.Sprintf("/api/v1/organizations/%s/quotas",
 		url.PathEscape(orgID))
 }
+
+// Exchange returns the endpoint for passport token exchange.
+func (e *Endpoints) Exchange() string {
+	return "/oauth2/v2/exchange"
+}

--- a/test/api/mtls_client.go
+++ b/test/api/mtls_client.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/principal"
+)
+
+// Static errors for the mTLS client — keeps lint happy and lets callers use
+// errors.Is for branch assertions if they ever need to.
+var (
+	errMTLSMissingBaseURL   = errors.New("mtls client: BaseURL is required")
+	errMTLSMissingKeyPair   = errors.New("mtls client: CertPath and KeyPath are required")
+	errMTLSInvalidCABundle  = errors.New("mtls client: parsing CA bundle")
+	errMTLSUnexpectedStatus = errors.New("mtls client: exchange returned unexpected status")
+)
+
+// MTLSClient performs impersonated passport exchanges against /oauth2/v2/exchange
+// using mutual TLS. The core APIClient is tightly coupled to bearer-token auth
+// and doesn't expose a hook for custom HTTP transports, so this is a small,
+// self-contained client purpose-built for the impersonation flow.
+type MTLSClient struct {
+	baseURL    string
+	httpClient *http.Client
+	endpoints  *Endpoints
+}
+
+// MTLSClientOptions configures a new MTLSClient.
+type MTLSClientOptions struct {
+	BaseURL  string
+	CertPath string
+	KeyPath  string
+	// CACertPath is the CA bundle used to verify the identity server cert.
+	// When empty, the system cert pool is used.
+	CACertPath string
+	Timeout    time.Duration
+}
+
+// NewMTLSClient builds a new client from file paths. It reads the cert, key
+// and CA bundle from disk, constructs a dedicated TLS transport, and returns
+// a client ready to POST /oauth2/v2/exchange.
+func NewMTLSClient(opts MTLSClientOptions) (*MTLSClient, error) {
+	if opts.BaseURL == "" {
+		return nil, errMTLSMissingBaseURL
+	}
+
+	if opts.CertPath == "" || opts.KeyPath == "" {
+		return nil, errMTLSMissingKeyPair
+	}
+
+	cert, err := tls.LoadX509KeyPair(opts.CertPath, opts.KeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("mtls client: loading key pair: %w", err)
+	}
+
+	tlsConfig := &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{cert},
+	}
+
+	if opts.CACertPath != "" {
+		caBytes, err := os.ReadFile(opts.CACertPath)
+		if err != nil {
+			return nil, fmt.Errorf("mtls client: reading CA bundle: %w", err)
+		}
+
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caBytes) {
+			return nil, errMTLSInvalidCABundle
+		}
+
+		tlsConfig.RootCAs = pool
+	}
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+		Timeout:   timeout,
+	}
+
+	return &MTLSClient{
+		baseURL:    opts.BaseURL,
+		httpClient: httpClient,
+		endpoints:  NewEndpoints(),
+	}, nil
+}
+
+// ImpersonatedExchangeOptions controls a single impersonated exchange call.
+// Principal is the identity being impersonated; when nil, no X-Principal header
+// is sent (useful for fail-closed negative tests). Impersonate controls the
+// X-Unikorn-Impersonate header; send "true" to opt into the impersonation path.
+type ImpersonatedExchangeOptions struct {
+	Principal    *principal.Principal
+	Impersonate  bool
+	Organization *string
+	Project      *string
+	// PrincipalHeaderOverride, when non-nil, replaces the base64 principal
+	// header value. Use the empty string to send "X-Principal:" with an empty
+	// value, or a bogus string to exercise malformed-header handling.
+	PrincipalHeaderOverride *string
+	// OmitImpersonateHeader suppresses the header entirely (regardless of
+	// Impersonate). Distinguishes "absent" from "false".
+	OmitImpersonateHeader bool
+	// ImpersonateHeaderValue, when non-empty, sends that literal value
+	// instead of "true"/"false" derived from Impersonate. Supports tests
+	// like ImpersonateHeaderFalse and casing variants.
+	ImpersonateHeaderValue string
+}
+
+// exchangeURL renders the full exchange URL including organization/project
+// query parameters.
+func (c *MTLSClient) exchangeURL(opts ImpersonatedExchangeOptions) string {
+	path := c.endpoints.Exchange()
+
+	params := url.Values{}
+	if opts.Organization != nil {
+		params.Set("organizationId", *opts.Organization)
+	}
+
+	if opts.Project != nil {
+		params.Set("projectId", *opts.Project)
+	}
+
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	return c.baseURL + path
+}
+
+// applyPrincipalHeader sets X-Principal based on the options. PrincipalHeaderOverride
+// takes precedence so tests can send malformed values; otherwise the principal is
+// marshalled and base64url-encoded.
+func applyPrincipalHeader(h http.Header, opts ImpersonatedExchangeOptions) error {
+	if opts.PrincipalHeaderOverride != nil {
+		h.Set(principal.Header, *opts.PrincipalHeaderOverride)
+
+		return nil
+	}
+
+	if opts.Principal == nil {
+		return nil
+	}
+
+	value, err := encodePrincipal(opts.Principal)
+	if err != nil {
+		return err
+	}
+
+	h.Set(principal.Header, value)
+
+	return nil
+}
+
+// impersonateHeaderValue resolves the literal value for X-Impersonate. Returns
+// an empty string when the header should be omitted.
+func impersonateHeaderValue(opts ImpersonatedExchangeOptions) string {
+	if opts.OmitImpersonateHeader {
+		return ""
+	}
+
+	if opts.ImpersonateHeaderValue != "" {
+		return opts.ImpersonateHeaderValue
+	}
+
+	if opts.Impersonate {
+		return "true"
+	}
+
+	return "false"
+}
+
+// ExchangePassportRaw posts to /oauth2/v2/exchange and returns the response plus
+// body bytes so tests can assert on both ExchangeResult and error shapes like
+// oauth2error{error, error_description}.
+func (c *MTLSClient) ExchangePassportRaw(ctx context.Context, opts ImpersonatedExchangeOptions) (*http.Response, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.exchangeURL(opts), http.NoBody)
+	if err != nil {
+		return nil, nil, fmt.Errorf("building request: %w", err)
+	}
+
+	if err := applyPrincipalHeader(req.Header, opts); err != nil {
+		return nil, nil, err
+	}
+
+	if value := impersonateHeaderValue(opts); value != "" {
+		req.Header.Set(principal.ImpersonateHeader, value)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("exchange POST: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp, nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	return resp, body, nil
+}
+
+// ExchangePassport is the happy-path helper that decodes a 200 response into
+// ExchangeResult. Negative tests should use ExchangePassportRaw.
+func (c *MTLSClient) ExchangePassport(ctx context.Context, opts ImpersonatedExchangeOptions) (*identityopenapi.ExchangeResult, error) {
+	//nolint:bodyclose // ExchangePassportRaw closes the body before returning.
+	resp, body, err := c.ExchangePassportRaw(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: %d: %s", errMTLSUnexpectedStatus, resp.StatusCode, string(body))
+	}
+
+	var result identityopenapi.ExchangeResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("unmarshaling exchange result: %w", err)
+	}
+
+	return &result, nil
+}
+
+func encodePrincipal(p *principal.Principal) (string, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return "", fmt.Errorf("marshaling principal: %w", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(data), nil
+}

--- a/test/api/suites/passport_test.go
+++ b/test/api/suites/passport_test.go
@@ -88,11 +88,13 @@ var _ = Describe("Passport Token Exchange", func() {
 				unauthClient := coreclient.NewAPIClient(config.BaseURL, "", config.RequestTimeout, &api.GinkgoLogger{})
 				path := client.GetEndpoints().Exchange()
 
-				_, _, err := unauthClient.DoRequest(ctx, http.MethodPost, path, nil, http.StatusOK)
+				_, respBody, err := unauthClient.DoRequest(ctx, http.MethodPost, path, nil, http.StatusOK)
 
 				Expect(err).To(HaveOccurred())
 				Expect(errors.Is(err, coreclient.ErrUnexpectedStatusCode)).To(BeTrue(),
 					"Should return unexpected status code error for missing auth")
+				Expect(string(respBody)).To(ContainSubstring("access_denied"),
+					"Response body should contain access_denied error")
 
 				GinkgoWriter.Printf("Expected error for missing authentication: %v\n", err)
 			})

--- a/test/api/suites/passport_test.go
+++ b/test/api/suites/passport_test.go
@@ -21,16 +21,43 @@ limitations under the License.
 package suites
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	coreclient "github.com/unikorn-cloud/core/pkg/testing/client"
 	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/oauth2"
+	"github.com/unikorn-cloud/identity/pkg/principal"
 	"github.com/unikorn-cloud/identity/test/api"
 )
+
+// decodePassportClaims parses a passport JWT's payload without verifying the
+// signature. Integration tests only care about the claim shape, and the signing
+// key would require fetching the JWKS.
+func decodePassportClaims(passport string) (*oauth2.PassportClaims, error) {
+	parts := strings.Split(passport, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("passport is not a JWT")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, err
+	}
+
+	claims := &oauth2.PassportClaims{}
+	if err := json.Unmarshal(payload, claims); err != nil {
+		return nil, err
+	}
+
+	return claims, nil
+}
 
 var _ = Describe("Passport Token Exchange", func() {
 	Context("When exchanging an access token for a passport", func() {
@@ -97,6 +124,137 @@ var _ = Describe("Passport Token Exchange", func() {
 					"Response body should contain access_denied error")
 
 				GinkgoWriter.Printf("Expected error for missing authentication: %v\n", err)
+			})
+		})
+	})
+
+	Context("When a service impersonates a user via mTLS", func() {
+		var (
+			mtlsClient *api.MTLSClient
+			actingAs   *principal.Principal
+		)
+
+		BeforeEach(func() {
+			if config.ImpersonationCertPath == "" || config.ImpersonationKeyPath == "" {
+				Skip("impersonation fixtures not configured; run `make integration-fixtures` to provision them")
+			}
+
+			if config.ImpersonationUserSubject == "" {
+				Skip("TEST_IMPERSONATION_USER_SUBJECT not set; run `make integration-fixtures`")
+			}
+
+			var err error
+			mtlsClient, err = api.NewMTLSClient(api.MTLSClientOptions{
+				BaseURL:    config.BaseURL,
+				CertPath:   config.ImpersonationCertPath,
+				KeyPath:    config.ImpersonationKeyPath,
+				CACertPath: config.CACertPath,
+				Timeout:    config.RequestTimeout,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			actingAs = &principal.Principal{
+				Actor:           config.ImpersonationUserSubject,
+				OrganizationIDs: []string{config.OrgID},
+				OrganizationID:  config.OrgID,
+			}
+		})
+
+		Describe("Given a valid principal and X-Impersonate: true", func() {
+			It("should return a passport whose actor matches the impersonated user", func() {
+				result, err := mtlsClient.ExchangePassport(ctx, api.ImpersonatedExchangeOptions{
+					Principal:    actingAs,
+					Impersonate:  true,
+					Organization: &config.OrgID,
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.Passport).NotTo(BeEmpty())
+				Expect(result.ExpiresIn).To(Equal(120))
+
+				claims, err := decodePassportClaims(result.Passport)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(claims.Actor).To(Equal(config.ImpersonationUserSubject),
+					"Passport actor should be the impersonated user, not the calling service")
+				Expect(string(claims.Acctype)).To(Equal("user"),
+					"Passport acctype must mark this as user-sourced, not service/system")
+				Expect(claims.OrgID).To(Equal(config.OrgID))
+
+				GinkgoWriter.Printf("Impersonated passport minted for %s in org %s\n",
+					claims.Actor, claims.OrgID)
+			})
+		})
+
+		Describe("Given a valid principal but the X-Impersonate header is missing", func() {
+			It("should refuse with OAuth2 invalid_request (400)", func() {
+				// Autonomous service-to-service mTLS calls must NOT be issued a
+				// passport: missing the impersonate header is a programming error
+				// that has to surface, not silently upgrade to system creds.
+				resp, body, err := mtlsClient.ExchangePassportRaw(ctx, api.ImpersonatedExchangeOptions{
+					Principal:             actingAs,
+					OmitImpersonateHeader: true,
+					Organization:          &config.OrgID,
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest),
+					"mTLS without X-Impersonate must fail closed")
+				Expect(string(body)).To(ContainSubstring("invalid_request"))
+			})
+		})
+
+		Describe("Given X-Impersonate: false", func() {
+			It("should refuse with OAuth2 invalid_request (400)", func() {
+				resp, body, err := mtlsClient.ExchangePassportRaw(ctx, api.ImpersonatedExchangeOptions{
+					Principal:              actingAs,
+					ImpersonateHeaderValue: "false",
+					Organization:           &config.OrgID,
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+				Expect(string(body)).To(ContainSubstring("invalid_request"))
+			})
+		})
+
+		Describe("Given a malformed X-Principal header", func() {
+			It("should refuse with OAuth2 access_denied (401)", func() {
+				garbage := "!!not-base64!!"
+				resp, body, err := mtlsClient.ExchangePassportRaw(ctx, api.ImpersonatedExchangeOptions{
+					Impersonate:             true,
+					Organization:            &config.OrgID,
+					PrincipalHeaderOverride: &garbage,
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized),
+					"invalid principal header must fail closed with 401")
+				Expect(string(body)).To(ContainSubstring("access_denied"))
+			})
+		})
+
+		Describe("Given a principal scoped to an organization the caller is not a member of", func() {
+			It("should refuse with OAuth2 access_denied (401)", func() {
+				// The principal lists an org the impersonated user doesn't
+				// belong to. The handler must reject this even with a valid
+				// cert + impersonate flag.
+				otherOrg := "org-does-not-exist"
+				otherOrgPrincipal := &principal.Principal{
+					Actor:           config.ImpersonationUserSubject,
+					OrganizationIDs: []string{otherOrg},
+					OrganizationID:  otherOrg,
+				}
+
+				resp, _, err := mtlsClient.ExchangePassportRaw(ctx, api.ImpersonatedExchangeOptions{
+					Principal:    otherOrgPrincipal,
+					Impersonate:  true,
+					Organization: &otherOrg,
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized),
+					"out-of-scope org in principal must be rejected")
 			})
 		})
 	})

--- a/test/api/suites/passport_test.go
+++ b/test/api/suites/passport_test.go
@@ -1,0 +1,101 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:revive,testpackage // dot imports and package naming standard for Ginkgo
+package suites
+
+import (
+	"errors"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	coreclient "github.com/unikorn-cloud/core/pkg/testing/client"
+	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/test/api"
+)
+
+var _ = Describe("Passport Token Exchange", func() {
+	Context("When exchanging an access token for a passport", func() {
+		Describe("Given valid authentication without scope", func() {
+			It("should return a signed passport with correct metadata", func() {
+				result, err := client.ExchangePassport(ctx, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.Passport).NotTo(BeEmpty(), "Passport JWT should not be empty")
+				Expect(result.ExpiresIn).To(Equal(120), "Passport TTL should be 120 seconds")
+
+				GinkgoWriter.Printf("Passport exchanged successfully, expires_in: %d\n", result.ExpiresIn)
+			})
+		})
+
+		Describe("Given valid authentication with organization scope", func() {
+			It("should return a passport scoped to the organization", func() {
+				options := &identityopenapi.ExchangeRequestOptions{
+					OrganizationId: &config.OrgID,
+				}
+
+				result, err := client.ExchangePassport(ctx, options)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.Passport).NotTo(BeEmpty(), "Passport JWT should not be empty")
+				Expect(result.ExpiresIn).To(Equal(120), "Passport TTL should be 120 seconds")
+
+				GinkgoWriter.Printf("Org-scoped passport exchanged for org %s\n", config.OrgID)
+			})
+		})
+
+		Describe("Given valid authentication with organization and project scope", func() {
+			It("should return a passport scoped to the organization and project", func() {
+				options := &identityopenapi.ExchangeRequestOptions{
+					OrganizationId: &config.OrgID,
+					ProjectId:      &config.ProjectID,
+				}
+
+				result, err := client.ExchangePassport(ctx, options)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.Passport).NotTo(BeEmpty(), "Passport JWT should not be empty")
+				Expect(result.ExpiresIn).To(Equal(120), "Passport TTL should be 120 seconds")
+
+				GinkgoWriter.Printf("Org+project-scoped passport exchanged for org %s, project %s\n",
+					config.OrgID, config.ProjectID)
+			})
+		})
+
+		Describe("Given no authentication", func() {
+			It("should reject the exchange request", func() {
+				unauthClient := coreclient.NewAPIClient(config.BaseURL, "", config.RequestTimeout, &api.GinkgoLogger{})
+				path := client.GetEndpoints().Exchange()
+
+				_, _, err := unauthClient.DoRequest(ctx, http.MethodPost, path, nil, http.StatusOK)
+
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrUnexpectedStatusCode)).To(BeTrue(),
+					"Should return unexpected status code error for missing auth")
+
+				GinkgoWriter.Printf("Expected error for missing authentication: %v\n", err)
+			})
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Implements ID-189 (step 4 of 7 in the Phase 2 Passport Token Exchange rollout). Services can now present a client cert plus `X-Impersonate: true` and an `X-Principal` header on `/oauth2/v2/exchange` and receive a passport minted on the impersonated user's behalf.

- Passport `acctype` is `user` with `actor` = impersonated subject so audit surfaces the real principal, not the service.
- Passport ACL is the intersection of the user's and the service's ACLs (confused-deputy prevention), computed via the existing `rbac.GetACL` system-account branch.
- Autonomous mTLS (cert without `X-Impersonate`) is refused with `invalid_request` so service-to-service traffic can't silently upgrade to system creds.
- The `impersonated=true` flag and `serviceIdentity` are emitted on the `passport_issued` log.
- Shared `principal.ExtractFromRequest` helper replaces the duplicate inline parser in the openapi middleware; now covered by its own unit test suite.

## Stack

Depends on #450 (`nscale-peter/id-187-passport`). This PR targets that branch so the full stack merges in order:
- #449 → `petermcarthur/id-186` (openapi spec)
- #450 → `nscale-peter/id-187-passport` (exchange endpoint)
- This PR → mTLS impersonation on top

## Test plan

- [x] `make touch license validate lint` — clean
- [x] `go test ./pkg/oauth2/... ./pkg/principal/... ./pkg/middleware/openapi/...` — passes
- [x] New unit tests in `pkg/oauth2/passport_mtls_test.go` (8 scenarios: happy path, missing/false `X-Impersonate`, malformed principal, empty actor, out-of-scope org, ACL intersection, missing cert)
- [x] New unit tests in `pkg/principal/extract_test.go` (6 scenarios)
- [x] BDD integration specs added to `test/api/suites/passport_test.go` under `When a service impersonates a user via mTLS` (happy path + 4 negative cases)
- [ ] `make test-api` against a KinD cluster after CI provisions the `ci-impersonator` fixture