### PR TITLE
docs: fix cross-repo knowledge graph links

### DIFF
--- a/pkg/client/README.md
+++ b/pkg/client/README.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 This package is the identity-specific realization of the generic client
-machinery in [`core/pkg/client`](../../core/pkg/client/README.md).
+machinery in [`core/pkg/client`](https://github.com/nscaledev/uni-core/blob/main/pkg/client/README.md).
 
 Its main job is to construct outbound identity API clients that obey the same
 internal trust model that identity enforces on inbound requests in
@@ -21,7 +21,7 @@ In practice that means:
 
 This is not a general client abstraction and it is not the main place where
 Kubernetes client construction is documented. The Kubernetes/TLS foundations
-come from [`core/pkg/client`](../../core/pkg/client/README.md). This package
+come from [`core/pkg/client`](https://github.com/nscaledev/uni-core/blob/main/pkg/client/README.md). This package
 turns those foundations into concrete identity API callers.
 
 ## Main Components
@@ -35,7 +35,7 @@ turns those foundations into concrete identity API callers.
 - optional HTTP client certificate configuration
 
 It uses the shared TLS configuration support from
-[`core/pkg/client`](../../core/pkg/client/README.md) to construct an
+[`core/pkg/client`](https://github.com/nscaledev/uni-core/blob/main/pkg/client/README.md) to construct an
 `http.Client` suitable for calling the identity API.
 
 ### APIClient
@@ -70,7 +70,7 @@ delegated identity model as API-originated calls.
 
 It provides idempotent add/remove operations for project dependency references
 over the identity API, keyed from the shared resource-reference model in
-[`core/pkg/manager`](../../core/pkg/manager/README.md).
+[`core/pkg/manager`](https://github.com/nscaledev/uni-core/blob/main/pkg/manager/README.md).
 
 That matters for lifecycle coordination because it gives other services a way to
 block project deletion without requiring prior knowledge of the project
@@ -112,7 +112,7 @@ keying directly on the shared resource reference.
 - `References` and `Allocations` should be safe to retry during convergence and
   teardown flows.
 - The shared resource-reference model from
-  [`core/pkg/manager`](../../core/pkg/manager/README.md) is the correct durable
+  [`core/pkg/manager`](https://github.com/nscaledev/uni-core/blob/main/pkg/manager/README.md) is the correct durable
   identity for cross-service resource dependency tracking.
 
 ## Caveats

--- a/pkg/controllers/README.md
+++ b/pkg/controllers/README.md
@@ -4,7 +4,7 @@
 
 This package contains the controller-factory layer for the identity service.
 It adapts concrete identity resource types into the shared controller framework
-provided by [`core/pkg/manager`](../../core/pkg/manager/README.md).
+provided by [`core/pkg/manager`](https://github.com/nscaledev/uni-core/blob/main/pkg/manager/README.md).
 
 The important point is that these packages do **not** contain the resource
 lifecycle semantics themselves. They are intentionally thin factories that:
@@ -42,7 +42,7 @@ The controllers use generation-changed predicates so normal reconcile is driven
 by desired-state changes in `spec`, rather than by incidental metadata churn.
 
 This keeps the controller role aligned with the manager/provisioner contract in
-[`core/pkg/manager`](../../core/pkg/manager/README.md): desired state is
+[`core/pkg/manager`](https://github.com/nscaledev/uni-core/blob/main/pkg/manager/README.md): desired state is
 expressed on the resource, the provisioner acts on it, and status/finalizer
 management happens within that shared lifecycle model.
 

--- a/pkg/handler/README.md
+++ b/pkg/handler/README.md
@@ -177,9 +177,9 @@ This is a systemic property of the storage model, not just an isolated flaw in o
 
 - [`pkg/middleware`](../middleware/README.md), which establishes the trusted request context that
   handlers consume
-- [`../core/pkg/server`](../../../core/pkg/server/README.md), which documents the generic server
+- [`core/pkg/server`](https://github.com/nscaledev/uni-core/blob/main/pkg/server/README.md), which documents the generic server
   and request-processing foundation beneath identity's service-specific handler layer
-- [`../core/pkg/server/conversion`](../../../core/pkg/server/conversion/README.md), which provides
+- [`core/pkg/server/conversion`](https://github.com/nscaledev/uni-core/blob/main/pkg/server/conversion/README.md), which provides
   shared metadata and API/storage conversion helpers used heavily here
 - [`pkg/apis/unikorn/v1alpha1`](../apis/unikorn/v1alpha1/README.md), which defines the persisted
   resource contract the handlers read and write

--- a/pkg/openapi/README.md
+++ b/pkg/openapi/README.md
@@ -74,7 +74,8 @@ the primary authoring surface:
 - public documentation quality depends directly on the quality of endpoint
   `summary`, `tags`, and `description` fields in the schema
 - shared platform API primitives are imported from
-  [`core/pkg/openapi`](../../core/pkg/openapi), rather than being redefined here
+  [`core/pkg/openapi`](https://github.com/nscaledev/uni-core/blob/main/pkg/openapi/README.md),
+  rather than being redefined here
 
 ## Semantics That Live Elsewhere
 

--- a/pkg/principal/README.md
+++ b/pkg/principal/README.md
@@ -112,5 +112,5 @@ service-to-service scoping, and least-privilege delegated access behaviour.
 
 ## Related Documentation
 
-- [`pkg/rbac`](../../rbac/README.md), which consumes delegated identity and impersonation signals to
+- [`pkg/rbac`](../rbac/README.md), which consumes delegated identity and impersonation signals to
   compute effective authority

--- a/pkg/server/README.md
+++ b/pkg/server/README.md
@@ -126,9 +126,9 @@ convention.
 
 ## Related Documentation
 
-- [`../core/pkg/server`](../../../core/pkg/server/README.md), which defines the shared server
+- [`core/pkg/server`](https://github.com/nscaledev/uni-core/blob/main/pkg/server/README.md), which defines the shared server
   substrate this package builds on
-- [`../core/pkg/server/middleware`](../../../core/pkg/server/middleware/README.md), which defines
+- [`core/pkg/server/middleware`](https://github.com/nscaledev/uni-core/blob/main/pkg/server/middleware/README.md), which defines
   the canonical shared pre-routing middleware pipeline composed here
 - [`pkg/middleware`](../middleware/README.md), which defines the identity-specific trust pipeline
   attached after routing


### PR DESCRIPTION
Replace repo-escaping relative markdown links in the package knowledge graph with explicit GitHub URLs for uni-core, and fix the broken repo-local RBAC link in pkg/principal. This keeps the documentation graph navigable when viewed on GitHub and avoids broken links caused by paths that walk outside the identity repository.
