### PR TITLE
test(api): cover group API with subject userID mutations

### DIFF
--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -435,7 +435,7 @@ func main() {
 	// ── Create user and ServiceAccounts ───────────────────────────────────────
 	const ciFixtureUserSubject = "ci-user@nscale.test"
 
-	createUser(ctx, ac, orgID, ciFixtureUserSubject, []string{userGroupID})
+	userID := createUser(ctx, ac, orgID, ciFixtureUserSubject, []string{userGroupID})
 	adminSAID, adminToken := createServiceAccount(ctx, ac, orgID, "ci-admin-sa", []string{adminGroupID})
 	userSAID, userToken := createServiceAccount(ctx, ac, orgID, "ci-user-sa", []string{userGroupID})
 
@@ -447,6 +447,7 @@ func main() {
 	fmt.Printf("API_AUTH_TOKEN=%s\n", adminToken)
 	fmt.Printf("TEST_ADMIN_GROUP_ID=%s\n", adminGroupID)
 	fmt.Printf("TEST_USER_GROUP_ID=%s\n", userGroupID)
+	fmt.Printf("TEST_USER_ID=%s\n", userID)
 	fmt.Printf("TEST_ADMIN_SA_ID=%s\n", adminSAID)
 	fmt.Printf("TEST_USER_SA_ID=%s\n", userSAID)
 	fmt.Printf("ADMIN_AUTH_TOKEN=%s\n", adminToken)

--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -434,6 +434,7 @@ func main() {
 
 	// ── Create user and ServiceAccounts ───────────────────────────────────────
 	const ciFixtureUserSubject = "ci-user@nscale.test"
+
 	createUser(ctx, ac, orgID, ciFixtureUserSubject, []string{userGroupID})
 	adminSAID, adminToken := createServiceAccount(ctx, ac, orgID, "ci-admin-sa", []string{adminGroupID})
 	userSAID, userToken := createServiceAccount(ctx, ac, orgID, "ci-user-sa", []string{userGroupID})

--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -20,6 +20,7 @@ limitations under the License.
 //   - an Organization
 //   - two Groups: one with the "administrator" role, one with the "user" role
 //   - a Project (members: both groups)
+//   - a User in the user group
 //   - two ServiceAccounts: one per group, each yielding a distinct bearer token
 //
 // The resulting tokens exercise both org-scoped (administrator) and
@@ -276,6 +277,31 @@ func createServiceAccount(ctx context.Context, ac *openapi.ClientWithResponses, 
 	return id, token
 }
 
+// createUser creates an active user in the given groups and returns its organization user ID.
+func createUser(ctx context.Context, ac *openapi.ClientWithResponses, orgID, subject string, groupIDs []string) string {
+	logf("Creating user %q...", subject)
+
+	resp, err := ac.PostApiV1OrganizationsOrganizationIDUsersWithResponse(ctx, orgID, openapi.UserWrite{
+		Spec: openapi.UserSpec{
+			GroupIDs: groupIDs,
+			State:    openapi.Active,
+			Subject:  subject,
+		},
+	})
+	if err != nil {
+		fatalf("failed to create user %q: %v", subject, err)
+	}
+
+	if resp.JSON201 == nil {
+		fatalf("create user %q returned %s", subject, resp.Status())
+	}
+
+	id := resp.JSON201.Metadata.Id
+	logf("  user %q organization user ID: %s", subject, id)
+
+	return id
+}
+
 // waitForOrgNamespace polls until the organization controller has provisioned the backing namespace.
 func waitForOrgNamespace(ctx context.Context, k8s client.Client, namespace, orgID string) {
 	logf("Waiting for Organization %s to be provisioned...", orgID)
@@ -406,7 +432,9 @@ func main() {
 	// Both groups are members so both service accounts can access project endpoints.
 	projectID := createProject(ctx, ac, orgID, "ci-test-project", []string{adminGroupID, userGroupID})
 
-	// ── Create ServiceAccounts ────────────────────────────────────────────────
+	// ── Create user and ServiceAccounts ───────────────────────────────────────
+	const ciFixtureUserSubject = "ci-user@nscale.test"
+	createUser(ctx, ac, orgID, ciFixtureUserSubject, []string{userGroupID})
 	adminSAID, adminToken := createServiceAccount(ctx, ac, orgID, "ci-admin-sa", []string{adminGroupID})
 	userSAID, userToken := createServiceAccount(ctx, ac, orgID, "ci-user-sa", []string{userGroupID})
 

--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -448,6 +448,7 @@ func main() {
 	fmt.Printf("TEST_ADMIN_GROUP_ID=%s\n", adminGroupID)
 	fmt.Printf("TEST_USER_GROUP_ID=%s\n", userGroupID)
 	fmt.Printf("TEST_USER_ID=%s\n", userID)
+	fmt.Printf("TEST_USER_SUBJECT_EMAIL=%s\n", ciFixtureUserSubject)
 	fmt.Printf("TEST_ADMIN_SA_ID=%s\n", adminSAID)
 	fmt.Printf("TEST_USER_SA_ID=%s\n", userSAID)
 	fmt.Printf("ADMIN_AUTH_TOKEN=%s\n", adminToken)

--- a/test/api/config.go
+++ b/test/api/config.go
@@ -25,14 +25,15 @@ import (
 // TestConfig extends the base config with Identity-specific fields.
 type TestConfig struct {
 	coreconfig.BaseConfig
-	AdminToken   string
-	UserToken    string
-	OrgID        string
-	ProjectID    string
-	AdminGroupID string
-	UserGroupID  string
-	UserID       string
-	UserSAID     string
+	AdminToken       string
+	UserToken        string
+	OrgID            string
+	ProjectID        string
+	AdminGroupID     string
+	UserGroupID      string
+	UserID           string
+	UserSubjectEmail string
+	UserSAID         string
 }
 
 // LoadTestConfig loads configuration from environment variables and .env files using viper.
@@ -71,14 +72,15 @@ func LoadTestConfig() (*TestConfig, error) {
 			LogRequests:     v.GetBool("LOG_REQUESTS"),
 			LogResponses:    v.GetBool("LOG_RESPONSES"),
 		},
-		AdminToken:   firstNonEmpty(v.GetString("ADMIN_AUTH_TOKEN"), v.GetString("API_AUTH_TOKEN")),
-		UserToken:    v.GetString("USER_AUTH_TOKEN"),
-		OrgID:        v.GetString("TEST_ORG_ID"),
-		ProjectID:    v.GetString("TEST_PROJECT_ID"),
-		AdminGroupID: v.GetString("TEST_ADMIN_GROUP_ID"),
-		UserGroupID:  v.GetString("TEST_USER_GROUP_ID"),
-		UserID:       v.GetString("TEST_USER_ID"),
-		UserSAID:     v.GetString("TEST_USER_SA_ID"),
+		AdminToken:       firstNonEmpty(v.GetString("ADMIN_AUTH_TOKEN"), v.GetString("API_AUTH_TOKEN")),
+		UserToken:        v.GetString("USER_AUTH_TOKEN"),
+		OrgID:            v.GetString("TEST_ORG_ID"),
+		ProjectID:        v.GetString("TEST_PROJECT_ID"),
+		AdminGroupID:     v.GetString("TEST_ADMIN_GROUP_ID"),
+		UserGroupID:      v.GetString("TEST_USER_GROUP_ID"),
+		UserID:           v.GetString("TEST_USER_ID"),
+		UserSubjectEmail: v.GetString("TEST_USER_SUBJECT_EMAIL"),
+		UserSAID:         v.GetString("TEST_USER_SA_ID"),
 	}
 
 	// Validate required fields

--- a/test/api/config.go
+++ b/test/api/config.go
@@ -31,6 +31,7 @@ type TestConfig struct {
 	ProjectID    string
 	AdminGroupID string
 	UserGroupID  string
+	UserID       string
 	UserSAID     string
 }
 
@@ -76,6 +77,7 @@ func LoadTestConfig() (*TestConfig, error) {
 		ProjectID:    v.GetString("TEST_PROJECT_ID"),
 		AdminGroupID: v.GetString("TEST_ADMIN_GROUP_ID"),
 		UserGroupID:  v.GetString("TEST_USER_GROUP_ID"),
+		UserID:       v.GetString("TEST_USER_ID"),
 		UserSAID:     v.GetString("TEST_USER_SA_ID"),
 	}
 

--- a/test/api/fixtures.go
+++ b/test/api/fixtures.go
@@ -123,6 +123,12 @@ func (b *GroupPayloadBuilder) WithUserIDs(userIDs []string) *GroupPayloadBuilder
 	return b
 }
 
+// WithSubjects sets the subjects for the group.
+func (b *GroupPayloadBuilder) WithSubjects(subjects []identityopenapi.Subject) *GroupPayloadBuilder {
+	b.group.Spec.Subjects = &subjects
+	return b
+}
+
 // Build returns the typed group struct directly.
 func (b *GroupPayloadBuilder) Build() identityopenapi.GroupWrite {
 	return b.group

--- a/test/api/suites/groups_test.go
+++ b/test/api/suites/groups_test.go
@@ -414,6 +414,16 @@ var _ = Describe("Group Subjects", func() {
 				Skip("No users available in organization to test legacy userIDs field")
 			}
 
+			if config.UserID != "" {
+				for _, user := range users {
+					if user.Metadata.Id == config.UserID {
+						return user
+					}
+				}
+
+				Skip(fmt.Sprintf("Configured TEST_USER_ID %q not found in organization users", config.UserID))
+			}
+
 			return users[0]
 		}
 

--- a/test/api/suites/groups_test.go
+++ b/test/api/suites/groups_test.go
@@ -408,23 +408,26 @@ var _ = Describe("Group Management", func() {
 // From nscale-auth0-tests: groups.spec.ts §5 — Subjects membership field.
 var _ = Describe("Group Subjects", func() {
 	Context("When managing group subjects", func() {
-		firstOrganizationUser := func() identityopenapi.UserRead {
-			users, err := client.ListUsers(ctx, config.OrgID)
-			if err != nil || len(users) == 0 {
-				Skip("No users available in organization to test legacy userIDs field")
+		fixtureUserID := func() string {
+			Expect(config.UserID).NotTo(BeEmpty(), "TEST_USER_ID must be set by integration fixtures")
+
+			return config.UserID
+		}
+
+		fixtureUserSubjectEmail := func() string {
+			Expect(config.UserSubjectEmail).NotTo(BeEmpty(), "TEST_USER_SUBJECT_EMAIL must be set by integration fixtures")
+
+			return config.UserSubjectEmail
+		}
+
+		fixtureUserSubject := func() identityopenapi.Subject {
+			subjectEmail := fixtureUserSubjectEmail()
+
+			return identityopenapi.Subject{
+				Email:  &subjectEmail,
+				Id:     subjectEmail,
+				Issuer: config.BaseURL,
 			}
-
-			if config.UserID != "" {
-				for _, user := range users {
-					if user.Metadata.Id == config.UserID {
-						return user
-					}
-				}
-
-				Skip(fmt.Sprintf("Configured TEST_USER_ID %q not found in organization users", config.UserID))
-			}
-
-			return users[0]
 		}
 
 		expectInvalidGroupWrite := func(method, path string, payload identityopenapi.GroupWrite, expectedDescription string) {
@@ -476,12 +479,42 @@ var _ = Describe("Group Subjects", func() {
 			})
 		})
 
+		// §5.1b Create with a valid internal subject — userIDs auto-populated
+		Describe("Given a new group created with a valid internal subject", func() {
+			It("should create successfully with subjects populated and userIDs auto-populated", func() {
+				expectedUserID := fixtureUserID()
+				expectedSubject := fixtureUserSubject()
+
+				payload := api.NewGroupPayload().WithSubjects([]identityopenapi.Subject{expectedSubject}).Build()
+				group, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
+
+				Expect(groupID).NotTo(BeEmpty())
+				Expect(group.Spec.Subjects).NotTo(BeNil(),
+					"subjects field must be populated after create")
+				Expect(*group.Spec.Subjects).To(HaveLen(1))
+				Expect((*group.Spec.Subjects)[0].Id).To(Equal(expectedSubject.Id))
+				Expect((*group.Spec.Subjects)[0].Email).NotTo(BeNil(),
+					"subject email must round-trip after create")
+				Expect(*(*group.Spec.Subjects)[0].Email).To(Equal(*expectedSubject.Email))
+				Expect((*group.Spec.Subjects)[0].Issuer).To(Equal(expectedSubject.Issuer),
+					"subject issuer must round-trip after create")
+				Expect(group.Spec.UserIDs).NotTo(BeNil(),
+					"userIDs field should be present for compatibility")
+				Expect(*group.Spec.UserIDs).To(HaveLen(1),
+					"internal subjects should auto-populate exactly one userID")
+				Expect(*group.Spec.UserIDs).To(ConsistOf(expectedUserID),
+					"internal subjects should auto-populate the fixture userID")
+
+				GinkgoWriter.Printf("Created group with internal subject: %s (ID: %s)\n",
+					group.Metadata.Name, groupID)
+			})
+		})
+
 		// §5.2 Create with userIDs (legacy) — subjects auto-populated
 		Describe("Given a new group created with userIDs (legacy field)", func() {
 			It("should create successfully and subjects should be auto-populated", func() {
-				// userIDs are OrganizationUser object IDs — fetch a real one from the org.
-				user := firstOrganizationUser()
-				realUserID := user.Metadata.Id
+				realUserID := fixtureUserID()
+				expectedSubject := fixtureUserSubject()
 				payload := api.NewGroupPayload().WithUserIDs([]string{realUserID}).Build()
 				group, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
 
@@ -495,14 +528,14 @@ var _ = Describe("Group Subjects", func() {
 					"subjects must be auto-populated when group is created with userIDs")
 				Expect(*group.Spec.Subjects).To(HaveLen(1),
 					"response subjects must contain exactly one resolved subject")
-				Expect((*group.Spec.Subjects)[0].Id).To(Equal(user.Spec.Subject),
+				Expect((*group.Spec.Subjects)[0].Id).To(Equal(expectedSubject.Id),
 					"response subject ID must match the resolved user subject")
 				Expect((*group.Spec.Subjects)[0].Email).NotTo(BeNil(),
 					"response subject email must be populated from the resolved user")
-				Expect(*(*group.Spec.Subjects)[0].Email).To(Equal(user.Spec.Subject),
+				Expect(*(*group.Spec.Subjects)[0].Email).To(Equal(*expectedSubject.Email),
 					"response subject email must match the resolved user subject")
-				Expect((*group.Spec.Subjects)[0].Issuer).NotTo(BeEmpty(),
-					"response subject issuer must be populated for a resolved user")
+				Expect((*group.Spec.Subjects)[0].Issuer).To(Equal(expectedSubject.Issuer),
+					"response subject issuer must match the identity issuer")
 
 				GinkgoWriter.Printf("Created group with userIDs (legacy): %s (ID: %s)\n",
 					group.Metadata.Name, groupID)
@@ -537,7 +570,7 @@ var _ = Describe("Group Subjects", func() {
 				ciInvalidUserEmail := fmt.Sprintf("ci-invalid-user-create-%d@nscale.test", time.Now().UnixNano())
 				email := ciInvalidUserEmail
 				testSubject := identityopenapi.Subject{Id: ciInvalidUserEmail, Email: &email, Issuer: ""}
-				userID := firstOrganizationUser().Metadata.Id
+				userID := fixtureUserID()
 
 				payload := api.NewGroupPayload().
 					WithSubjects([]identityopenapi.Subject{testSubject}).
@@ -674,7 +707,7 @@ var _ = Describe("Group Subjects", func() {
 				ciInvalidUserEmail := fmt.Sprintf("ci-invalid-user-update-%d@nscale.test", time.Now().UnixNano())
 				email := ciInvalidUserEmail
 				testSubject := identityopenapi.Subject{Id: ciInvalidUserEmail, Email: &email, Issuer: ""}
-				userID := firstOrganizationUser().Metadata.Id
+				userID := fixtureUserID()
 
 				updatePayload := api.NewGroupPayload().
 					WithSubjects([]identityopenapi.Subject{testSubject}).

--- a/test/api/suites/groups_test.go
+++ b/test/api/suites/groups_test.go
@@ -21,8 +21,11 @@ limitations under the License.
 package suites
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -97,6 +100,7 @@ var _ = Describe("Group Management", func() {
 						found = true
 						Expect(group.Metadata.Name).To(Equal(createdGroup.Metadata.Name))
 						GinkgoWriter.Printf("Found created group in list: %s\n", groupID)
+
 						break
 					}
 				}
@@ -396,6 +400,258 @@ var _ = Describe("Group Management", func() {
 				err := client.DeleteGroup(ctx, "invalid-org-id", "00000000-0000-0000-0000-000000000000")
 
 				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+})
+
+// From nscale-auth0-tests: groups.spec.ts §5 — Subjects membership field.
+var _ = Describe("Group Subjects", func() {
+	Context("When managing group subjects", func() {
+		// §5.1 Create with external subjects field
+		Describe("Given a new group created with external subjects", func() {
+			It("should create successfully with subjects populated and userIDs empty", func() {
+				testEmail := fmt.Sprintf("qa-subject-%d@example.com", time.Now().UnixNano())
+				email := testEmail
+				testSubject := identityopenapi.Subject{Id: testEmail, Email: &email, Issuer: ""}
+
+				payload := api.NewGroupPayload().WithSubjects([]identityopenapi.Subject{testSubject}).Build()
+				group, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
+
+				Expect(groupID).NotTo(BeEmpty())
+				Expect(group.Spec.Subjects).NotTo(BeNil(),
+					"subjects field must be populated after create")
+				Expect(*group.Spec.Subjects).To(HaveLen(1))
+				Expect((*group.Spec.Subjects)[0].Id).To(Equal(testEmail))
+				Expect((*group.Spec.Subjects)[0].Email).NotTo(BeNil(),
+					"subject email must round-trip after create")
+				Expect(*(*group.Spec.Subjects)[0].Email).To(Equal(testEmail))
+				Expect((*group.Spec.Subjects)[0].Issuer).To(BeEmpty(),
+					"external subject issuer should remain empty")
+				Expect(group.Spec.UserIDs).NotTo(BeNil(),
+					"userIDs field should be present for compatibility")
+				Expect(*group.Spec.UserIDs).To(BeEmpty(),
+					"external subjects should not auto-populate userIDs")
+
+				GinkgoWriter.Printf("Created group with subjects: %s (ID: %s)\n",
+					group.Metadata.Name, groupID)
+			})
+		})
+
+		// §5.2 Create with userIDs (legacy) — subjects auto-populated
+		Describe("Given a new group created with userIDs (legacy field)", func() {
+			It("should create successfully and subjects should be auto-populated", func() {
+				// userIDs are OrganizationUser object IDs — fetch a real one from the org.
+				users, err := client.ListUsers(ctx, config.OrgID)
+				if err != nil || len(users) == 0 {
+					Skip("No users available in organization to test legacy userIDs field")
+				}
+
+				realUserID := users[0].Metadata.Id
+
+				payload := api.NewGroupPayload().WithUserIDs([]string{realUserID}).Build()
+				group, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
+
+				Expect(groupID).NotTo(BeEmpty())
+				Expect(group.Spec.UserIDs).NotTo(BeNil(),
+					"userIDs must be present after create with legacy field")
+				Expect(*group.Spec.UserIDs).To(ConsistOf(realUserID),
+					"response userIDs must contain exactly the requested userID")
+				// subjects should be auto-populated from the resolved userID
+				Expect(group.Spec.Subjects).NotTo(BeNil(),
+					"subjects must be auto-populated when group is created with userIDs")
+				Expect(*group.Spec.Subjects).To(HaveLen(1),
+					"response subjects must contain exactly one resolved subject")
+				Expect((*group.Spec.Subjects)[0].Id).To(Equal(users[0].Spec.Subject),
+					"response subject ID must match the resolved user subject")
+				Expect((*group.Spec.Subjects)[0].Email).NotTo(BeNil(),
+					"response subject email must be populated from the resolved user")
+				Expect(*(*group.Spec.Subjects)[0].Email).To(Equal(users[0].Spec.Subject),
+					"response subject email must match the resolved user subject")
+				Expect((*group.Spec.Subjects)[0].Issuer).NotTo(BeEmpty(),
+					"response subject issuer must be populated for a resolved user")
+
+				GinkgoWriter.Printf("Created group with userIDs (legacy): %s (ID: %s)\n",
+					group.Metadata.Name, groupID)
+			})
+		})
+
+		// §5.2b Create with non-existent userID -> 400
+		Describe("Given a new group created with a non-existent userID", func() {
+			It("should return invalid request", func() {
+				payload := api.NewGroupPayload().
+					WithUserIDs([]string{"00000000-0000-0000-0000-000000000000"}).
+					Build()
+
+				body, err := json.Marshal(payload)
+				Expect(err).NotTo(HaveOccurred())
+
+				_, _, err = client.DoRequest(
+					ctx,
+					http.MethodPost,
+					api.NewEndpoints().ListGroups(config.OrgID),
+					bytes.NewReader(body),
+					http.StatusBadRequest,
+				)
+				Expect(err).NotTo(HaveOccurred(),
+					"creating a group with a non-existent userID should return 400")
+			})
+		})
+
+		// §5.3 Create with both subjects AND userIDs → rejected
+		Describe("Given a new group with both subjects and userIDs set", func() {
+			It("should be rejected with an error", func() {
+				testEmail := fmt.Sprintf("qa-both-%d@example.com", time.Now().UnixNano())
+				email := testEmail
+				testSubject := identityopenapi.Subject{Id: testEmail, Email: &email, Issuer: ""}
+				fakeUserID := fmt.Sprintf("fake-user-%d", time.Now().UnixNano())
+
+				payload := api.NewGroupPayload().
+					WithSubjects([]identityopenapi.Subject{testSubject}).
+					WithUserIDs([]string{fakeUserID}).
+					Build()
+
+				_, err := client.CreateGroup(ctx, config.OrgID, payload)
+
+				Expect(err).To(HaveOccurred(),
+					"creating a group with both subjects and userIDs must be rejected")
+
+				GinkgoWriter.Printf("Correctly rejected group with both subjects and userIDs: %v\n", err)
+			})
+		})
+
+		// §5.4 GET returns subject contents and userIDs compatibility field
+		Describe("Given an existing group with subjects", func() {
+			It("should return subject contents and empty userIDs on GET", func() {
+				testEmail := fmt.Sprintf("qa-get-%d@example.com", time.Now().UnixNano())
+				email := testEmail
+				testSubject := identityopenapi.Subject{Id: testEmail, Email: &email, Issuer: ""}
+
+				payload := api.NewGroupPayload().WithSubjects([]identityopenapi.Subject{testSubject}).Build()
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
+
+				retrieved, err := client.GetGroup(ctx, config.OrgID, groupID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(retrieved).NotTo(BeNil())
+				Expect(retrieved.Spec.Subjects).NotTo(BeNil(),
+					"GET response must include subjects field")
+				Expect(*retrieved.Spec.Subjects).To(HaveLen(1))
+				Expect((*retrieved.Spec.Subjects)[0].Id).To(Equal(testEmail))
+				Expect((*retrieved.Spec.Subjects)[0].Email).NotTo(BeNil(),
+					"GET response subject email must be populated")
+				Expect(*(*retrieved.Spec.Subjects)[0].Email).To(Equal(testEmail))
+				Expect((*retrieved.Spec.Subjects)[0].Issuer).To(BeEmpty(),
+					"GET response external subject issuer should remain empty")
+				Expect(retrieved.Spec.UserIDs).NotTo(BeNil(),
+					"GET response must include userIDs compatibility field")
+				Expect(*retrieved.Spec.UserIDs).To(BeEmpty(),
+					"external subjects should not auto-populate userIDs")
+
+				GinkgoWriter.Printf("GET returned subjects field for group: %s\n", groupID)
+			})
+		})
+
+		// §5.5 Add a subject via PUT → subject appears in membership
+		Describe("Given an existing group, adding a subject via PUT", func() {
+			It("should reflect the new subject in the GET response", func() {
+				firstEmail := fmt.Sprintf("qa-add1-%d@example.com", time.Now().UnixNano())
+				firstEmailCopy := firstEmail
+				firstSubject := identityopenapi.Subject{Id: firstEmail, Email: &firstEmailCopy, Issuer: ""}
+
+				payload := api.NewGroupPayload().WithSubjects([]identityopenapi.Subject{firstSubject}).Build()
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
+
+				secondEmail := fmt.Sprintf("qa-add2-%d@example.com", time.Now().UnixNano())
+				secondEmailCopy := secondEmail
+				secondSubject := identityopenapi.Subject{Id: secondEmail, Email: &secondEmailCopy, Issuer: ""}
+
+				updatePayload := api.NewGroupPayload().
+					WithSubjects([]identityopenapi.Subject{firstSubject, secondSubject}).
+					Build()
+
+				err := client.UpdateGroup(ctx, config.OrgID, groupID, updatePayload)
+				Expect(err).NotTo(HaveOccurred())
+
+				// §5.5 — verify via GET that the new subject is in the membership
+				retrieved, err := client.GetGroup(ctx, config.OrgID, groupID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(retrieved.Spec.Subjects).NotTo(BeNil())
+
+				var subjectIDs []string
+				for _, s := range *retrieved.Spec.Subjects {
+					subjectIDs = append(subjectIDs, s.Id)
+				}
+
+				Expect(subjectIDs).To(ConsistOf(firstEmail, secondEmail),
+					"group membership must contain exactly both subjects after PUT")
+
+				GinkgoWriter.Printf("Added subject %s to group %s\n", secondEmail, groupID)
+			})
+		})
+
+		// §5.6 Remove a subject via PUT → subject no longer in membership
+		Describe("Given an existing group with two subjects, removing one via PUT", func() {
+			It("should no longer return the removed subject in the GET response", func() {
+				firstEmail := fmt.Sprintf("qa-rem1-%d@example.com", time.Now().UnixNano())
+				firstEmailCopy := firstEmail
+				firstSubject := identityopenapi.Subject{Id: firstEmail, Email: &firstEmailCopy, Issuer: ""}
+
+				secondEmail := fmt.Sprintf("qa-rem2-%d@example.com", time.Now().UnixNano())
+				secondEmailCopy := secondEmail
+				secondSubject := identityopenapi.Subject{Id: secondEmail, Email: &secondEmailCopy, Issuer: ""}
+
+				payload := api.NewGroupPayload().
+					WithSubjects([]identityopenapi.Subject{firstSubject, secondSubject}).
+					Build()
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
+
+				// Remove secondSubject by PUTting only firstSubject
+				updatePayload := api.NewGroupPayload().
+					WithSubjects([]identityopenapi.Subject{firstSubject}).
+					Build()
+
+				err := client.UpdateGroup(ctx, config.OrgID, groupID, updatePayload)
+				Expect(err).NotTo(HaveOccurred())
+
+				retrieved, err := client.GetGroup(ctx, config.OrgID, groupID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(retrieved.Spec.Subjects).NotTo(BeNil())
+
+				var subjectIDs []string
+				for _, s := range *retrieved.Spec.Subjects {
+					subjectIDs = append(subjectIDs, s.Id)
+				}
+
+				Expect(subjectIDs).To(ConsistOf(firstEmail),
+					"group membership must contain exactly the retained subject after PUT")
+
+				GinkgoWriter.Printf("Removed subject %s from group %s\n", secondEmail, groupID)
+			})
+		})
+
+		// §5.7 PUT with both subjects and userIDs → rejected
+		Describe("Given a PUT with both subjects and userIDs set", func() {
+			It("should be rejected with an error", func() {
+				payload := api.NewGroupPayload().Build()
+				_, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
+
+				testEmail := fmt.Sprintf("qa-both-put-%d@example.com", time.Now().UnixNano())
+				email := testEmail
+				testSubject := identityopenapi.Subject{Id: testEmail, Email: &email, Issuer: ""}
+				fakeUserID := fmt.Sprintf("fake-user-put-%d", time.Now().UnixNano())
+
+				updatePayload := api.NewGroupPayload().
+					WithSubjects([]identityopenapi.Subject{testSubject}).
+					WithUserIDs([]string{fakeUserID}).
+					Build()
+
+				err := client.UpdateGroup(ctx, config.OrgID, groupID, updatePayload)
+
+				Expect(err).To(HaveOccurred(),
+					"updating a group with both subjects and userIDs must be rejected")
+
+				GinkgoWriter.Printf("Correctly rejected PUT with both subjects and userIDs: %v\n", err)
 			})
 		})
 	})

--- a/test/api/suites/groups_test.go
+++ b/test/api/suites/groups_test.go
@@ -405,7 +405,6 @@ var _ = Describe("Group Management", func() {
 	})
 })
 
-// From nscale-auth0-tests: groups.spec.ts §5 — Subjects membership field.
 var _ = Describe("Group Subjects", func() {
 	Context("When managing group subjects", func() {
 		fixtureUserID := func() string {
@@ -420,14 +419,16 @@ var _ = Describe("Group Subjects", func() {
 			return config.UserSubjectEmail
 		}
 
-		fixtureUserSubject := func() identityopenapi.Subject {
-			subjectEmail := fixtureUserSubjectEmail()
-
+		internalSubject := func(subjectEmail string) identityopenapi.Subject {
 			return identityopenapi.Subject{
 				Email:  &subjectEmail,
 				Id:     subjectEmail,
 				Issuer: config.BaseURL,
 			}
+		}
+
+		fixtureUserSubject := func() identityopenapi.Subject {
+			return internalSubject(fixtureUserSubjectEmail())
 		}
 
 		expectInvalidGroupWrite := func(method, path string, payload identityopenapi.GroupWrite, expectedDescription string) {
@@ -449,37 +450,6 @@ var _ = Describe("Group Subjects", func() {
 			Expect(oauthErr.ErrorDescription).To(ContainSubstring(expectedDescription))
 		}
 
-		// §5.1 Create with external subjects field
-		Describe("Given a new group created with external subjects", func() {
-			It("should create successfully with subjects populated and userIDs empty", func() {
-				testEmail := fmt.Sprintf("qa-subject-%d@example.com", time.Now().UnixNano())
-				email := testEmail
-				testSubject := identityopenapi.Subject{Id: testEmail, Email: &email, Issuer: ""}
-
-				payload := api.NewGroupPayload().WithSubjects([]identityopenapi.Subject{testSubject}).Build()
-				group, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
-
-				Expect(groupID).NotTo(BeEmpty())
-				Expect(group.Spec.Subjects).NotTo(BeNil(),
-					"subjects field must be populated after create")
-				Expect(*group.Spec.Subjects).To(HaveLen(1))
-				Expect((*group.Spec.Subjects)[0].Id).To(Equal(testEmail))
-				Expect((*group.Spec.Subjects)[0].Email).NotTo(BeNil(),
-					"subject email must round-trip after create")
-				Expect(*(*group.Spec.Subjects)[0].Email).To(Equal(testEmail))
-				Expect((*group.Spec.Subjects)[0].Issuer).To(BeEmpty(),
-					"external subject issuer should remain empty")
-				Expect(group.Spec.UserIDs).NotTo(BeNil(),
-					"userIDs field should be present for compatibility")
-				Expect(*group.Spec.UserIDs).To(BeEmpty(),
-					"external subjects should not auto-populate userIDs")
-
-				GinkgoWriter.Printf("Created group with subjects: %s (ID: %s)\n",
-					group.Metadata.Name, groupID)
-			})
-		})
-
-		// §5.1b Create with a valid internal subject — userIDs auto-populated
 		Describe("Given a new group created with a valid internal subject", func() {
 			It("should create successfully with subjects populated and userIDs auto-populated", func() {
 				expectedUserID := fixtureUserID()
@@ -510,7 +480,6 @@ var _ = Describe("Group Subjects", func() {
 			})
 		})
 
-		// §5.2 Create with userIDs (legacy) — subjects auto-populated
 		Describe("Given a new group created with userIDs (legacy field)", func() {
 			It("should create successfully and subjects should be auto-populated", func() {
 				realUserID := fixtureUserID()
@@ -542,7 +511,6 @@ var _ = Describe("Group Subjects", func() {
 			})
 		})
 
-		// §5.2b Create with non-existent userID -> 400
 		Describe("Given a new group created with a non-existent userID", func() {
 			It("should return invalid request", func() {
 				payload := api.NewGroupPayload().
@@ -564,7 +532,6 @@ var _ = Describe("Group Subjects", func() {
 			})
 		})
 
-		// §5.3 Create with both subjects AND userIDs → rejected
 		Describe("Given a new group with both subjects and userIDs set", func() {
 			It("should be rejected with an error", func() {
 				ciInvalidUserEmail := fmt.Sprintf("ci-invalid-user-create-%d@nscale.test", time.Now().UnixNano())
@@ -588,7 +555,6 @@ var _ = Describe("Group Subjects", func() {
 			})
 		})
 
-		// §5.4 GET returns subject contents and userIDs compatibility field
 		Describe("Given an existing group with subjects", func() {
 			It("should return subject contents and empty userIDs on GET", func() {
 				testEmail := fmt.Sprintf("qa-get-%d@example.com", time.Now().UnixNano())
@@ -620,7 +586,6 @@ var _ = Describe("Group Subjects", func() {
 			})
 		})
 
-		// §5.5 Add a subject via PUT → subject appears in membership
 		Describe("Given an existing group, adding a subject via PUT", func() {
 			It("should reflect the new subject in the GET response", func() {
 				firstEmail := fmt.Sprintf("qa-add1-%d@example.com", time.Now().UnixNano())
@@ -641,7 +606,6 @@ var _ = Describe("Group Subjects", func() {
 				err := client.UpdateGroup(ctx, config.OrgID, groupID, updatePayload)
 				Expect(err).NotTo(HaveOccurred())
 
-				// §5.5 — verify via GET that the new subject is in the membership
 				retrieved, err := client.GetGroup(ctx, config.OrgID, groupID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(retrieved.Spec.Subjects).NotTo(BeNil())
@@ -658,21 +622,28 @@ var _ = Describe("Group Subjects", func() {
 			})
 		})
 
-		// §5.6 Remove a subject via PUT → subject no longer in membership
 		Describe("Given an existing group with two subjects, removing one via PUT", func() {
 			It("should no longer return the removed subject in the GET response", func() {
-				firstEmail := fmt.Sprintf("qa-rem1-%d@example.com", time.Now().UnixNano())
-				firstEmailCopy := firstEmail
-				firstSubject := identityopenapi.Subject{Id: firstEmail, Email: &firstEmailCopy, Issuer: ""}
-
-				secondEmail := fmt.Sprintf("qa-rem2-%d@example.com", time.Now().UnixNano())
-				secondEmailCopy := secondEmail
-				secondSubject := identityopenapi.Subject{Id: secondEmail, Email: &secondEmailCopy, Issuer: ""}
+				firstUser, firstUserID := api.CreateUserWithCleanup(client, ctx, config, api.NewUserPayload().
+					WithSubject(fmt.Sprintf("qa-rem-user-1-%d@nscale.test", time.Now().UnixNano())).
+					WithState(identityopenapi.Active).
+					Build())
+				secondUser, secondUserID := api.CreateUserWithCleanup(client, ctx, config, api.NewUserPayload().
+					WithSubject(fmt.Sprintf("qa-rem-user-2-%d@nscale.test", time.Now().UnixNano())).
+					WithState(identityopenapi.Active).
+					Build())
+				firstSubject := internalSubject(firstUser.Spec.Subject)
+				secondSubject := internalSubject(secondUser.Spec.Subject)
 
 				payload := api.NewGroupPayload().
 					WithSubjects([]identityopenapi.Subject{firstSubject, secondSubject}).
 					Build()
-				_, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
+				group, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
+
+				Expect(group.Spec.UserIDs).NotTo(BeNil(),
+					"userIDs field should be populated from valid internal subjects")
+				Expect(*group.Spec.UserIDs).To(ConsistOf(firstUserID, secondUserID),
+					"group should initially contain both resolved userIDs")
 
 				// Remove secondSubject by PUTting only firstSubject
 				updatePayload := api.NewGroupPayload().
@@ -691,14 +662,19 @@ var _ = Describe("Group Subjects", func() {
 					subjectIDs = append(subjectIDs, s.Id)
 				}
 
-				Expect(subjectIDs).To(ConsistOf(firstEmail),
+				Expect(subjectIDs).To(ConsistOf(firstSubject.Id),
 					"group membership must contain exactly the retained subject after PUT")
+				Expect(retrieved.Spec.UserIDs).NotTo(BeNil(),
+					"GET response must include userIDs compatibility field")
+				Expect(*retrieved.Spec.UserIDs).To(HaveLen(1),
+					"group membership must contain exactly one userID after PUT")
+				Expect(*retrieved.Spec.UserIDs).To(ConsistOf(firstUserID),
+					"group membership must contain exactly the retained userID after PUT")
 
-				GinkgoWriter.Printf("Removed subject %s from group %s\n", secondEmail, groupID)
+				GinkgoWriter.Printf("Removed subject %s from group %s\n", secondSubject.Id, groupID)
 			})
 		})
 
-		// §5.7 PUT with both subjects and userIDs → rejected
 		Describe("Given a PUT with both subjects and userIDs set", func() {
 			It("should be rejected with an error", func() {
 				payload := api.NewGroupPayload().Build()

--- a/test/api/suites/groups_test.go
+++ b/test/api/suites/groups_test.go
@@ -408,6 +408,34 @@ var _ = Describe("Group Management", func() {
 // From nscale-auth0-tests: groups.spec.ts §5 — Subjects membership field.
 var _ = Describe("Group Subjects", func() {
 	Context("When managing group subjects", func() {
+		firstOrganizationUser := func() identityopenapi.UserRead {
+			users, err := client.ListUsers(ctx, config.OrgID)
+			if err != nil || len(users) == 0 {
+				Skip("No users available in organization to test legacy userIDs field")
+			}
+
+			return users[0]
+		}
+
+		expectInvalidGroupWrite := func(method, path string, payload identityopenapi.GroupWrite, expectedDescription string) {
+			body, err := json.Marshal(payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, respBody, err := client.DoRequest(
+				ctx,
+				method,
+				path,
+				bytes.NewReader(body),
+				http.StatusBadRequest,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			var oauthErr identityopenapi.Oauth2Error
+			Expect(json.Unmarshal(respBody, &oauthErr)).To(Succeed())
+			Expect(oauthErr.Error).To(Equal(identityopenapi.InvalidRequest))
+			Expect(oauthErr.ErrorDescription).To(ContainSubstring(expectedDescription))
+		}
+
 		// §5.1 Create with external subjects field
 		Describe("Given a new group created with external subjects", func() {
 			It("should create successfully with subjects populated and userIDs empty", func() {
@@ -442,13 +470,8 @@ var _ = Describe("Group Subjects", func() {
 		Describe("Given a new group created with userIDs (legacy field)", func() {
 			It("should create successfully and subjects should be auto-populated", func() {
 				// userIDs are OrganizationUser object IDs — fetch a real one from the org.
-				users, err := client.ListUsers(ctx, config.OrgID)
-				if err != nil || len(users) == 0 {
-					Skip("No users available in organization to test legacy userIDs field")
-				}
-
-				realUserID := users[0].Metadata.Id
-
+				user := firstOrganizationUser()
+				realUserID := user.Metadata.Id
 				payload := api.NewGroupPayload().WithUserIDs([]string{realUserID}).Build()
 				group, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
 
@@ -462,11 +485,11 @@ var _ = Describe("Group Subjects", func() {
 					"subjects must be auto-populated when group is created with userIDs")
 				Expect(*group.Spec.Subjects).To(HaveLen(1),
 					"response subjects must contain exactly one resolved subject")
-				Expect((*group.Spec.Subjects)[0].Id).To(Equal(users[0].Spec.Subject),
+				Expect((*group.Spec.Subjects)[0].Id).To(Equal(user.Spec.Subject),
 					"response subject ID must match the resolved user subject")
 				Expect((*group.Spec.Subjects)[0].Email).NotTo(BeNil(),
 					"response subject email must be populated from the resolved user")
-				Expect(*(*group.Spec.Subjects)[0].Email).To(Equal(users[0].Spec.Subject),
+				Expect(*(*group.Spec.Subjects)[0].Email).To(Equal(user.Spec.Subject),
 					"response subject email must match the resolved user subject")
 				Expect((*group.Spec.Subjects)[0].Issuer).NotTo(BeEmpty(),
 					"response subject issuer must be populated for a resolved user")
@@ -501,22 +524,24 @@ var _ = Describe("Group Subjects", func() {
 		// §5.3 Create with both subjects AND userIDs → rejected
 		Describe("Given a new group with both subjects and userIDs set", func() {
 			It("should be rejected with an error", func() {
-				testEmail := fmt.Sprintf("qa-both-%d@example.com", time.Now().UnixNano())
-				email := testEmail
-				testSubject := identityopenapi.Subject{Id: testEmail, Email: &email, Issuer: ""}
-				fakeUserID := fmt.Sprintf("fake-user-%d", time.Now().UnixNano())
+				ciInvalidUserEmail := fmt.Sprintf("ci-invalid-user-create-%d@nscale.test", time.Now().UnixNano())
+				email := ciInvalidUserEmail
+				testSubject := identityopenapi.Subject{Id: ciInvalidUserEmail, Email: &email, Issuer: ""}
+				userID := firstOrganizationUser().Metadata.Id
 
 				payload := api.NewGroupPayload().
 					WithSubjects([]identityopenapi.Subject{testSubject}).
-					WithUserIDs([]string{fakeUserID}).
+					WithUserIDs([]string{userID}).
 					Build()
 
-				_, err := client.CreateGroup(ctx, config.OrgID, payload)
+				expectInvalidGroupWrite(
+					http.MethodPost,
+					api.NewEndpoints().ListGroups(config.OrgID),
+					payload,
+					"cannot provide both subjects and userIDs",
+				)
 
-				Expect(err).To(HaveOccurred(),
-					"creating a group with both subjects and userIDs must be rejected")
-
-				GinkgoWriter.Printf("Correctly rejected group with both subjects and userIDs: %v\n", err)
+				GinkgoWriter.Printf("Correctly rejected group with both subjects and userIDs\n")
 			})
 		})
 
@@ -636,22 +661,24 @@ var _ = Describe("Group Subjects", func() {
 				payload := api.NewGroupPayload().Build()
 				_, groupID := api.CreateGroupWithCleanup(client, ctx, config, payload)
 
-				testEmail := fmt.Sprintf("qa-both-put-%d@example.com", time.Now().UnixNano())
-				email := testEmail
-				testSubject := identityopenapi.Subject{Id: testEmail, Email: &email, Issuer: ""}
-				fakeUserID := fmt.Sprintf("fake-user-put-%d", time.Now().UnixNano())
+				ciInvalidUserEmail := fmt.Sprintf("ci-invalid-user-update-%d@nscale.test", time.Now().UnixNano())
+				email := ciInvalidUserEmail
+				testSubject := identityopenapi.Subject{Id: ciInvalidUserEmail, Email: &email, Issuer: ""}
+				userID := firstOrganizationUser().Metadata.Id
 
 				updatePayload := api.NewGroupPayload().
 					WithSubjects([]identityopenapi.Subject{testSubject}).
-					WithUserIDs([]string{fakeUserID}).
+					WithUserIDs([]string{userID}).
 					Build()
 
-				err := client.UpdateGroup(ctx, config.OrgID, groupID, updatePayload)
+				expectInvalidGroupWrite(
+					http.MethodPut,
+					api.NewEndpoints().GetGroup(config.OrgID, groupID),
+					updatePayload,
+					"cannot provide both subjects and userIDs",
+				)
 
-				Expect(err).To(HaveOccurred(),
-					"updating a group with both subjects and userIDs must be rejected")
-
-				GinkgoWriter.Printf("Correctly rejected PUT with both subjects and userIDs: %v\n", err)
+				GinkgoWriter.Printf("Correctly rejected PUT with both subjects and userIDs\n")
 			})
 		})
 	})


### PR DESCRIPTION
Focused split from #462.

Includes:
- add a typed group payload builder helper for subjects
- add integration coverage for creating groups with external subjects and legacy userIDs
- assert legacy userID creates populate the exact userID and resolved subject fields
- cover invalid userID rejection, subject/userID conflict rejection, GET subject fields, and PUT add/remove subject mutations

Validation:
- GOCACHE=$PWD/.codex-gocache go test ./test/api/...