### PR TITLE
fix(openapi): separate direct and impersonated ACL cache entries

### DIFF
--- a/pkg/middleware/openapi/cachekey_test.go
+++ b/pkg/middleware/openapi/cachekey_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:testpackage // We intentionally exercise the unexported cache-key helper directly.
+package openapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
+	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/principal"
+)
+
+func TestACLCacheKey(t *testing.T) {
+	t.Parallel()
+
+	// directInfo models a direct bearer-token call. The same cache key shape is
+	// also used for attributed service-to-service calls where the principal
+	// header is audit-only and RBAC still resolves against the authenticated
+	// caller.
+	directInfo := &authorization.Info{
+		Userinfo: &identityapi.Userinfo{
+			Sub: "user-1",
+		},
+	}
+
+	serviceInfo := &authorization.Info{
+		Userinfo: &identityapi.Userinfo{
+			Sub: "compute-service",
+		},
+		SystemAccount: true,
+	}
+
+	t.Run("DirectIncludesOrganizationScope", func(t *testing.T) {
+		t.Parallel()
+
+		global, err := aclCacheKey(t.Context(), directInfo, "")
+		require.NoError(t, err)
+
+		scoped, err := aclCacheKey(t.Context(), directInfo, "org-1")
+		require.NoError(t, err)
+
+		require.Equal(t, "direct|user-1|_global", global)
+		require.Equal(t, "direct|user-1|org-1", scoped)
+		require.NotEqual(t, global, scoped)
+	})
+
+	t.Run("AttributedCallUsesDirectKeyShape", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := principal.NewContext(t.Context(), &principal.Principal{
+			Actor: "someone-else",
+		})
+
+		key, err := aclCacheKey(ctx, serviceInfo, "org-1")
+		require.NoError(t, err)
+
+		require.Equal(t, "direct|compute-service|org-1", key)
+	})
+
+	t.Run("ImpersonatedDiffersFromDirect", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := principal.NewContext(t.Context(), &principal.Principal{
+			Actor: "user-1",
+		})
+		ctx = principal.NewImpersonateContext(ctx)
+
+		direct, err := aclCacheKey(t.Context(), serviceInfo, "org-1")
+		require.NoError(t, err)
+
+		impersonated, err := aclCacheKey(ctx, serviceInfo, "org-1")
+		require.NoError(t, err)
+
+		require.Equal(t, "direct|compute-service|org-1", direct)
+		require.Equal(t, "impersonated|compute-service|user-1|org-1", impersonated)
+		require.NotEqual(t, direct, impersonated)
+	})
+
+	t.Run("ImpersonatedIncludesCallingService", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := principal.NewContext(t.Context(), &principal.Principal{
+			Actor: "user-1",
+		})
+		ctx = principal.NewImpersonateContext(ctx)
+
+		otherServiceInfo := &authorization.Info{
+			Userinfo: &identityapi.Userinfo{
+				Sub: "region-service",
+			},
+			SystemAccount: true,
+		}
+
+		computeKey, err := aclCacheKey(ctx, serviceInfo, "org-1")
+		require.NoError(t, err)
+
+		regionKey, err := aclCacheKey(ctx, otherServiceInfo, "org-1")
+		require.NoError(t, err)
+
+		require.NotEqual(t, computeKey, regionKey)
+		require.Equal(t, "impersonated|compute-service|user-1|org-1", computeKey)
+		require.Equal(t, "impersonated|region-service|user-1|org-1", regionKey)
+	})
+
+	t.Run("ImpersonatedIncludesOrganizationScope", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := principal.NewContext(t.Context(), &principal.Principal{
+			Actor: "user-1",
+		})
+		ctx = principal.NewImpersonateContext(ctx)
+
+		global, err := aclCacheKey(ctx, serviceInfo, "")
+		require.NoError(t, err)
+
+		scoped, err := aclCacheKey(ctx, serviceInfo, "org-1")
+		require.NoError(t, err)
+
+		require.Equal(t, "impersonated|compute-service|user-1|_global", global)
+		require.Equal(t, "impersonated|compute-service|user-1|org-1", scoped)
+		require.NotEqual(t, global, scoped)
+	})
+
+	t.Run("SyntheticImpersonationWithoutActorErrors", func(t *testing.T) {
+		t.Parallel()
+
+		// Defensive unit test for the helper itself. The HTTP middleware rejects
+		// this state at the boundary before aclCacheKey is reached.
+		ctx := principal.NewContext(t.Context(), &principal.Principal{})
+		ctx = principal.NewImpersonateContext(ctx)
+
+		_, err := aclCacheKey(ctx, serviceInfo, "org-1")
+
+		require.Error(t, err)
+	})
+}

--- a/pkg/middleware/openapi/openapi.go
+++ b/pkg/middleware/openapi/openapi.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"net/http"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3filter"
@@ -149,25 +148,55 @@ func hasHTTPAuthorization(r *http.Request) bool {
 	return r.Header.Get("Authorization") != ""
 }
 
-// aclCacheKey returns the key to use when caching an ACL. For impersonated calls
-// the key includes the end-user actor and their organization IDs so that each
-// user gets their own cache entry and different org claim sets produce distinct
-// entries. Organization scope must also be part of the key, otherwise unscoped
-// ACLs can be incorrectly reused for /organizations/{id}/acl and other scoped routes.
-func aclCacheKey(ctx context.Context, info *authorization.Info, organizationID string) string {
+// aclCacheKey returns the key to use when caching an ACL.
+//
+// There are three authorization modes that matter here.
+//
+//  1. Direct bearer-token calls from users or service accounts.
+//     RBAC is resolved directly against the authenticated token subject.
+//
+//  2. Attributed service-to-service calls without impersonation.
+//     A principal header may be present for attribution, ownership and audit,
+//     but RBAC is still resolved against the authenticated calling service.
+//
+//  3. Impersonated service-to-service calls.
+//     RBAC is resolved as the intersection of the calling service's ACL and
+//     the propagated actor's ACL in order to prevent confused deputy bugs.
+//
+// All three modes retain the requested organization scope in the cache key.
+// Even though RBAC enforcement uses the non-legacy Organizations field, the
+// scoped /api/v1/organizations/{id}/acl response still depends on
+// organizationID for membership checks and for the legacy Organization field.
+//
+// Mode 3 must be keyed separately from direct or attributed calls because the
+// effective ACL is the intersection of the calling service's ACL and the
+// impersonated actor's ACL. Reusing a direct entry for an impersonated call
+// would over-grant, while reusing an impersonated entry for a direct or
+// attributed call would under-grant.
+//
+// The impersonated cache key therefore includes both:
+// - the authenticated calling service subject.
+// - the impersonated actor.
+func aclCacheKey(ctx context.Context, info *authorization.Info, organizationID string) (string, error) {
 	scope := organizationID
 	if scope == "" {
 		scope = "_global"
 	}
 
 	if principal.ImpersonateFromContext(ctx) {
-		if p, err := principal.FromContext(ctx); err == nil && p.Actor != "" {
-			orgKey := strings.Join(p.OrganizationIDs, ",")
-			return p.Actor + "|" + scope + "|" + orgKey
+		p, err := principal.FromContext(ctx)
+		if err != nil {
+			return "", fmt.Errorf("%w: impersonated principal missing", ErrHeader)
 		}
+
+		if p.Actor == "" {
+			return "", fmt.Errorf("%w: impersonated principal actor missing", ErrHeader)
+		}
+
+		return "impersonated|" + info.Userinfo.Sub + "|" + p.Actor + "|" + scope, nil
 	}
 
-	return info.Userinfo.Sub + "|" + scope
+	return "direct|" + info.Userinfo.Sub + "|" + scope, nil
 }
 
 // validateAuthentication is invoked on an oauth2 endpoint.  It is responsible for extracting
@@ -219,6 +248,26 @@ func (v *Validator) validateAuthentication(ctx context.Context, input *openapi3f
 	return v.authorizer.Authorize(input)
 }
 
+func (v *Validator) getACL(ctx context.Context, info *authorization.Info, organizationID string) (*identityapi.Acl, error) {
+	cacheKey, err := aclCacheKey(ctx, info, organizationID)
+	if err != nil {
+		return nil, errors.OAuth2InvalidRequest("acl cache key generation failure").WithError(err)
+	}
+
+	if acl, ok := v.acls.Get(cacheKey); ok {
+		return acl, nil
+	}
+
+	acl, err := v.authorizer.GetACL(authorization.NewContext(ctx, info), organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	v.acls.Add(cacheKey, acl, v.options.ACLCacheTimeout)
+
+	return acl, nil
+}
+
 func (v *Validator) validateRequest(r *http.Request, route *routers.Route, params map[string]string) (*openapi3filter.ResponseValidationInput, error) {
 	// This authorization callback is fired if the API endpoint is marked as
 	// requiring it.
@@ -246,19 +295,10 @@ func (v *Validator) validateRequest(r *http.Request, route *routers.Route, param
 			return err
 		}
 
-		// This happens every call, so do some caching to improve throughput.
-		cacheKey := aclCacheKey(ctx, info, params["organizationID"])
-
-		acl, ok := v.acls.Get(cacheKey)
-		if !ok {
-			// Get the ACL associated with the actor.
-			acl, err = v.authorizer.GetACL(authorization.NewContext(ctx, info), params["organizationID"])
-			if err != nil {
-				authInfo.err = err
-				return err
-			}
-
-			v.acls.Add(cacheKey, acl, v.options.ACLCacheTimeout)
+		acl, err := v.getACL(ctx, info, params["organizationID"])
+		if err != nil {
+			authInfo.err = err
+			return err
 		}
 
 		authInfo.acl = acl
@@ -369,6 +409,10 @@ func extractPrincipal(ctx context.Context, r *http.Request) (context.Context, er
 	ctx = principal.NewContext(ctx, p)
 
 	if r.Header.Get(principal.ImpersonateHeader) == "true" {
+		if p.Actor == "" {
+			return nil, fmt.Errorf("%w: impersonated principal actor missing", ErrHeader)
+		}
+
 		ctx = principal.NewImpersonateContext(ctx)
 	}
 

--- a/pkg/middleware/openapi/openapi_test.go
+++ b/pkg/middleware/openapi/openapi_test.go
@@ -18,15 +18,22 @@ limitations under the License.
 package openapi_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"io"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-chi/chi/v5"
@@ -93,6 +100,38 @@ func addCertificateHeader(t *testing.T, r *http.Request, verified bool) {
 	}
 }
 
+func addCertificateHeaderForCN(t *testing.T, r *http.Request, verified bool, commonName string) {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: commonName,
+		},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: der,
+	})
+
+	r.Header.Set("Ssl-Client-Cert", url.QueryEscape(string(certPEM)))
+
+	if verified {
+		r.Header.Set("Ssl-Client-Verify", "SUCCESS")
+	}
+}
+
 func addRelayedCertificateHeader(t *testing.T, r *http.Request) {
 	t.Helper()
 
@@ -148,6 +187,17 @@ func addPrincipalHeader(t *testing.T, r *http.Request) {
 	p := &principal.Principal{
 		Actor: userActor,
 	}
+
+	dataJSON, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	r.Header.Set(principal.Header, base64.RawURLEncoding.EncodeToString(dataJSON))
+}
+
+func addPrincipalHeaderWithoutActor(t *testing.T, r *http.Request) {
+	t.Helper()
+
+	p := &principal.Principal{}
 
 	dataJSON, err := json.Marshal(p)
 	require.NoError(t, err)
@@ -249,7 +299,8 @@ func getMux(t *testing.T, authorizer openapi.Authorizer, handler *handler) http.
 	t.Helper()
 
 	options := &openapi.Options{
-		ACLCacheSize: 1,
+		ACLCacheSize:    1,
+		ACLCacheTimeout: time.Minute,
 	}
 
 	routeresolver := routeresolver.New(getSchema(t))
@@ -476,6 +527,160 @@ func TestServiceToServiceAuthenticationSuccess(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Result().StatusCode)
 	h.validate(t, serviceActor)
+}
+
+func TestServiceToServiceImpersonationRequiresActor(t *testing.T) {
+	t.Parallel()
+
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	authorizer := mock.NewMockAuthorizer(c)
+
+	h := &handler{}
+	m := getMux(t, authorizer, h)
+
+	w := httptest.NewRecorder()
+
+	r, err := http.NewRequestWithContext(t.Context(), http.MethodGet, authenticatedURL, nil)
+	require.NoError(t, err)
+
+	addCertificateHeader(t, r, true)
+	addPrincipalHeaderWithoutActor(t, r)
+	r.Header.Set(principal.ImpersonateHeader, "true")
+
+	m.ServeHTTP(w, r)
+
+	validateError(t, w, errors.IsBadRequest)
+}
+
+func TestServiceToServiceDirectAndImpersonatedACLsDoNotShareCacheEntries(t *testing.T) {
+	t.Parallel()
+
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	authorizer := mock.NewMockAuthorizer(c)
+	authorizer.EXPECT().GetACL(gomock.Any(), gomock.Any()).Times(2).Return(&identityapi.Acl{}, nil)
+
+	h := &handler{}
+	m := getMux(t, authorizer, h)
+
+	r1, err := http.NewRequestWithContext(t.Context(), http.MethodGet, authenticatedURL, nil)
+	require.NoError(t, err)
+	addCertificateHeader(t, r1, true)
+	addPrincipalHeader(t, r1)
+
+	w1 := httptest.NewRecorder()
+	m.ServeHTTP(w1, r1)
+	require.Equal(t, http.StatusOK, w1.Result().StatusCode)
+
+	r2, err := http.NewRequestWithContext(t.Context(), http.MethodGet, authenticatedURL, nil)
+	require.NoError(t, err)
+	addCertificateHeader(t, r2, true)
+	addPrincipalHeader(t, r2)
+	r2.Header.Set(principal.ImpersonateHeader, "true")
+
+	w2 := httptest.NewRecorder()
+	m.ServeHTTP(w2, r2)
+	require.Equal(t, http.StatusOK, w2.Result().StatusCode)
+}
+
+func TestServiceToServiceDirectACLsReuseCacheEntries(t *testing.T) {
+	t.Parallel()
+
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	authorizer := mock.NewMockAuthorizer(c)
+	authorizer.EXPECT().GetACL(gomock.Any(), gomock.Any()).Times(1).Return(&identityapi.Acl{}, nil)
+
+	h := &handler{}
+	m := getMux(t, authorizer, h)
+
+	r1, err := http.NewRequestWithContext(t.Context(), http.MethodGet, authenticatedURL, nil)
+	require.NoError(t, err)
+	addCertificateHeader(t, r1, true)
+	addPrincipalHeader(t, r1)
+
+	w1 := httptest.NewRecorder()
+	m.ServeHTTP(w1, r1)
+	require.Equal(t, http.StatusOK, w1.Result().StatusCode)
+
+	r2, err := http.NewRequestWithContext(t.Context(), http.MethodGet, authenticatedURL, nil)
+	require.NoError(t, err)
+	addCertificateHeader(t, r2, true)
+	addPrincipalHeader(t, r2)
+
+	w2 := httptest.NewRecorder()
+	m.ServeHTTP(w2, r2)
+	require.Equal(t, http.StatusOK, w2.Result().StatusCode)
+}
+
+func TestServiceToServiceImpersonatedACLsReuseCacheEntries(t *testing.T) {
+	t.Parallel()
+
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	authorizer := mock.NewMockAuthorizer(c)
+	authorizer.EXPECT().GetACL(gomock.Any(), gomock.Any()).Times(1).Return(&identityapi.Acl{}, nil)
+
+	h := &handler{}
+	m := getMux(t, authorizer, h)
+
+	r1, err := http.NewRequestWithContext(t.Context(), http.MethodGet, authenticatedURL, nil)
+	require.NoError(t, err)
+	addCertificateHeader(t, r1, true)
+	addPrincipalHeader(t, r1)
+	r1.Header.Set(principal.ImpersonateHeader, "true")
+
+	w1 := httptest.NewRecorder()
+	m.ServeHTTP(w1, r1)
+	require.Equal(t, http.StatusOK, w1.Result().StatusCode)
+
+	r2, err := http.NewRequestWithContext(t.Context(), http.MethodGet, authenticatedURL, nil)
+	require.NoError(t, err)
+	addCertificateHeader(t, r2, true)
+	addPrincipalHeader(t, r2)
+	r2.Header.Set(principal.ImpersonateHeader, "true")
+
+	w2 := httptest.NewRecorder()
+	m.ServeHTTP(w2, r2)
+	require.Equal(t, http.StatusOK, w2.Result().StatusCode)
+}
+
+func TestServiceToServiceImpersonatedACLsDoNotShareCacheEntriesAcrossServices(t *testing.T) {
+	t.Parallel()
+
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	authorizer := mock.NewMockAuthorizer(c)
+	authorizer.EXPECT().GetACL(gomock.Any(), gomock.Any()).Times(2).Return(&identityapi.Acl{}, nil)
+
+	h := &handler{}
+	m := getMux(t, authorizer, h)
+
+	r1, err := http.NewRequestWithContext(t.Context(), http.MethodGet, authenticatedURL, nil)
+	require.NoError(t, err)
+	addCertificateHeaderForCN(t, r1, true, "compute-service")
+	addPrincipalHeader(t, r1)
+	r1.Header.Set(principal.ImpersonateHeader, "true")
+
+	w1 := httptest.NewRecorder()
+	m.ServeHTTP(w1, r1)
+	require.Equal(t, http.StatusOK, w1.Result().StatusCode)
+
+	r2, err := http.NewRequestWithContext(t.Context(), http.MethodGet, authenticatedURL, nil)
+	require.NoError(t, err)
+	addCertificateHeaderForCN(t, r2, true, "region-service")
+	addPrincipalHeader(t, r2)
+	r2.Header.Set(principal.ImpersonateHeader, "true")
+
+	w2 := httptest.NewRecorder()
+	m.ServeHTTP(w2, r2)
+	require.Equal(t, http.StatusOK, w2.Result().StatusCode)
 }
 
 type poisonReader struct{}


### PR DESCRIPTION
## Summary
- separate direct/attributed ACL cache entries from impersonated ACL cache entries
- retain organization scope in the cache key for scoped ACL responses
- reject malformed impersonation requests at the middleware boundary and add cache regression coverage

## Problem
The ACL middleware cache key did not fully encode how an ACL had been resolved. Direct bearer-token requests and impersonated service-to-service requests could collide when they referred to the same actor and organization, even though impersonated ACLs are intersections of service and actor permissions rather than the actor's full ACL.

In practice that meant an impersonated ACL could poison the cache for a later direct request and under-authorize it.

## Fix
The cache key now distinguishes authorization mode:
- `direct|<authenticated-subject>|<org-or-_global>` for direct bearer-token and attributed non-impersonated service calls
- `impersonated|<calling-service-subject>|<actor>|<org-or-_global>` for impersonated service calls

The requested organization remains part of the key because scoped `/api/v1/organizations/{id}/acl` responses still depend on org scope.

This also tightens the impersonation model: if `X-Impersonate` is set but the propagated principal has no actor, the middleware now rejects the request with `400` instead of silently degrading to a direct path.

## Tests
Added and updated middleware tests covering:
- direct cache hits
- impersonated cache hits
- direct vs impersonated separation
- different calling services not sharing impersonated cache entries for the same actor
- malformed impersonation being rejected at the boundary

## Verification
- `make touch`
- `make license`
- `make validate`
- `make generate`
- `make lint`
- `GOCACHE=/tmp/gocache go test ./pkg/middleware/openapi ./pkg/rbac`
- `GOCACHE=/tmp/gocache make test-unit`
- local Claude review against `main`
