### PR TITLE
remove storage service account and role

### DIFF
--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -134,7 +134,6 @@ systemAccounts:
   unikorn-region: region-service
   unikorn-kubernetes: kubernetes-service
   unikorn-compute: compute-service
-  uni-storage: storage-service
 
 # A static list of roles.
 # Any unscoped API resources are to be managed by the platform operator
@@ -234,15 +233,6 @@ roles:
         region:securitygroups: [create,read,update,delete]
         region:securitygroups:v2: [read]
         region:sshcertificateauthorities:v2: [read]
-  storage-service:
-    decription: Storage service
-    protected: true
-    scopes:
-      global:
-        identity:projects: [read]
-        identity:projects/references: [create,delete]
-        identity:allocations: [create,read,update,delete]
-        region:networks:v2/references: [create,read,update,delete]
   # An administrator can do anything within an organization.
   administrator:
     description: Organization administrator


### PR DESCRIPTION
This PR moves Nscale-specific roles and service accounts out of the UNI identity chart. uni-storage is not part of public Unikorn, so its identity resources should not be baked into UNI itself. This keeps the UNI chart generic and moves product-specific identity setup to the appropriate downstream configuration.