### PR TITLE
fix(rbac): return 403 when service account requests ACL for non-home org

### DIFF
--- a/pkg/middleware/openapi/local/authorizer.go
+++ b/pkg/middleware/openapi/local/authorizer.go
@@ -20,6 +20,7 @@ package local
 
 import (
 	"context"
+	goerrors "errors"
 	"net/http"
 	"strings"
 
@@ -130,5 +131,17 @@ func (a *Authorizer) Authorize(authentication *openapi3filter.AuthenticationInpu
 // GetACL retrieves access control information from the subject identified
 // by the Authorize call.
 func (a *Authorizer) GetACL(ctx context.Context, organizationID string) (*openapi.Acl, error) {
-	return a.rbac.GetACL(ctx, organizationID)
+	acl, err := a.rbac.GetACL(ctx, organizationID)
+	if err != nil {
+		// A principal asking for an organization scope it does not belong to is a
+		// permission denial. Translate the sentinel into the HTTP 403 contract here
+		// so RBAC stays free of HTTP coupling.
+		if goerrors.Is(err, rbac.ErrNotInOrganization) {
+			return nil, errors.HTTPForbidden("principal is not a member of the requested organization").WithError(err)
+		}
+
+		return nil, err
+	}
+
+	return acl, nil
 }

--- a/pkg/middleware/openapi/local/authorizer_test.go
+++ b/pkg/middleware/openapi/local/authorizer_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/core/pkg/server/errors"
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
+	"github.com/unikorn-cloud/identity/pkg/middleware/openapi/local"
+	"github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestGetACL_ServiceAccount_NonMemberOrganization_Returns403 verifies that the
+// local authorizer translates the rbac sentinel ErrNotInOrganization into an
+// HTTP 403 error when a service account requests an organization-scoped ACL for
+// an organization that is not its home org. This is the boundary contract that
+// closes the bug where the endpoint silently returned 200 with the home-org ACL.
+func TestGetACL_ServiceAccount_NonMemberOrganization_Returns403(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, unikornv1.AddToScheme(scheme))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	authorizer := local.NewAuthorizer(nil, rbac.New(c, "test-namespace", &rbac.Options{}))
+
+	info := &authorization.Info{
+		Userinfo: &openapi.Userinfo{
+			Sub: "service-account-subject",
+			HttpsunikornCloudOrgauthz: &openapi.AuthClaims{
+				Acctype: openapi.Service,
+				OrgIds:  []string{"home-org-id"},
+			},
+		},
+	}
+
+	ctx := authorization.NewContext(t.Context(), info)
+
+	_, err := authorizer.GetACL(ctx, "different-org-id")
+	require.Error(t, err)
+
+	assert.True(t, errors.IsForbidden(err),
+		"local authorizer must report 403 for cross-org service-account ACL requests, got %v", err)
+	assert.ErrorIs(t, err, rbac.ErrNotInOrganization,
+		"wrapped error should preserve the rbac sentinel for diagnostics")
+}

--- a/pkg/rbac/groups_test.go
+++ b/pkg/rbac/groups_test.go
@@ -881,9 +881,9 @@ func TestServiceAccountMultipleOrgIDs(t *testing.T) {
 	assert.ErrorIs(t, err, rbac.ErrWrongOrganizationCount)
 }
 
-// TestServiceAccountWrongOrganization verifies that a service account querying with an
-// org ID it doesn't belong to gracefully falls back to an unscoped ACL without
-// org-scoped permissions.
+// TestServiceAccount_WrongOrganization verifies that a service account querying with an
+// org ID it doesn't belong to is rejected with ErrNotInOrganization. The HTTP layer
+// translates this into a 403 response, matching the behavior of user accounts.
 func TestServiceAccount_WrongOrganization(t *testing.T) {
 	t.Parallel()
 
@@ -901,10 +901,9 @@ func TestServiceAccount_WrongOrganization(t *testing.T) {
 
 	ctx := authorization.NewContext(t.Context(), info)
 
-	acl, err := f.rbac.GetACL(ctx, altOrgID) // <-- asking about **alternative org**
-	require.NoError(t, err)
-	assert.Nil(t, acl.Organization, "org-scoped section should be absent for mismatched org")
-	assert.NotNil(t, acl.Organizations, "unscoped organizations list should still be present")
+	_, err := f.rbac.GetACL(ctx, altOrgID) // <-- asking about **alternative org**
+	require.Error(t, err)
+	assert.ErrorIs(t, err, rbac.ErrNotInOrganization)
 }
 
 // getACLForSystemAccount gets the ACL for a system account (mTLS-authenticated service), optionally

--- a/pkg/rbac/groups_test.go
+++ b/pkg/rbac/groups_test.go
@@ -1063,6 +1063,47 @@ func TestSystemAccountWithServiceAccountPrincipalUsesServiceACL(t *testing.T) {
 	assert.Equal(t, aclDirect, aclImpersonated)
 }
 
+// TestSystemAccount_ImpersonatedServiceAccount_WrongOrganization verifies that a
+// system account impersonating a service-typed principal whose home org does not
+// match the requested scope is rejected with ErrNotInOrganization. This guards
+// the impersonation dispatch path (processImpersonatedPrincipalACL →
+// processServiceAccountACL) against the same cross-org leak that ID-194 closed
+// for direct service-account requests.
+func TestSystemAccount_ImpersonatedServiceAccount_WrongOrganization(t *testing.T) {
+	t.Parallel()
+
+	f, c := setupTestEnvironment(t)
+
+	superServiceRole := &unikornv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      "role-super-service",
+		},
+		Spec: unikornv1.RoleSpec{
+			Scopes: unikornv1.RoleScopes{
+				Global: []unikornv1.RoleScope{
+					{Name: "org:read", Operations: []unikornv1.Operation{unikornv1.Read}},
+				},
+			},
+		},
+	}
+	require.NoError(t, c.Create(t.Context(), superServiceRole))
+
+	f.rbac = rbac.New(c, testNamespace, &rbac.Options{
+		SystemAccountRoleIDs: map[string]string{"compute-service": "role-super-service"},
+	})
+
+	// The impersonated service account claims altOrgID as its home, but
+	// getACLForSystemAccount asks for testOrgID — a cross-org request.
+	_, err := getACLForSystemAccount(t, f.rbac, "compute-service", &principal.Principal{
+		Actor:           f.serviceAccountAltAlphaID,
+		Type:            openapi.Service,
+		OrganizationIDs: []string{altOrgID},
+	}, true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, rbac.ErrNotInOrganization)
+}
+
 func TestSystemAccountWithMissingPrincipalTypeFailsClosed(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -567,27 +567,13 @@ func (r *RBAC) getServiceAccountContext(ctx context.Context, organizationID stri
 
 // processServiceAccountACL looks up a service account, any groups it's a member of,
 // then adds their permissions to the ACL.  As service accounts are bound to a specific
-// organization we must check the scoped organization matches that of the service account.
-//
-//nolint:cyclop
+// organization, getServiceAccountContext returns ErrNotInOrganization when the requested
+// scope is for a different organization; that error is propagated so the HTTP layer
+// returns 403 to the caller.
 func (r *RBAC) processServiceAccountACL(ctx context.Context, subject, organizationID string, authz *openapi.AuthClaims) (*openapi.Acl, error) {
 	subjectOrganizationID, organizationNamespace, err := r.getServiceAccountContext(ctx, organizationID, authz)
 	if err != nil {
-		// TODO: same information leakage concern as processUserAccountACL — see
-		// the TODO there for details. Once downstream consumers are audited we
-		// should return ErrNotInOrganization here instead of falling through.
-		if !goerrors.Is(err, ErrNotInOrganization) {
-			return nil, err
-		}
-
-		// Org mismatch: skip scoped section, fall through to unscoped ACL
-		// using the service account's home org.
-		subjectOrganizationID = authz.OrgIds[0]
-
-		organizationNamespace, err = r.getOrganizationNamespace(ctx, subjectOrganizationID)
-		if err != nil {
-			return nil, fmt.Errorf("%w, failed to get organization namespace %q", err, subjectOrganizationID)
-		}
+		return nil, err
 	}
 
 	groups, err := r.getGroups(ctx, organizationNamespace, groupServiceAccountFilter(subject))
@@ -607,11 +593,8 @@ func (r *RBAC) processServiceAccountACL(ctx context.Context, subject, organizati
 		return nil, err
 	}
 
-	// Scoped ACL handling — only when the requested org matches the service account's org.
-	if organizationID == "" || organizationID == subjectOrganizationID {
-		if err := r.accumulateOrganizationScopedPermissions(ctx, acl, groups, roles, subjectOrganizationID); err != nil {
-			return nil, err
-		}
+	if err := r.accumulateOrganizationScopedPermissions(ctx, acl, groups, roles, subjectOrganizationID); err != nil {
+		return nil, err
 	}
 
 	// Unscoped ACL handling.

--- a/test/api/suites/acl_test.go
+++ b/test/api/suites/acl_test.go
@@ -169,29 +169,17 @@ var _ = Describe("Access Control Discovery", func() {
 			})
 		})
 
-		Describe("Given invalid organization ID", func() {
-			It("should fall back to global ACL content without scoped organization details", func() {
-				acl, err := adminClient.GetOrganizationACL(ctx, "00000000-0000-0000-0000-000000000000")
+		Describe("Given an organization the caller is not a member of", func() {
+			It("should reject the request with 403 Forbidden", func() {
+				path := adminClient.GetEndpoints().GetOrganizationACL("00000000-0000-0000-0000-000000000000")
 
-				Expect(err).NotTo(HaveOccurred())
-				Expect(acl).NotTo(BeNil())
-				Expect(acl.Organization).To(BeNil(),
-					"Organization field should be absent when the requested organization is not in scope")
-				Expect(acl.Organizations).NotTo(BeNil(),
-					"Organizations ACL should still be present for the caller")
-				Expect(*acl.Organizations).NotTo(BeEmpty(),
-					"At least one organization should still be visible in the fallback ACL")
+				_, respBody, err := adminClient.DoRequest(ctx, http.MethodGet, path, nil, http.StatusOK)
 
-				found := false
-				for _, org := range *acl.Organizations {
-					if org.Id == config.OrgID {
-						found = true
-						break
-					}
-				}
-
-				Expect(found).To(BeTrue(),
-					"Fallback ACL should still include the caller's real organization %s", config.OrgID)
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrUnexpectedStatusCode)).To(BeTrue(),
+					"non-member org ACL request should fail with unexpected-status-code error")
+				Expect(string(respBody)).To(ContainSubstring("forbidden"),
+					"response body should identify the failure as forbidden")
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

`/api/v1/organizations/{org_id}/acl` returned **200** with the service account's home-org ACL instead of **403** when called with an unrelated org ID. `processServiceAccountACL` silently caught `ErrNotInOrganization` and fell through to the home org. This change propagates the sentinel error and translates it into HTTP 403 at the local authorizer boundary, keeping `pkg/rbac` free of HTTP coupling. `TestServiceAccount_WrongOrganization` is updated to assert the new contract, and a new boundary test in `pkg/middleware/openapi/local` covers the 403 mapping.

Closes ID-194.

## Test plan

- [x] `go test ./pkg/rbac/... ./pkg/middleware/openapi/local/...` passes locally
- [x] `make lint` passes
- [ ] `spec/existing-token/acl.spec.ts › 3.6 service account gets 403 for non-home org` passes once deployed