### PR TITLE
Add identity project scopes for storage-service

### DIFF
--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -239,6 +239,8 @@ roles:
     protected: true
     scopes:
       global:
+        identity:projects: [read]
+        identity:projects/references: [create,delete]
         identity:allocations: [create,read,update,delete]
         region:networks:v2/references: [create,read,update,delete]
   # An administrator can do anything within an organization.


### PR DESCRIPTION
This PR ensures the required project scopes are available to uni-storage, enabling proper RBAC validation and project reference management.