### PR TITLE
test(api): cover audit, userinfo, and RBAC access

### DIFF
--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -71,12 +71,7 @@ func logf(format string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, "==> "+format+"\n", args...)
 }
 
-func newKubernetesClient() client.Client {
-	cfg, err := config.GetConfig()
-	if err != nil {
-		fatalf("failed to get kubeconfig: %v", err)
-	}
-
+func newClientScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
 		fatalf("failed to register core scheme: %v", err)
@@ -86,12 +81,7 @@ func newKubernetesClient() client.Client {
 		fatalf("failed to register identity scheme: %v", err)
 	}
 
-	k8s, err := client.New(cfg, client.Options{Scheme: scheme})
-	if err != nil {
-		fatalf("failed to create Kubernetes client: %v", err)
-	}
-
-	return k8s
+	return scheme
 }
 
 // issueCert creates a cert-manager Certificate via controller-runtime and
@@ -294,14 +284,15 @@ func createServiceAccount(ctx context.Context, ac *openapi.ClientWithResponses, 
 	}
 
 	id := resp.JSON201.Metadata.Id
+	token := ""
 
-	if resp.JSON201.Status.AccessToken == nil || *resp.JSON201.Status.AccessToken == "" {
-		fatalf("create service account %q did not return an access token", name)
+	if resp.JSON201.Status.AccessToken != nil {
+		token = *resp.JSON201.Status.AccessToken
 	}
 
 	logf("  service account %q ID: %s", name, id)
 
-	return id, *resp.JSON201.Status.AccessToken
+	return id, token
 }
 
 // createUser creates an active user in the given groups and returns its organization user ID.
@@ -443,33 +434,29 @@ func resolveRoles(ctx context.Context, ac *openapi.ClientWithResponses, orgID st
 	return administratorRoleID, userRoleID, auditRoleID
 }
 
-func createOrganizationFixture(ctx context.Context, ac *openapi.ClientWithResponses, k8s client.Client, namespace, name, description string) string {
-	logf("Creating %s Organization...", description)
+func createNonMemberOrganization(ctx context.Context, ac *openapi.ClientWithResponses, k8s client.Client, namespace string) string {
+	logf("Creating non-member Organization...")
+
+	otherOrgName := fmt.Sprintf("ci-unauthorised-org-%d", time.Now().UnixNano())
 
 	resp, err := ac.PostApiV1OrganizationsWithResponse(ctx, openapi.OrganizationWrite{
-		Metadata: coreopenapi.ResourceWriteMetadata{Name: name},
+		Metadata: coreopenapi.ResourceWriteMetadata{Name: otherOrgName},
 		Spec:     openapi.OrganizationSpec{OrganizationType: openapi.Adhoc},
 	})
 	if err != nil {
-		fatalf("failed to create %s Organization: %v", description, err)
+		fatalf("failed to create non-member Organization: %v", err)
 	}
 
 	if resp.JSON202 == nil {
-		fatalf("create %s Organization returned %s", description, resp.Status())
+		fatalf("create non-member Organization returned %s", resp.Status())
 	}
 
 	orgID := resp.JSON202.Metadata.Id
 	logf("  Organization ID: %s", orgID)
+
 	waitForOrgNamespace(ctx, k8s, namespace, orgID)
 
 	return orgID
-}
-
-func createAuditFixtures(ctx context.Context, ac *openapi.ClientWithResponses, orgID, auditRoleID string) string {
-	auditGroupID := createGroup(ctx, ac, orgID, "ci-audit-group", []string{auditRoleID})
-	_, auditToken := createServiceAccount(ctx, ac, orgID, "ci-audit-sa", []string{auditGroupID})
-
-	return auditToken
 }
 
 func main() {
@@ -494,7 +481,15 @@ func main() {
 	ctx := context.Background()
 
 	// Build a controller-runtime client using the in-cluster or KUBECONFIG credentials.
-	k8s := newKubernetesClient()
+	cfg, err := config.GetConfig()
+	if err != nil {
+		fatalf("failed to get kubeconfig: %v", err)
+	}
+
+	k8s, err := client.New(cfg, client.Options{Scheme: newClientScheme()})
+	if err != nil {
+		fatalf("failed to create Kubernetes client: %v", err)
+	}
 
 	// Issue mTLS client cert for ci-fixtures. The CN maps directly to the
 	// platform-administrator system account — no token exchange required.
@@ -505,12 +500,29 @@ func main() {
 	ac := newAPIClient(*baseURL, *caCertPath, certPEM, keyPEM)
 
 	// ── Create Organization ──────────────────────────────────────────────────
-	orgID := createOrganizationFixture(ctx, ac, k8s, *namespace, "ci-test-org", "test")
+	logf("Creating test Organization...")
+
+	orgResp, err := ac.PostApiV1OrganizationsWithResponse(ctx, openapi.OrganizationWrite{
+		Metadata: coreopenapi.ResourceWriteMetadata{Name: "ci-test-org"},
+		Spec:     openapi.OrganizationSpec{OrganizationType: openapi.Adhoc},
+	})
+	if err != nil {
+		fatalf("failed to create Organization: %v", err)
+	}
+
+	if orgResp.JSON202 == nil {
+		fatalf("create Organization returned %s", orgResp.Status())
+	}
+
+	orgID := orgResp.JSON202.Metadata.Id
+	logf("  Organization ID: %s", orgID)
+
+	// Wait for the organization controller to provision the backing namespace.
+	waitForOrgNamespace(ctx, k8s, *namespace, orgID)
 
 	// Create a second org that test identities are not members of.
 	// Used by non-member authorization tests (UNAUTHORISED_ORG_ID).
-	otherOrgName := fmt.Sprintf("ci-unauthorised-org-%d", time.Now().UnixNano())
-	unauthorisedOrgID := createOrganizationFixture(ctx, ac, k8s, *namespace, otherOrgName, "non-member")
+	unauthorisedOrgID := createNonMemberOrganization(ctx, ac, k8s, *namespace)
 
 	// ── Resolve role IDs ─────────────────────────────────────────────────────
 	// platform-administrator is protected and not returned by the API.
@@ -533,7 +545,9 @@ func main() {
 
 	adminSAID, adminToken := createServiceAccount(ctx, ac, orgID, "ci-admin-sa", []string{adminGroupID})
 	userSAID, serviceAccountToken := createServiceAccount(ctx, ac, orgID, "ci-user-sa", []string{userGroupID})
-	auditToken := createAuditFixtures(ctx, ac, orgID, auditRoleID)
+	auditGroupID := createGroup(ctx, ac, orgID, "ci-audit-group", []string{auditRoleID})
+	_, auditToken := createServiceAccount(ctx, ac, orgID, "ci-audit-sa", []string{auditGroupID})
+
 	userID := createUser(ctx, ac, orgID, ciFixtureUserSubject, []string{userGroupID})
 	userGlobalID := findGlobalUserID(ctx, k8s, *namespace, ciFixtureUserSubject)
 	userToken := issueUserToken(ctx, k8s, *namespace, *baseURL, ciFixtureUserSubject, userGlobalID)

--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -294,15 +294,14 @@ func createServiceAccount(ctx context.Context, ac *openapi.ClientWithResponses, 
 	}
 
 	id := resp.JSON201.Metadata.Id
-	token := ""
 
-	if resp.JSON201.Status.AccessToken != nil {
-		token = *resp.JSON201.Status.AccessToken
+	if resp.JSON201.Status.AccessToken == nil || *resp.JSON201.Status.AccessToken == "" {
+		fatalf("create service account %q did not return an access token", name)
 	}
 
 	logf("  service account %q ID: %s", name, id)
 
-	return id, token
+	return id, *resp.JSON201.Status.AccessToken
 }
 
 // createUser creates an active user in the given groups and returns its organization user ID.

--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -179,7 +179,6 @@ func newAPIClient(baseURL, caCertPath string, certPEM, keyPEM []byte) *openapi.C
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				MinVersion:   tls.VersionTLS12,
 				Certificates: []tls.Certificate{cert},

--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -17,11 +17,11 @@ limitations under the License.
 // integration-fixtures bootstraps the minimum test resources for integration tests.
 // It uses controller-runtime to issue an mTLS client certificate, then
 // calls the identity HTTP API via the generated OpenAPI client to create:
-//   - an Organization
-//   - two Groups: one with the "administrator" role, one with the "user" role
+//   - two Organizations: one test org and one non-member org
+//   - three Groups: "administrator", "user", and "auditor"
 //   - a Project (members: both groups)
-//   - a User in the user group
-//   - two ServiceAccounts: one per group, each yielding a distinct bearer token
+//   - a user in the user group, yielding a federated bearer token
+//   - ServiceAccounts for admin, user, and audit groups, each yielding a distinct bearer token
 //
 // The resulting tokens exercise both org-scoped (administrator) and
 // project-scoped (user) RBAC paths in the main integration suite.
@@ -45,10 +45,15 @@ import (
 	"time"
 
 	coreopenapi "github.com/unikorn-cloud/core/pkg/openapi"
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	handlercommon "github.com/unikorn-cloud/identity/pkg/handler/common"
+	"github.com/unikorn-cloud/identity/pkg/jose"
+	"github.com/unikorn-cloud/identity/pkg/oauth2"
 	"github.com/unikorn-cloud/identity/pkg/openapi"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -64,6 +69,29 @@ func fatalf(format string, args ...interface{}) {
 
 func logf(format string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, "==> "+format+"\n", args...)
+}
+
+func newKubernetesClient() client.Client {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		fatalf("failed to get kubeconfig: %v", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		fatalf("failed to register core scheme: %v", err)
+	}
+
+	if err := unikornv1.AddToScheme(scheme); err != nil {
+		fatalf("failed to register identity scheme: %v", err)
+	}
+
+	k8s, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		fatalf("failed to create Kubernetes client: %v", err)
+	}
+
+	return k8s
 }
 
 // issueCert creates a cert-manager Certificate via controller-runtime and
@@ -151,6 +179,7 @@ func newAPIClient(baseURL, caCertPath string, certPEM, keyPEM []byte) *openapi.C
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				MinVersion:   tls.VersionTLS12,
 				Certificates: []tls.Certificate{cert},
@@ -302,6 +331,58 @@ func createUser(ctx context.Context, ac *openapi.ClientWithResponses, orgID, sub
 	return id
 }
 
+func findGlobalUserID(ctx context.Context, k8s client.Client, namespace, subject string) string {
+	users := &unikornv1.UserList{}
+	if err := k8s.List(ctx, users, client.InNamespace(namespace)); err != nil {
+		fatalf("failed to list global users: %v", err)
+	}
+
+	for _, user := range users.Items {
+		if user.Spec.Subject == subject {
+			return user.Name
+		}
+	}
+
+	fatalf("global user for subject %q not found", subject)
+
+	return ""
+}
+
+func issueUserToken(ctx context.Context, k8s client.Client, namespace, baseURL, subject, globalUserID string) string {
+	issuer := handlercommon.IssuerValue{}
+	if err := issuer.Set(baseURL); err != nil {
+		fatalf("failed to parse issuer %q: %v", baseURL, err)
+	}
+
+	jwtIssuer := jose.NewJWTIssuer(k8s, namespace, &jose.Options{})
+	authenticator := oauth2.New(&oauth2.Options{
+		AccessTokenDuration:      time.Hour,
+		RefreshTokenDuration:     time.Hour,
+		TokenCacheSize:           8192,
+		CodeCacheSize:            8192,
+		AccountCreationCacheSize: 8192,
+	}, namespace, issuer, k8s, jwtIssuer, nil, nil)
+
+	tokens, err := authenticator.Issue(ctx, &oauth2.IssueInfo{
+		Issuer:   issuer.URL,
+		Audience: issuer.Hostname,
+		Subject:  subject,
+		Type:     oauth2.TokenTypeFederated,
+		Federated: &oauth2.FederatedClaims{
+			Provider: "ci-fixtures",
+			ClientID: "ci-fixtures",
+			UserID:   globalUserID,
+			Scope:    oauth2.NewScope("openid email profile"),
+		},
+		Interactive: true,
+	})
+	if err != nil {
+		fatalf("failed to issue user token for %q: %v", subject, err)
+	}
+
+	return tokens.AccessToken
+}
+
 // waitForOrgNamespace polls until the organization controller has provisioned the backing namespace.
 func waitForOrgNamespace(ctx context.Context, k8s client.Client, namespace, orgID string) {
 	logf("Waiting for Organization %s to be provisioned...", orgID)
@@ -326,8 +407,11 @@ func waitForOrgNamespace(ctx context.Context, k8s client.Client, namespace, orgI
 	}
 }
 
-// resolveRoles lists the organization roles and returns the IDs for administrator and user.
-func resolveRoles(ctx context.Context, ac *openapi.ClientWithResponses, orgID string) (string, string) {
+// resolveRoles lists organization roles and returns role IDs.
+// - administrator is required.
+// - user is required.
+// - auditor is required.
+func resolveRoles(ctx context.Context, ac *openapi.ClientWithResponses, orgID string) (string, string, string) {
 	logf("Resolving role IDs...")
 
 	rolesResp, err := ac.GetApiV1OrganizationsOrganizationIDRolesWithResponse(ctx, orgID)
@@ -349,10 +433,45 @@ func resolveRoles(ctx context.Context, ac *openapi.ClientWithResponses, orgID st
 		fatalf("user role not found in org %s", orgID)
 	}
 
+	auditRoleID := findRole(rolesResp.JSON200, "auditor")
+	if auditRoleID == "" {
+		fatalf("auditor role not found in org %s", orgID)
+	}
+
 	logf("  administrator role ID: %s", administratorRoleID)
 	logf("  user role ID: %s", userRoleID)
+	logf("  auditor role ID: %s", auditRoleID)
 
-	return administratorRoleID, userRoleID
+	return administratorRoleID, userRoleID, auditRoleID
+}
+
+func createOrganizationFixture(ctx context.Context, ac *openapi.ClientWithResponses, k8s client.Client, namespace, name, description string) string {
+	logf("Creating %s Organization...", description)
+
+	resp, err := ac.PostApiV1OrganizationsWithResponse(ctx, openapi.OrganizationWrite{
+		Metadata: coreopenapi.ResourceWriteMetadata{Name: name},
+		Spec:     openapi.OrganizationSpec{OrganizationType: openapi.Adhoc},
+	})
+	if err != nil {
+		fatalf("failed to create %s Organization: %v", description, err)
+	}
+
+	if resp.JSON202 == nil {
+		fatalf("create %s Organization returned %s", description, resp.Status())
+	}
+
+	orgID := resp.JSON202.Metadata.Id
+	logf("  Organization ID: %s", orgID)
+	waitForOrgNamespace(ctx, k8s, namespace, orgID)
+
+	return orgID
+}
+
+func createAuditFixtures(ctx context.Context, ac *openapi.ClientWithResponses, orgID, auditRoleID string) string {
+	auditGroupID := createGroup(ctx, ac, orgID, "ci-audit-group", []string{auditRoleID})
+	_, auditToken := createServiceAccount(ctx, ac, orgID, "ci-audit-sa", []string{auditGroupID})
+
+	return auditToken
 }
 
 func main() {
@@ -377,15 +496,7 @@ func main() {
 	ctx := context.Background()
 
 	// Build a controller-runtime client using the in-cluster or KUBECONFIG credentials.
-	cfg, err := config.GetConfig()
-	if err != nil {
-		fatalf("failed to get kubeconfig: %v", err)
-	}
-
-	k8s, err := client.New(cfg, client.Options{})
-	if err != nil {
-		fatalf("failed to create Kubernetes client: %v", err)
-	}
+	k8s := newKubernetesClient()
 
 	// Issue mTLS client cert for ci-fixtures. The CN maps directly to the
 	// platform-administrator system account — no token exchange required.
@@ -396,30 +507,17 @@ func main() {
 	ac := newAPIClient(*baseURL, *caCertPath, certPEM, keyPEM)
 
 	// ── Create Organization ──────────────────────────────────────────────────
-	logf("Creating test Organization...")
+	orgID := createOrganizationFixture(ctx, ac, k8s, *namespace, "ci-test-org", "test")
 
-	orgResp, err := ac.PostApiV1OrganizationsWithResponse(ctx, openapi.OrganizationWrite{
-		Metadata: coreopenapi.ResourceWriteMetadata{Name: "ci-test-org"},
-		Spec:     openapi.OrganizationSpec{OrganizationType: openapi.Adhoc},
-	})
-	if err != nil {
-		fatalf("failed to create Organization: %v", err)
-	}
-
-	if orgResp.JSON202 == nil {
-		fatalf("create Organization returned %s", orgResp.Status())
-	}
-
-	orgID := orgResp.JSON202.Metadata.Id
-	logf("  Organization ID: %s", orgID)
-
-	// Wait for the organization controller to provision the backing namespace.
-	waitForOrgNamespace(ctx, k8s, *namespace, orgID)
+	// Create a second org that test identities are not members of.
+	// Used by non-member authorization tests (UNAUTHORISED_ORG_ID).
+	otherOrgName := fmt.Sprintf("ci-unauthorised-org-%d", time.Now().UnixNano())
+	unauthorisedOrgID := createOrganizationFixture(ctx, ac, k8s, *namespace, otherOrgName, "non-member")
 
 	// ── Resolve role IDs ─────────────────────────────────────────────────────
 	// platform-administrator is protected and not returned by the API.
 	// We use administrator (org-scoped, full identity CRUD) and user (project-scoped).
-	administratorRoleID, userRoleID := resolveRoles(ctx, ac, orgID)
+	administratorRoleID, userRoleID, auditRoleID := resolveRoles(ctx, ac, orgID)
 
 	// ── Create Groups ─────────────────────────────────────────────────────────
 	// ci-admin-group: organization administrator — full identity CRUD at org scope.
@@ -435,14 +533,18 @@ func main() {
 	// ── Create user and ServiceAccounts ───────────────────────────────────────
 	const ciFixtureUserSubject = "ci-user@nscale.test"
 
-	userID := createUser(ctx, ac, orgID, ciFixtureUserSubject, []string{userGroupID})
 	adminSAID, adminToken := createServiceAccount(ctx, ac, orgID, "ci-admin-sa", []string{adminGroupID})
-	userSAID, userToken := createServiceAccount(ctx, ac, orgID, "ci-user-sa", []string{userGroupID})
+	userSAID, serviceAccountToken := createServiceAccount(ctx, ac, orgID, "ci-user-sa", []string{userGroupID})
+	auditToken := createAuditFixtures(ctx, ac, orgID, auditRoleID)
+	userID := createUser(ctx, ac, orgID, ciFixtureUserSubject, []string{userGroupID})
+	userGlobalID := findGlobalUserID(ctx, k8s, *namespace, ciFixtureUserSubject)
+	userToken := issueUserToken(ctx, k8s, *namespace, *baseURL, ciFixtureUserSubject, userGlobalID)
 
 	// ── Output .env fragment to stdout ────────────────────────────────────────
 	fmt.Printf("IDENTITY_BASE_URL=%s\n", *baseURL)
 	fmt.Printf("IDENTITY_CA_CERT=%s\n", *caCertPath)
 	fmt.Printf("TEST_ORG_ID=%s\n", orgID)
+	fmt.Printf("UNAUTHORISED_ORG_ID=%s\n", unauthorisedOrgID)
 	fmt.Printf("TEST_PROJECT_ID=%s\n", projectID)
 	fmt.Printf("API_AUTH_TOKEN=%s\n", adminToken)
 	fmt.Printf("TEST_ADMIN_GROUP_ID=%s\n", adminGroupID)
@@ -453,4 +555,6 @@ func main() {
 	fmt.Printf("TEST_USER_SA_ID=%s\n", userSAID)
 	fmt.Printf("ADMIN_AUTH_TOKEN=%s\n", adminToken)
 	fmt.Printf("USER_AUTH_TOKEN=%s\n", userToken)
+	fmt.Printf("SERVICE_ACCOUNT_TOKEN=%s\n", serviceAccountToken)
+	fmt.Printf("AUDIT_AUTH_TOKEN=%s\n", auditToken)
 }

--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -273,6 +273,24 @@ func (c *APIClient) DeleteGroup(ctx context.Context, orgID, groupID string) erro
 	return nil
 }
 
+// GetUserinfo returns userinfo claims for the current token.
+func (c *APIClient) GetUserinfo(ctx context.Context) (*identityopenapi.Userinfo, error) {
+	path := c.endpoints.GetUserinfo()
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	_, respBody, err := c.DoRequest(ctx, http.MethodGet, path, nil, http.StatusOK)
+	if err != nil {
+		return nil, fmt.Errorf("getting userinfo: %w", err)
+	}
+
+	var userinfo identityopenapi.Userinfo
+	if err := json.Unmarshal(respBody, &userinfo); err != nil {
+		return nil, fmt.Errorf("unmarshaling userinfo: %w", err)
+	}
+
+	return &userinfo, nil
+}
+
 // GetGlobalACL gets the global ACL for the current user.
 func (c *APIClient) GetGlobalACL(ctx context.Context) (*identityopenapi.Acl, error) {
 	path := c.endpoints.GetGlobalACL()

--- a/test/api/config.go
+++ b/test/api/config.go
@@ -25,15 +25,18 @@ import (
 // TestConfig extends the base config with Identity-specific fields.
 type TestConfig struct {
 	coreconfig.BaseConfig
-	AdminToken       string
-	UserToken        string
-	OrgID            string
-	ProjectID        string
-	AdminGroupID     string
-	UserGroupID      string
-	UserID           string
-	UserSubjectEmail string
-	UserSAID         string
+	AdminToken          string
+	UserToken           string
+	AuditToken          string
+	OrgID               string
+	ProjectID           string
+	AdminGroupID        string
+	UserGroupID         string
+	UserID              string
+	UserSubjectEmail    string
+	UserSAID            string
+	UnauthorisedOrgID   string
+	ServiceAccountToken string
 }
 
 // LoadTestConfig loads configuration from environment variables and .env files using viper.
@@ -72,15 +75,18 @@ func LoadTestConfig() (*TestConfig, error) {
 			LogRequests:     v.GetBool("LOG_REQUESTS"),
 			LogResponses:    v.GetBool("LOG_RESPONSES"),
 		},
-		AdminToken:       firstNonEmpty(v.GetString("ADMIN_AUTH_TOKEN"), v.GetString("API_AUTH_TOKEN")),
-		UserToken:        v.GetString("USER_AUTH_TOKEN"),
-		OrgID:            v.GetString("TEST_ORG_ID"),
-		ProjectID:        v.GetString("TEST_PROJECT_ID"),
-		AdminGroupID:     v.GetString("TEST_ADMIN_GROUP_ID"),
-		UserGroupID:      v.GetString("TEST_USER_GROUP_ID"),
-		UserID:           v.GetString("TEST_USER_ID"),
-		UserSubjectEmail: v.GetString("TEST_USER_SUBJECT_EMAIL"),
-		UserSAID:         v.GetString("TEST_USER_SA_ID"),
+		AdminToken:          firstNonEmpty(v.GetString("ADMIN_AUTH_TOKEN"), v.GetString("API_AUTH_TOKEN")),
+		UserToken:           v.GetString("USER_AUTH_TOKEN"),
+		AuditToken:          v.GetString("AUDIT_AUTH_TOKEN"),
+		OrgID:               v.GetString("TEST_ORG_ID"),
+		ProjectID:           v.GetString("TEST_PROJECT_ID"),
+		AdminGroupID:        v.GetString("TEST_ADMIN_GROUP_ID"),
+		UserGroupID:         v.GetString("TEST_USER_GROUP_ID"),
+		UserID:              v.GetString("TEST_USER_ID"),
+		UserSubjectEmail:    v.GetString("TEST_USER_SUBJECT_EMAIL"),
+		UserSAID:            v.GetString("TEST_USER_SA_ID"),
+		UnauthorisedOrgID:   v.GetString("UNAUTHORISED_ORG_ID"),
+		ServiceAccountToken: v.GetString("SERVICE_ACCOUNT_TOKEN"),
 	}
 
 	// Validate required fields

--- a/test/api/endpoints.go
+++ b/test/api/endpoints.go
@@ -30,6 +30,11 @@ func NewEndpoints() *Endpoints {
 	return &Endpoints{}
 }
 
+// GetUserinfo returns the endpoint for the userinfo endpoint.
+func (e *Endpoints) GetUserinfo() string {
+	return "/oauth2/v2/userinfo"
+}
+
 // ListOrganizations returns the endpoint for listing all organizations.
 func (e *Endpoints) ListOrganizations() string {
 	return "/api/v1/organizations"

--- a/test/api/suites/acl_test.go
+++ b/test/api/suites/acl_test.go
@@ -103,15 +103,12 @@ var _ = Describe("Access Control Discovery", func() {
 		// so only the user token produces ACL entries under Organization.Projects.
 		Describe("Given the caller is a member of groups assigned to projects", func() {
 			BeforeEach(func() {
-				if userClient == nil {
-					Skip("USER_AUTH_TOKEN is required for ACL projection testing")
-				}
+				Expect(userClient).NotTo(BeNil(), "USER_AUTH_TOKEN must be set by integration fixtures")
 			})
 
 			It("should no longer include a project in the ACL after it is deleted", func() {
-				if config.UserGroupID == "" {
-					Skip("TEST_USER_GROUP_ID is not configured")
-				}
+				Expect(config.UserGroupID).NotTo(BeEmpty(),
+					"TEST_USER_GROUP_ID must be set by integration fixtures")
 
 				_, projectID := api.CreateProjectWithCleanup(adminClient, ctx, config,
 					api.NewProjectPayload().
@@ -200,9 +197,8 @@ var _ = Describe("Access Control Discovery", func() {
 
 	Context("When a service account accesses the ACL", func() {
 		BeforeEach(func() {
-			if serviceAccountClient == nil {
-				Skip("SERVICE_ACCOUNT_TOKEN is not configured")
-			}
+			Expect(serviceAccountClient).NotTo(BeNil(),
+				"SERVICE_ACCOUNT_TOKEN must be set by integration fixtures")
 		})
 		Describe("Given the service account's home organisation", func() {
 			It("should return the service account's ACL for its home org", func() {

--- a/test/api/suites/acl_test.go
+++ b/test/api/suites/acl_test.go
@@ -73,7 +73,6 @@ var _ = Describe("Access Control Discovery", func() {
 					if org.Id == config.OrgID {
 						found = true
 						GinkgoWriter.Printf("Found test organization in ACL: %s\n", config.OrgID)
-
 						break
 					}
 				}
@@ -86,7 +85,7 @@ var _ = Describe("Access Control Discovery", func() {
 		Describe("Given invalid authentication", func() {
 			It("should reject requests without valid token", func() {
 				unauthClient := coreclient.NewAPIClient(config.BaseURL, "", config.RequestTimeout, &api.GinkgoLogger{})
-				_, _, err := unauthClient.DoRequest(ctx, http.MethodGet, api.NewEndpoints().GetGlobalACL(), nil, http.StatusOK)
+				_, _, err := unauthClient.DoRequest(ctx, http.MethodGet, "/api/v1/acl", nil, http.StatusOK)
 
 				Expect(err).To(HaveOccurred())
 				Expect(errors.Is(err, coreclient.ErrUnexpectedStatusCode)).To(BeTrue(),
@@ -95,7 +94,6 @@ var _ = Describe("Access Control Discovery", func() {
 				GinkgoWriter.Printf("Expected error for missing authentication: %v\n", err)
 			})
 		})
-
 	})
 
 	Context("When getting organization ACL", func() {
@@ -103,12 +101,15 @@ var _ = Describe("Access Control Discovery", func() {
 		// so only the user token produces ACL entries under Organization.Projects.
 		Describe("Given the caller is a member of groups assigned to projects", func() {
 			BeforeEach(func() {
-				Expect(userClient).NotTo(BeNil(), "USER_AUTH_TOKEN must be set by integration fixtures")
+				if userClient == nil {
+					Skip("USER_AUTH_TOKEN is required for ACL projection testing")
+				}
 			})
 
 			It("should no longer include a project in the ACL after it is deleted", func() {
-				Expect(config.UserGroupID).NotTo(BeEmpty(),
-					"TEST_USER_GROUP_ID must be set by integration fixtures")
+				if config.UserGroupID == "" {
+					Skip("TEST_USER_GROUP_ID is not configured")
+				}
 
 				_, projectID := api.CreateProjectWithCleanup(adminClient, ctx, config,
 					api.NewProjectPayload().

--- a/test/api/suites/acl_test.go
+++ b/test/api/suites/acl_test.go
@@ -200,6 +200,8 @@ var _ = Describe("Access Control Discovery", func() {
 		BeforeEach(func() {
 			Expect(serviceAccountClient).NotTo(BeNil(),
 				"SERVICE_ACCOUNT_TOKEN must be set by integration fixtures")
+			Expect(config.UnauthorisedOrgID).NotTo(BeEmpty(),
+				"UNAUTHORISED_ORG_ID must be set by integration fixtures")
 		})
 		Describe("Given the service account's home organisation", func() {
 			It("should return the service account's ACL for its home org", func() {
@@ -211,6 +213,8 @@ var _ = Describe("Access Control Discovery", func() {
 					"service account must have at least one organisation in its ACL")
 				Expect(*acl.Organizations).To(ContainElement(HaveField("Id", Equal(config.OrgID))),
 					"service account ACL should include home organisation %s", config.OrgID)
+				Expect(*acl.Organizations).NotTo(ContainElement(HaveField("Id", Equal(config.UnauthorisedOrgID))),
+					"service account ACL must not include non-member organisation %s", config.UnauthorisedOrgID)
 				GinkgoWriter.Printf("Service account ACL retrieved with %d organisations\n", len(*acl.Organizations))
 			})
 		})

--- a/test/api/suites/acl_test.go
+++ b/test/api/suites/acl_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Access Control Discovery", func() {
 					if org.Id == config.OrgID {
 						found = true
 						GinkgoWriter.Printf("Found test organization in ACL: %s\n", config.OrgID)
+
 						break
 					}
 				}
@@ -85,7 +86,7 @@ var _ = Describe("Access Control Discovery", func() {
 		Describe("Given invalid authentication", func() {
 			It("should reject requests without valid token", func() {
 				unauthClient := coreclient.NewAPIClient(config.BaseURL, "", config.RequestTimeout, &api.GinkgoLogger{})
-				_, _, err := unauthClient.DoRequest(ctx, http.MethodGet, "/api/v1/acl", nil, http.StatusOK)
+				_, _, err := unauthClient.DoRequest(ctx, http.MethodGet, api.NewEndpoints().GetGlobalACL(), nil, http.StatusOK)
 
 				Expect(err).To(HaveOccurred())
 				Expect(errors.Is(err, coreclient.ErrUnexpectedStatusCode)).To(BeTrue(),
@@ -94,6 +95,7 @@ var _ = Describe("Access Control Discovery", func() {
 				GinkgoWriter.Printf("Expected error for missing authentication: %v\n", err)
 			})
 		})
+
 	})
 
 	Context("When getting organization ACL", func() {
@@ -192,6 +194,28 @@ var _ = Describe("Access Control Discovery", func() {
 
 				Expect(found).To(BeTrue(),
 					"Fallback ACL should still include the caller's real organization %s", config.OrgID)
+			})
+		})
+	})
+
+	// From nscale-auth0-tests: acl.spec.ts §3.5, §3.6
+	Context("When a service account accesses the ACL", func() {
+		BeforeEach(func() {
+			if serviceAccountClient == nil {
+				Skip("SERVICE_ACCOUNT_TOKEN is not configured")
+			}
+		})
+		Describe("Given the service account's home organisation", func() {
+			It("should return the service account's ACL for its home org", func() {
+				acl, err := serviceAccountClient.GetGlobalACL(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(acl).NotTo(BeNil())
+				Expect(acl.Organizations).NotTo(BeNil())
+				Expect(*acl.Organizations).NotTo(BeEmpty(),
+					"service account must have at least one organisation in its ACL")
+				Expect(*acl.Organizations).To(ContainElement(HaveField("Id", Equal(config.OrgID))),
+					"service account ACL should include home organisation %s", config.OrgID)
+				GinkgoWriter.Printf("Service account ACL retrieved with %d organisations\n", len(*acl.Organizations))
 			})
 		})
 	})

--- a/test/api/suites/acl_test.go
+++ b/test/api/suites/acl_test.go
@@ -198,7 +198,6 @@ var _ = Describe("Access Control Discovery", func() {
 		})
 	})
 
-	// From nscale-auth0-tests: acl.spec.ts §3.5, §3.6
 	Context("When a service account accesses the ACL", func() {
 		BeforeEach(func() {
 			if serviceAccountClient == nil {

--- a/test/api/suites/audit_rbac_test.go
+++ b/test/api/suites/audit_rbac_test.go
@@ -59,6 +59,9 @@ var _ = Describe("Console Audit View Permissions", func() {
 
 		Describe("Given a request to list organizations", func() {
 			It("audit token should succeed and return at least one organization", func() {
+				Expect(config.UnauthorisedOrgID).NotTo(BeEmpty(),
+					"UNAUTHORISED_ORG_ID must be set by integration fixtures")
+
 				orgs, err := auditClient.ListOrganizations(ctx)
 
 				Expect(err).NotTo(HaveOccurred())
@@ -66,10 +69,13 @@ var _ = Describe("Console Audit View Permissions", func() {
 
 				var orgIDs []string
 				for _, org := range orgs {
+					Expect(org.Metadata.Id).NotTo(BeEmpty())
 					orgIDs = append(orgIDs, org.Metadata.Id)
 				}
 
 				Expect(orgIDs).To(ContainElement(config.OrgID))
+				Expect(orgIDs).NotTo(ContainElement(config.UnauthorisedOrgID),
+					"audit token must not list organizations outside its scope")
 
 				GinkgoWriter.Printf("Audit: listed %d organizations\n", len(orgs))
 			})
@@ -90,27 +96,51 @@ var _ = Describe("Console Audit View Permissions", func() {
 		Describe("Given a request to list users", func() {
 			It("audit token should succeed and return a list", func() {
 				Expect(config.UserID).NotTo(BeEmpty(), "TEST_USER_ID must be set by integration fixtures")
+				Expect(config.UserSubjectEmail).NotTo(BeEmpty(),
+					"TEST_USER_SUBJECT_EMAIL must be set by integration fixtures")
 
 				users, err := auditClient.ListUsers(ctx, config.OrgID)
 
 				Expect(err).NotTo(HaveOccurred())
 
-				var userIDs []string
+				found := false
 				for _, user := range users {
-					userIDs = append(userIDs, user.Metadata.Id)
+					Expect(user.Metadata.OrganizationId).To(Equal(config.OrgID))
+
+					if user.Metadata.Id == config.UserID {
+						found = true
+						Expect(user.Spec.Subject).To(Equal(config.UserSubjectEmail))
+
+						break
+					}
 				}
 
-				Expect(userIDs).To(ContainElement(config.UserID))
+				Expect(found).To(BeTrue(),
+					"audit token should see fixture user %s in organization %s", config.UserID, config.OrgID)
 				GinkgoWriter.Printf("Audit: listed %d users\n", len(users))
 			})
 		})
 
 		Describe("Given a request to list roles", func() {
-			It("audit token should succeed and return at least one role", func() {
+			It("audit token should succeed and return the auditor role", func() {
 				roles, err := auditClient.ListRoles(ctx, config.OrgID)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(roles).NotTo(BeEmpty())
+
+				roleNames := make(map[string]bool)
+				for _, role := range roles {
+					Expect(role.Metadata.Id).NotTo(BeEmpty())
+					Expect(role.Metadata.Name).NotTo(BeEmpty())
+
+					roleNames[role.Metadata.Name] = true
+				}
+
+				Expect(roleNames).To(HaveKey("auditor"))
+				Expect(roleNames).NotTo(HaveKey("administrator"),
+					"audit token must not see administrator as a grantable role")
+				Expect(roleNames).NotTo(HaveKey("user"),
+					"audit token must not see user as a grantable role")
 
 				GinkgoWriter.Printf("Audit: listed %d roles\n", len(roles))
 			})
@@ -118,10 +148,25 @@ var _ = Describe("Console Audit View Permissions", func() {
 
 		Describe("Given a request to list groups", func() {
 			It("audit token should succeed and return a list", func() {
+				Expect(config.AdminGroupID).NotTo(BeEmpty(),
+					"TEST_ADMIN_GROUP_ID must be set by integration fixtures")
+				Expect(config.UserGroupID).NotTo(BeEmpty(),
+					"TEST_USER_GROUP_ID must be set by integration fixtures")
+
 				groups, err := auditClient.ListGroups(ctx, config.OrgID)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(groups).NotTo(BeEmpty())
+
+				var groupIDs []string
+				for _, group := range groups {
+					Expect(group.Metadata.Id).NotTo(BeEmpty())
+					Expect(group.Metadata.OrganizationId).To(Equal(config.OrgID))
+
+					groupIDs = append(groupIDs, group.Metadata.Id)
+				}
+
+				Expect(groupIDs).To(ContainElements(config.AdminGroupID, config.UserGroupID))
 				GinkgoWriter.Printf("Audit: listed %d groups\n", len(groups))
 			})
 		})
@@ -134,6 +179,8 @@ var _ = Describe("Console Audit View Permissions", func() {
 
 				var projectIDs []string
 				for _, project := range projects {
+					Expect(project.Metadata.OrganizationId).To(Equal(config.OrgID))
+
 					projectIDs = append(projectIDs, project.Metadata.Id)
 				}
 
@@ -145,17 +192,28 @@ var _ = Describe("Console Audit View Permissions", func() {
 		Describe("Given a request to list service accounts", func() {
 			It("audit token should succeed and return a list", func() {
 				Expect(config.UserSAID).NotTo(BeEmpty(), "TEST_USER_SA_ID must be set by integration fixtures")
+				Expect(config.UserGroupID).NotTo(BeEmpty(),
+					"TEST_USER_GROUP_ID must be set by integration fixtures")
 
 				sas, err := auditClient.ListServiceAccounts(ctx, config.OrgID)
 
 				Expect(err).NotTo(HaveOccurred())
 
-				var serviceAccountIDs []string
+				found := false
 				for _, sa := range sas {
-					serviceAccountIDs = append(serviceAccountIDs, sa.Metadata.Id)
+					Expect(sa.Metadata.Id).NotTo(BeEmpty())
+					Expect(sa.Metadata.OrganizationId).To(Equal(config.OrgID))
+
+					if sa.Metadata.Id == config.UserSAID {
+						found = true
+						Expect(sa.Spec.GroupIDs).To(ContainElement(config.UserGroupID))
+
+						break
+					}
 				}
 
-				Expect(serviceAccountIDs).To(ContainElement(config.UserSAID))
+				Expect(found).To(BeTrue(),
+					"audit token should see fixture service account %s", config.UserSAID)
 				GinkgoWriter.Printf("Audit: listed %d service accounts\n", len(sas))
 			})
 		})

--- a/test/api/suites/audit_rbac_test.go
+++ b/test/api/suites/audit_rbac_test.go
@@ -1,0 +1,214 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// From nscale-auth0-tests: console-audit-view.spec.ts §8 — ported to Go/Ginkgo.
+// Tests that an audit-role token can read all console-visible resources but cannot
+// mutate groups, organizations, or quotas.
+
+//nolint:revive,testpackage // dot imports and package naming standard for Ginkgo
+package suites
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/test/api"
+)
+
+var _ = Describe("Console Audit View Permissions", func() {
+	Context("When reading console-visible resources", func() {
+		BeforeEach(func() {
+			if auditClient == nil {
+				Skip("AUDIT_AUTH_TOKEN is not configured — skipping audit read-access tests")
+			}
+		})
+
+		// §8.1
+		Describe("Given a request to list organizations", func() {
+			It("audit token should succeed and return at least one organization", func() {
+				orgs, err := auditClient.ListOrganizations(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(orgs).NotTo(BeEmpty())
+
+				GinkgoWriter.Printf("Audit: listed %d organizations\n", len(orgs))
+			})
+		})
+
+		// §8.2
+		Describe("Given a request to view organization details", func() {
+			It("audit token should return organization with matching ID", func() {
+				org, err := auditClient.GetOrganization(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(org).NotTo(BeNil())
+				Expect(org.Metadata.Id).To(Equal(config.OrgID))
+
+				GinkgoWriter.Printf("Audit: fetched org %s\n", config.OrgID)
+			})
+		})
+
+		// §8.3
+		Describe("Given a request to list users", func() {
+			It("audit token should succeed and return a list", func() {
+				users, err := auditClient.ListUsers(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				// An empty list is valid — the assertion is that access is permitted (no error).
+				GinkgoWriter.Printf("Audit: listed %d users\n", len(users))
+			})
+		})
+
+		// §8.4
+		Describe("Given a request to list roles", func() {
+			It("audit token should succeed and return at least one role", func() {
+				roles, err := auditClient.ListRoles(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(roles).NotTo(BeEmpty())
+
+				GinkgoWriter.Printf("Audit: listed %d roles\n", len(roles))
+			})
+		})
+
+		// §8.5
+		Describe("Given a request to list groups", func() {
+			It("audit token should succeed and return a list", func() {
+				groups, err := auditClient.ListGroups(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				GinkgoWriter.Printf("Audit: listed %d groups\n", len(groups))
+			})
+		})
+
+		// §8.6
+		Describe("Given a request to list projects", func() {
+			It("audit token should succeed and return a list", func() {
+				projects, err := auditClient.ListProjects(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				GinkgoWriter.Printf("Audit: listed %d projects\n", len(projects))
+			})
+		})
+
+		// §8.7
+		Describe("Given a request to list service accounts", func() {
+			It("audit token should succeed and return a list", func() {
+				sas, err := auditClient.ListServiceAccounts(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				GinkgoWriter.Printf("Audit: listed %d service accounts\n", len(sas))
+			})
+		})
+
+		// §8.8
+		Describe("Given a request to read quotas", func() {
+			It("audit token should succeed and return a quotas object", func() {
+				quotas, err := auditClient.GetQuotas(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(quotas).NotTo(BeNil())
+
+				GinkgoWriter.Printf("Audit: read quotas (%d entries)\n", len(quotas.Quotas))
+			})
+		})
+	})
+
+	Context("When mutating console-managed resources", func() {
+		BeforeEach(func() {
+			if auditClient == nil {
+				Skip("AUDIT_AUTH_TOKEN is not configured — skipping audit write-denied tests")
+			}
+		})
+
+		// §8.9 audit token cannot create groups
+		Describe("Given a POST to create a group", func() {
+			It("audit token should be denied with a forbidden response", func() {
+				_, err := auditClient.CreateGroup(ctx, config.OrgID,
+					api.NewGroupPayload().Build())
+
+				Expect(err).To(HaveOccurred(),
+					"audit token must not be allowed to create groups")
+
+				GinkgoWriter.Printf("Audit group create correctly denied: %v\n", err)
+			})
+		})
+
+		// §8.10 audit token cannot update groups
+		Describe("Given a PUT to update a group", func() {
+			It("audit token should be denied with a forbidden response", func() {
+				_, groupID := api.CreateGroupWithCleanup(adminClient, ctx, config,
+					api.NewGroupPayload().Build())
+
+				err := auditClient.UpdateGroup(ctx, config.OrgID, groupID,
+					api.NewGroupPayload().Build())
+
+				Expect(err).To(HaveOccurred(),
+					"audit token must not be allowed to update groups")
+
+				GinkgoWriter.Printf("Audit group update correctly denied: %v\n", err)
+			})
+		})
+
+		// §8.11 audit token cannot delete groups
+		Describe("Given a DELETE to remove a group", func() {
+			It("audit token should be denied with a forbidden response", func() {
+				_, groupID := api.CreateGroupWithCleanup(adminClient, ctx, config,
+					api.NewGroupPayload().Build())
+
+				err := auditClient.DeleteGroup(ctx, config.OrgID, groupID)
+
+				Expect(err).To(HaveOccurred(),
+					"audit token must not be allowed to delete groups")
+
+				GinkgoWriter.Printf("Audit group delete correctly denied: %v\n", err)
+			})
+		})
+
+		// §8.12 audit token cannot update organization
+		Describe("Given a PUT to update the organization", func() {
+			It("audit token should be denied with a forbidden response", func() {
+				original, err := adminClient.GetOrganization(ctx, config.OrgID)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = auditClient.UpdateOrganization(ctx, config.OrgID,
+					api.NewOrganizationPayload().FromRead(*original).Build())
+
+				Expect(err).To(HaveOccurred(),
+					"audit token must not be allowed to update the organization")
+
+				GinkgoWriter.Printf("Audit org update correctly denied: %v\n", err)
+			})
+		})
+
+		// §8.13 audit token cannot update quotas
+		Describe("Given a PUT to update quotas", func() {
+			It("audit token should be denied with a forbidden response", func() {
+				_, err := auditClient.SetQuotas(ctx, config.OrgID,
+					identityopenapi.QuotasWrite{})
+
+				Expect(err).To(HaveOccurred(),
+					"audit token must not be allowed to update quotas")
+
+				GinkgoWriter.Printf("Audit quota update correctly denied: %v\n", err)
+			})
+		})
+	})
+})

--- a/test/api/suites/audit_rbac_test.go
+++ b/test/api/suites/audit_rbac_test.go
@@ -54,9 +54,7 @@ func expectAuditRequestForbidden(method, path string, payload any) {
 var _ = Describe("Console Audit View Permissions", func() {
 	Context("When reading console-visible resources", func() {
 		BeforeEach(func() {
-			if auditClient == nil {
-				Skip("AUDIT_AUTH_TOKEN is not configured — skipping audit read-access tests")
-			}
+			Expect(auditClient).NotTo(BeNil(), "AUDIT_AUTH_TOKEN must be set by integration fixtures")
 		})
 
 		Describe("Given a request to list organizations", func() {
@@ -91,18 +89,18 @@ var _ = Describe("Console Audit View Permissions", func() {
 
 		Describe("Given a request to list users", func() {
 			It("audit token should succeed and return a list", func() {
+				Expect(config.UserID).NotTo(BeEmpty(), "TEST_USER_ID must be set by integration fixtures")
+
 				users, err := auditClient.ListUsers(ctx, config.OrgID)
 
 				Expect(err).NotTo(HaveOccurred())
-				if config.UserID != "" {
-					var userIDs []string
-					for _, user := range users {
-						userIDs = append(userIDs, user.Metadata.Id)
-					}
 
-					Expect(userIDs).To(ContainElement(config.UserID))
+				var userIDs []string
+				for _, user := range users {
+					userIDs = append(userIDs, user.Metadata.Id)
 				}
 
+				Expect(userIDs).To(ContainElement(config.UserID))
 				GinkgoWriter.Printf("Audit: listed %d users\n", len(users))
 			})
 		})
@@ -146,18 +144,18 @@ var _ = Describe("Console Audit View Permissions", func() {
 
 		Describe("Given a request to list service accounts", func() {
 			It("audit token should succeed and return a list", func() {
+				Expect(config.UserSAID).NotTo(BeEmpty(), "TEST_USER_SA_ID must be set by integration fixtures")
+
 				sas, err := auditClient.ListServiceAccounts(ctx, config.OrgID)
 
 				Expect(err).NotTo(HaveOccurred())
-				if config.UserSAID != "" {
-					var serviceAccountIDs []string
-					for _, sa := range sas {
-						serviceAccountIDs = append(serviceAccountIDs, sa.Metadata.Id)
-					}
 
-					Expect(serviceAccountIDs).To(ContainElement(config.UserSAID))
+				var serviceAccountIDs []string
+				for _, sa := range sas {
+					serviceAccountIDs = append(serviceAccountIDs, sa.Metadata.Id)
 				}
 
+				Expect(serviceAccountIDs).To(ContainElement(config.UserSAID))
 				GinkgoWriter.Printf("Audit: listed %d service accounts\n", len(sas))
 			})
 		})
@@ -176,9 +174,7 @@ var _ = Describe("Console Audit View Permissions", func() {
 
 	Context("When mutating console-managed resources", func() {
 		BeforeEach(func() {
-			if auditClient == nil {
-				Skip("AUDIT_AUTH_TOKEN is not configured — skipping audit write-denied tests")
-			}
+			Expect(auditClient).NotTo(BeNil(), "AUDIT_AUTH_TOKEN must be set by integration fixtures")
 		})
 
 		Describe("Given a POST to create a group", func() {
@@ -231,9 +227,18 @@ var _ = Describe("Console Audit View Permissions", func() {
 
 		Describe("Given a PUT to update quotas", func() {
 			It("audit token should be denied with a forbidden response", func() {
+				current, err := adminClient.GetQuotas(ctx, config.OrgID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(current.Quotas).NotTo(BeEmpty())
+
+				writes := make(identityopenapi.QuotaWriteList, len(current.Quotas))
+				for i, quota := range current.Quotas {
+					writes[i] = identityopenapi.QuotaWrite{Kind: quota.Kind, Quantity: quota.Quantity}
+				}
+
 				expectAuditRequestForbidden(http.MethodPut,
 					api.NewEndpoints().GetQuotas(config.OrgID),
-					identityopenapi.QuotasWrite{})
+					identityopenapi.QuotasWrite{Quotas: writes})
 
 				GinkgoWriter.Printf("Audit quota update correctly denied with 403\n")
 			})

--- a/test/api/suites/audit_rbac_test.go
+++ b/test/api/suites/audit_rbac_test.go
@@ -17,20 +17,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// From nscale-auth0-tests: console-audit-view.spec.ts §8 — ported to Go/Ginkgo.
-// Tests that an audit-role token can read all console-visible resources but cannot
-// mutate groups, organizations, or quotas.
-
 //nolint:revive,testpackage // dot imports and package naming standard for Ginkgo
 package suites
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
 	"github.com/unikorn-cloud/identity/test/api"
 )
+
+func expectAuditRequestForbidden(method, path string, payload any) {
+	GinkgoHelper()
+
+	var body io.Reader
+	if payload != nil {
+		bodyBytes, err := json.Marshal(payload)
+		Expect(err).NotTo(HaveOccurred())
+
+		body = bytes.NewReader(bodyBytes)
+	}
+
+	resp, _, err := auditClient.DoRequest(ctx, method, path, body, http.StatusForbidden)
+	Expect(err).NotTo(HaveOccurred(),
+		"audit %s %s should return 403 Forbidden", method, path)
+	Expect(resp).NotTo(BeNil())
+	Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+}
 
 var _ = Describe("Console Audit View Permissions", func() {
 	Context("When reading console-visible resources", func() {
@@ -40,7 +59,6 @@ var _ = Describe("Console Audit View Permissions", func() {
 			}
 		})
 
-		// §8.1
 		Describe("Given a request to list organizations", func() {
 			It("audit token should succeed and return at least one organization", func() {
 				orgs, err := auditClient.ListOrganizations(ctx)
@@ -48,11 +66,17 @@ var _ = Describe("Console Audit View Permissions", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(orgs).NotTo(BeEmpty())
 
+				var orgIDs []string
+				for _, org := range orgs {
+					orgIDs = append(orgIDs, org.Metadata.Id)
+				}
+
+				Expect(orgIDs).To(ContainElement(config.OrgID))
+
 				GinkgoWriter.Printf("Audit: listed %d organizations\n", len(orgs))
 			})
 		})
 
-		// §8.2
 		Describe("Given a request to view organization details", func() {
 			It("audit token should return organization with matching ID", func() {
 				org, err := auditClient.GetOrganization(ctx, config.OrgID)
@@ -65,18 +89,24 @@ var _ = Describe("Console Audit View Permissions", func() {
 			})
 		})
 
-		// §8.3
 		Describe("Given a request to list users", func() {
 			It("audit token should succeed and return a list", func() {
 				users, err := auditClient.ListUsers(ctx, config.OrgID)
 
 				Expect(err).NotTo(HaveOccurred())
-				// An empty list is valid — the assertion is that access is permitted (no error).
+				if config.UserID != "" {
+					var userIDs []string
+					for _, user := range users {
+						userIDs = append(userIDs, user.Metadata.Id)
+					}
+
+					Expect(userIDs).To(ContainElement(config.UserID))
+				}
+
 				GinkgoWriter.Printf("Audit: listed %d users\n", len(users))
 			})
 		})
 
-		// §8.4
 		Describe("Given a request to list roles", func() {
 			It("audit token should succeed and return at least one role", func() {
 				roles, err := auditClient.ListRoles(ctx, config.OrgID)
@@ -88,37 +118,50 @@ var _ = Describe("Console Audit View Permissions", func() {
 			})
 		})
 
-		// §8.5
 		Describe("Given a request to list groups", func() {
 			It("audit token should succeed and return a list", func() {
 				groups, err := auditClient.ListGroups(ctx, config.OrgID)
 
 				Expect(err).NotTo(HaveOccurred())
+				Expect(groups).NotTo(BeEmpty())
 				GinkgoWriter.Printf("Audit: listed %d groups\n", len(groups))
 			})
 		})
 
-		// §8.6
 		Describe("Given a request to list projects", func() {
 			It("audit token should succeed and return a list", func() {
 				projects, err := auditClient.ListProjects(ctx, config.OrgID)
 
 				Expect(err).NotTo(HaveOccurred())
+
+				var projectIDs []string
+				for _, project := range projects {
+					projectIDs = append(projectIDs, project.Metadata.Id)
+				}
+
+				Expect(projectIDs).To(ContainElement(config.ProjectID))
 				GinkgoWriter.Printf("Audit: listed %d projects\n", len(projects))
 			})
 		})
 
-		// §8.7
 		Describe("Given a request to list service accounts", func() {
 			It("audit token should succeed and return a list", func() {
 				sas, err := auditClient.ListServiceAccounts(ctx, config.OrgID)
 
 				Expect(err).NotTo(HaveOccurred())
+				if config.UserSAID != "" {
+					var serviceAccountIDs []string
+					for _, sa := range sas {
+						serviceAccountIDs = append(serviceAccountIDs, sa.Metadata.Id)
+					}
+
+					Expect(serviceAccountIDs).To(ContainElement(config.UserSAID))
+				}
+
 				GinkgoWriter.Printf("Audit: listed %d service accounts\n", len(sas))
 			})
 		})
 
-		// §8.8
 		Describe("Given a request to read quotas", func() {
 			It("audit token should succeed and return a quotas object", func() {
 				quotas, err := auditClient.GetQuotas(ctx, config.OrgID)
@@ -138,76 +181,61 @@ var _ = Describe("Console Audit View Permissions", func() {
 			}
 		})
 
-		// §8.9 audit token cannot create groups
 		Describe("Given a POST to create a group", func() {
 			It("audit token should be denied with a forbidden response", func() {
-				_, err := auditClient.CreateGroup(ctx, config.OrgID,
+				expectAuditRequestForbidden(http.MethodPost,
+					api.NewEndpoints().ListGroups(config.OrgID),
 					api.NewGroupPayload().Build())
 
-				Expect(err).To(HaveOccurred(),
-					"audit token must not be allowed to create groups")
-
-				GinkgoWriter.Printf("Audit group create correctly denied: %v\n", err)
+				GinkgoWriter.Printf("Audit group create correctly denied with 403\n")
 			})
 		})
 
-		// §8.10 audit token cannot update groups
 		Describe("Given a PUT to update a group", func() {
 			It("audit token should be denied with a forbidden response", func() {
 				_, groupID := api.CreateGroupWithCleanup(adminClient, ctx, config,
 					api.NewGroupPayload().Build())
 
-				err := auditClient.UpdateGroup(ctx, config.OrgID, groupID,
+				expectAuditRequestForbidden(http.MethodPut,
+					api.NewEndpoints().GetGroup(config.OrgID, groupID),
 					api.NewGroupPayload().Build())
 
-				Expect(err).To(HaveOccurred(),
-					"audit token must not be allowed to update groups")
-
-				GinkgoWriter.Printf("Audit group update correctly denied: %v\n", err)
+				GinkgoWriter.Printf("Audit group update correctly denied with 403\n")
 			})
 		})
 
-		// §8.11 audit token cannot delete groups
 		Describe("Given a DELETE to remove a group", func() {
 			It("audit token should be denied with a forbidden response", func() {
 				_, groupID := api.CreateGroupWithCleanup(adminClient, ctx, config,
 					api.NewGroupPayload().Build())
 
-				err := auditClient.DeleteGroup(ctx, config.OrgID, groupID)
+				expectAuditRequestForbidden(http.MethodDelete,
+					api.NewEndpoints().GetGroup(config.OrgID, groupID), nil)
 
-				Expect(err).To(HaveOccurred(),
-					"audit token must not be allowed to delete groups")
-
-				GinkgoWriter.Printf("Audit group delete correctly denied: %v\n", err)
+				GinkgoWriter.Printf("Audit group delete correctly denied with 403\n")
 			})
 		})
 
-		// §8.12 audit token cannot update organization
 		Describe("Given a PUT to update the organization", func() {
 			It("audit token should be denied with a forbidden response", func() {
 				original, err := adminClient.GetOrganization(ctx, config.OrgID)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = auditClient.UpdateOrganization(ctx, config.OrgID,
+				expectAuditRequestForbidden(http.MethodPut,
+					api.NewEndpoints().GetOrganization(config.OrgID),
 					api.NewOrganizationPayload().FromRead(*original).Build())
 
-				Expect(err).To(HaveOccurred(),
-					"audit token must not be allowed to update the organization")
-
-				GinkgoWriter.Printf("Audit org update correctly denied: %v\n", err)
+				GinkgoWriter.Printf("Audit org update correctly denied with 403\n")
 			})
 		})
 
-		// §8.13 audit token cannot update quotas
 		Describe("Given a PUT to update quotas", func() {
 			It("audit token should be denied with a forbidden response", func() {
-				_, err := auditClient.SetQuotas(ctx, config.OrgID,
+				expectAuditRequestForbidden(http.MethodPut,
+					api.NewEndpoints().GetQuotas(config.OrgID),
 					identityopenapi.QuotasWrite{})
 
-				Expect(err).To(HaveOccurred(),
-					"audit token must not be allowed to update quotas")
-
-				GinkgoWriter.Printf("Audit quota update correctly denied: %v\n", err)
+				GinkgoWriter.Printf("Audit quota update correctly denied with 403\n")
 			})
 		})
 	})

--- a/test/api/suites/rbac_matrix_test.go
+++ b/test/api/suites/rbac_matrix_test.go
@@ -166,13 +166,10 @@ var _ = Describe("RBAC Enforcement", func() {
 		})
 
 		Describe("Given a request to list service accounts", func() {
-			It("should return only the requesting principal's own service account", func() {
-				serviceAccounts, err := userClient.ListServiceAccounts(ctx, config.OrgID)
+			It("should be denied with a forbidden response", func() {
+				_, err := userClient.ListServiceAccounts(ctx, config.OrgID)
 
-				Expect(err).NotTo(HaveOccurred())
-				Expect(serviceAccounts).To(HaveLen(1))
-				Expect(serviceAccounts[0].Metadata.Id).To(Equal(config.UserSAID))
-				Expect(serviceAccounts[0].Metadata.OrganizationId).To(Equal(config.OrgID))
+				Expect(err).To(HaveOccurred())
 			})
 		})
 
@@ -334,6 +331,28 @@ var _ = Describe("RBAC Enforcement", func() {
 				err := userClient.DeleteOauth2Provider(ctx, config.OrgID, providerID)
 
 				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("When authenticated as a service account", func() {
+		BeforeEach(func() {
+			if serviceAccountClient == nil {
+				Skip("SERVICE_ACCOUNT_TOKEN is required for service account RBAC tests")
+			}
+			if config.UserSAID == "" {
+				Skip("TEST_USER_SA_ID is not configured")
+			}
+		})
+
+		Describe("Given a request to list service accounts", func() {
+			It("should return only the requesting service account", func() {
+				serviceAccounts, err := serviceAccountClient.ListServiceAccounts(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(serviceAccounts).To(HaveLen(1))
+				Expect(serviceAccounts[0].Metadata.Id).To(Equal(config.UserSAID))
+				Expect(serviceAccounts[0].Metadata.OrganizationId).To(Equal(config.OrgID))
 			})
 		})
 	})

--- a/test/api/suites/rbac_matrix_test.go
+++ b/test/api/suites/rbac_matrix_test.go
@@ -23,6 +23,7 @@ package suites
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -32,25 +33,58 @@ import (
 	"github.com/unikorn-cloud/identity/test/api"
 )
 
+func expectUserRequestForbidden(method, path string, payload any) {
+	GinkgoHelper()
+
+	var body io.Reader
+	if payload != nil {
+		bodyBytes, err := json.Marshal(payload)
+		Expect(err).NotTo(HaveOccurred())
+
+		body = bytes.NewReader(bodyBytes)
+	}
+
+	resp, _, err := userClient.DoRequest(ctx, method, path, body, http.StatusForbidden)
+	Expect(err).NotTo(HaveOccurred(),
+		"user %s %s should return 403 Forbidden", method, path)
+	Expect(resp).NotTo(BeNil())
+	Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+}
+
 var _ = Describe("RBAC Enforcement", func() {
 	BeforeEach(func() {
-		if adminClient == nil || userClient == nil {
-			Skip("ADMIN_AUTH_TOKEN and USER_AUTH_TOKEN are required for RBAC enforcement testing")
-		}
+		Expect(config.AdminToken).NotTo(BeEmpty(),
+			"ADMIN_AUTH_TOKEN must be set by integration fixtures")
+		Expect(adminClient).NotTo(BeNil(),
+			"ADMIN_AUTH_TOKEN must create an administrator API client")
+		Expect(config.UserToken).NotTo(BeEmpty(),
+			"USER_AUTH_TOKEN must be set by integration fixtures")
+		Expect(userClient).NotTo(BeNil(),
+			"USER_AUTH_TOKEN must create a user API client")
 	})
 
 	Context("When authenticated as an administrator", func() {
 		Describe("Given a request to list groups", func() {
 			It("should return all groups in the organization with complete metadata", func() {
+				Expect(config.AdminGroupID).NotTo(BeEmpty(),
+					"TEST_ADMIN_GROUP_ID must be set by integration fixtures")
+				Expect(config.UserGroupID).NotTo(BeEmpty(),
+					"TEST_USER_GROUP_ID must be set by integration fixtures")
+
 				groups, err := adminClient.ListGroups(ctx, config.OrgID)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(groups).NotTo(BeEmpty())
 
+				var groupIDs []string
 				for _, group := range groups {
 					Expect(group.Metadata.Id).NotTo(BeEmpty())
 					Expect(group.Metadata.OrganizationId).To(Equal(config.OrgID))
+
+					groupIDs = append(groupIDs, group.Metadata.Id)
 				}
+
+				Expect(groupIDs).To(ContainElements(config.AdminGroupID, config.UserGroupID))
 			})
 		})
 
@@ -61,11 +95,18 @@ var _ = Describe("RBAC Enforcement", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(roles).NotTo(BeEmpty())
 
+				roleNames := make(map[string]bool)
 				for _, role := range roles {
 					// RoleRead uses the base ResourceReadMetadata which does not carry
 					// OrganizationId; only Id is guaranteed on this resource type.
 					Expect(role.Metadata.Id).NotTo(BeEmpty())
+					Expect(role.Metadata.Name).NotTo(BeEmpty())
+
+					roleNames[role.Metadata.Name] = true
 				}
+
+				Expect(roleNames).To(HaveKey("administrator"))
+				Expect(roleNames).To(HaveKey("auditor"))
 			})
 		})
 
@@ -84,9 +125,8 @@ var _ = Describe("RBAC Enforcement", func() {
 
 			Describe("Given TEST_USER_SA_ID is configured", func() {
 				BeforeEach(func() {
-					if config.UserSAID == "" {
-						Skip("TEST_USER_SA_ID is not configured")
-					}
+					Expect(config.UserSAID).NotTo(BeEmpty(),
+						"TEST_USER_SA_ID must be set by integration fixtures")
 				})
 
 				It("should include service accounts belonging to other principals", func() {
@@ -174,45 +214,35 @@ var _ = Describe("RBAC Enforcement", func() {
 
 	Context("When authenticated as a user", func() {
 		BeforeEach(func() {
-			if userClient == nil {
-				Skip("USER_AUTH_TOKEN is required for user RBAC tests")
-			}
+			Expect(userClient).NotTo(BeNil(), "USER_AUTH_TOKEN must be set by integration fixtures")
 		})
-
-		// For denial tests, an error on any non-2xx response is sufficient to verify
-		// that access was denied without needing to inspect the response body.
 
 		Describe("Given a request to list groups", func() {
 			It("should be denied with a forbidden response", func() {
-				_, err := userClient.ListGroups(ctx, config.OrgID)
-				Expect(err).To(HaveOccurred())
+				expectUserRequestForbidden(http.MethodGet,
+					api.NewEndpoints().ListGroups(config.OrgID), nil)
 			})
 		})
 
 		Describe("Given a request to list roles", func() {
 			It("should be denied with a forbidden response", func() {
-				_, err := userClient.ListRoles(ctx, config.OrgID)
-				Expect(err).To(HaveOccurred())
+				expectUserRequestForbidden(http.MethodGet,
+					api.NewEndpoints().ListRoles(config.OrgID), nil)
 			})
 		})
 
 		Describe("Given a request to list service accounts", func() {
 			It("should be denied with a forbidden response", func() {
-				resp, _, err := userClient.DoRequest(ctx, http.MethodGet,
-					api.NewEndpoints().ListServiceAccounts(config.OrgID), nil, http.StatusForbidden)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(resp).NotTo(BeNil())
-				Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+				expectUserRequestForbidden(http.MethodGet,
+					api.NewEndpoints().ListServiceAccounts(config.OrgID), nil)
 			})
 		})
 
 		Describe("Given a request to create a group", func() {
 			It("should be denied with a forbidden response", func() {
-				_, err := userClient.CreateGroup(ctx, config.OrgID,
+				expectUserRequestForbidden(http.MethodPost,
+					api.NewEndpoints().ListGroups(config.OrgID),
 					api.NewGroupPayload().Build())
-
-				Expect(err).To(HaveOccurred())
 			})
 		})
 
@@ -221,10 +251,9 @@ var _ = Describe("RBAC Enforcement", func() {
 				_, groupID := api.CreateGroupWithCleanup(adminClient, ctx, config,
 					api.NewGroupPayload().Build())
 
-				err := userClient.UpdateGroup(ctx, config.OrgID, groupID,
+				expectUserRequestForbidden(http.MethodPut,
+					api.NewEndpoints().GetGroup(config.OrgID, groupID),
 					api.NewGroupPayload().Build())
-
-				Expect(err).To(HaveOccurred())
 			})
 		})
 
@@ -233,26 +262,23 @@ var _ = Describe("RBAC Enforcement", func() {
 				_, groupID := api.CreateGroupWithCleanup(adminClient, ctx, config,
 					api.NewGroupPayload().Build())
 
-				err := userClient.DeleteGroup(ctx, config.OrgID, groupID)
-
-				Expect(err).To(HaveOccurred())
+				expectUserRequestForbidden(http.MethodDelete,
+					api.NewEndpoints().GetGroup(config.OrgID, groupID), nil)
 			})
 		})
 
 		Describe("Given a request to create a service account", func() {
 			It("should be denied with a forbidden response", func() {
-				_, err := userClient.CreateServiceAccount(ctx, config.OrgID,
+				expectUserRequestForbidden(http.MethodPost,
+					api.NewEndpoints().ListServiceAccounts(config.OrgID),
 					api.NewServiceAccountPayload().Build())
-
-				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		Describe("Given a request to list users", func() {
 			It("should be denied with a forbidden response", func() {
-				_, err := userClient.ListUsers(ctx, config.OrgID)
-
-				Expect(err).To(HaveOccurred())
+				expectUserRequestForbidden(http.MethodGet,
+					api.NewEndpoints().ListUsers(config.OrgID), nil)
 			})
 		})
 
@@ -267,15 +293,9 @@ var _ = Describe("RBAC Enforcement", func() {
 					writes[i] = identityopenapi.QuotaWrite{Kind: quota.Kind, Quantity: quota.Quantity}
 				}
 
-				body, err := json.Marshal(identityopenapi.QuotasWrite{Quotas: writes})
-				Expect(err).NotTo(HaveOccurred())
-
-				resp, _, err := userClient.DoRequest(ctx, http.MethodPut,
-					api.NewEndpoints().GetQuotas(config.OrgID), bytes.NewReader(body), http.StatusForbidden)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(resp).NotTo(BeNil())
-				Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+				expectUserRequestForbidden(http.MethodPut,
+					api.NewEndpoints().GetQuotas(config.OrgID),
+					identityopenapi.QuotasWrite{Quotas: writes})
 			})
 		})
 
@@ -284,9 +304,8 @@ var _ = Describe("RBAC Enforcement", func() {
 				_, saID := api.CreateServiceAccountWithCleanup(adminClient, ctx, config,
 					api.NewServiceAccountPayload().Build())
 
-				err := userClient.DeleteServiceAccount(ctx, config.OrgID, saID)
-
-				Expect(err).To(HaveOccurred())
+				expectUserRequestForbidden(http.MethodDelete,
+					api.NewEndpoints().GetServiceAccount(config.OrgID, saID), nil)
 			})
 		})
 
@@ -296,10 +315,9 @@ var _ = Describe("RBAC Enforcement", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 
-				err = userClient.UpdateOrganization(ctx, config.OrgID,
+				expectUserRequestForbidden(http.MethodPut,
+					api.NewEndpoints().GetOrganization(config.OrgID),
 					api.NewOrganizationPayload().FromRead(*original).Build())
-
-				Expect(err).To(HaveOccurred())
 			})
 		})
 
@@ -333,12 +351,15 @@ var _ = Describe("RBAC Enforcement", func() {
 				_, projectID := api.CreateProjectWithCleanup(adminClient, ctx, config,
 					api.NewProjectPayload().Build())
 
-				// Wait for provisioning so a 404 is a real denial, not a race.
+				// Wait for provisioning so the denial is RBAC, not a provisioning race.
 				api.WaitForProjectProvisioned(adminClient, ctx, config, projectID)
 
-				_, err := userClient.GetProject(ctx, config.OrgID, projectID)
+				resp, _, err := userClient.DoRequest(ctx, http.MethodGet,
+					api.NewEndpoints().GetProject(config.OrgID, projectID), nil, http.StatusForbidden)
 
-				Expect(err).To(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 			})
 
 			It("should not include a project the user is not a member of in the list", func() {
@@ -364,10 +385,9 @@ var _ = Describe("RBAC Enforcement", func() {
 
 		Describe("Given a request to create an OAuth2 provider", func() {
 			It("should be denied with a forbidden response", func() {
-				_, err := userClient.CreateOauth2Provider(ctx, config.OrgID,
+				expectUserRequestForbidden(http.MethodPost,
+					api.NewEndpoints().ListOauth2Providers(config.OrgID),
 					api.NewOauth2ProviderPayload().Build())
-
-				Expect(err).To(HaveOccurred())
 			})
 		})
 
@@ -376,9 +396,8 @@ var _ = Describe("RBAC Enforcement", func() {
 				_, providerID := api.CreateOauth2ProviderWithCleanup(adminClient, ctx, config,
 					api.NewOauth2ProviderPayload().Build())
 
-				err := userClient.DeleteOauth2Provider(ctx, config.OrgID, providerID)
-
-				Expect(err).To(HaveOccurred())
+				expectUserRequestForbidden(http.MethodDelete,
+					api.NewEndpoints().GetOauth2Provider(config.OrgID, providerID), nil)
 			})
 		})
 	})

--- a/test/api/suites/rbac_matrix_test.go
+++ b/test/api/suites/rbac_matrix_test.go
@@ -21,6 +21,8 @@ limitations under the License.
 package suites
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -256,10 +258,24 @@ var _ = Describe("RBAC Enforcement", func() {
 
 		Describe("Given a request to set quotas", func() {
 			It("should be denied with a forbidden response", func() {
-				_, err := userClient.SetQuotas(ctx, config.OrgID,
-					identityopenapi.QuotasWrite{})
+				current, err := adminClient.GetQuotas(ctx, config.OrgID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(current.Quotas).NotTo(BeEmpty())
 
-				Expect(err).To(HaveOccurred())
+				writes := make(identityopenapi.QuotaWriteList, len(current.Quotas))
+				for i, quota := range current.Quotas {
+					writes[i] = identityopenapi.QuotaWrite{Kind: quota.Kind, Quantity: quota.Quantity}
+				}
+
+				body, err := json.Marshal(identityopenapi.QuotasWrite{Quotas: writes})
+				Expect(err).NotTo(HaveOccurred())
+
+				resp, _, err := userClient.DoRequest(ctx, http.MethodPut,
+					api.NewEndpoints().GetQuotas(config.OrgID), bytes.NewReader(body), http.StatusForbidden)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 			})
 		})
 

--- a/test/api/suites/rbac_matrix_test.go
+++ b/test/api/suites/rbac_matrix_test.go
@@ -21,6 +21,8 @@ limitations under the License.
 package suites
 
 import (
+	"net/http"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -120,6 +122,38 @@ var _ = Describe("RBAC Enforcement", func() {
 					Expect(u.Metadata.OrganizationId).To(Equal(config.OrgID))
 				}
 			})
+
+			Describe("Given TEST_USER_ID is configured", func() {
+				BeforeEach(func() {
+					if config.UserID == "" {
+						Skip("TEST_USER_ID is not configured")
+					}
+				})
+
+				It("should include the fixture user in the organization users list", func() {
+					users, err := adminClient.ListUsers(ctx, config.OrgID)
+
+					Expect(err).NotTo(HaveOccurred())
+
+					var found bool
+
+					for _, user := range users {
+						if user.Metadata.Id == config.UserID {
+							found = true
+							Expect(user.Metadata.OrganizationId).To(Equal(config.OrgID))
+
+							if config.UserSubjectEmail != "" {
+								Expect(user.Spec.Subject).To(Equal(config.UserSubjectEmail))
+							}
+
+							break
+						}
+					}
+
+					Expect(found).To(BeTrue(),
+						"admin should see fixture user %s in organization %s", config.UserID, config.OrgID)
+				})
+			})
 		})
 
 		Describe("Given a request to list projects", func() {
@@ -167,9 +201,12 @@ var _ = Describe("RBAC Enforcement", func() {
 
 		Describe("Given a request to list service accounts", func() {
 			It("should be denied with a forbidden response", func() {
-				_, err := userClient.ListServiceAccounts(ctx, config.OrgID)
+				resp, _, err := userClient.DoRequest(ctx, http.MethodGet,
+					api.NewEndpoints().ListServiceAccounts(config.OrgID), nil, http.StatusForbidden)
 
-				Expect(err).To(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 			})
 		})
 
@@ -311,6 +348,23 @@ var _ = Describe("RBAC Enforcement", func() {
 
 				Expect(projectIDs).NotTo(ContainElement(projectID),
 					"user should not see a project they are not a member of")
+			})
+		})
+
+		Describe("Given a request against an organization the user is not a member of", func() {
+			BeforeEach(func() {
+				if config.UnauthorisedOrgID == "" {
+					Skip("UNAUTHORISED_ORG_ID is not configured")
+				}
+			})
+
+			It("should be denied with a forbidden response", func() {
+				resp, _, err := userClient.DoRequest(ctx, http.MethodGet,
+					api.NewEndpoints().ListProjects(config.UnauthorisedOrgID), nil, http.StatusForbidden)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 			})
 		})
 

--- a/test/api/suites/rbac_matrix_test.go
+++ b/test/api/suites/rbac_matrix_test.go
@@ -32,8 +32,9 @@ import (
 
 var _ = Describe("RBAC Enforcement", func() {
 	BeforeEach(func() {
-		Expect(adminClient).NotTo(BeNil(), "ADMIN_AUTH_TOKEN or API_AUTH_TOKEN must be set by integration fixtures")
-		Expect(userClient).NotTo(BeNil(), "USER_AUTH_TOKEN must be set by integration fixtures")
+		if adminClient == nil || userClient == nil {
+			Skip("ADMIN_AUTH_TOKEN and USER_AUTH_TOKEN are required for RBAC enforcement testing")
+		}
 	})
 
 	Context("When authenticated as an administrator", func() {
@@ -80,9 +81,13 @@ var _ = Describe("RBAC Enforcement", func() {
 			})
 
 			Describe("Given TEST_USER_SA_ID is configured", func() {
-				It("should include service accounts belonging to other principals", func() {
-					Expect(config.UserSAID).NotTo(BeEmpty(), "TEST_USER_SA_ID must be set by integration fixtures")
+				BeforeEach(func() {
+					if config.UserSAID == "" {
+						Skip("TEST_USER_SA_ID is not configured")
+					}
+				})
 
+				It("should include service accounts belonging to other principals", func() {
 					serviceAccounts, err := adminClient.ListServiceAccounts(ctx, config.OrgID)
 
 					Expect(err).NotTo(HaveOccurred())
@@ -166,6 +171,12 @@ var _ = Describe("RBAC Enforcement", func() {
 	})
 
 	Context("When authenticated as a user", func() {
+		BeforeEach(func() {
+			if userClient == nil {
+				Skip("USER_AUTH_TOKEN is required for user RBAC tests")
+			}
+		})
+
 		// For denial tests, an error on any non-2xx response is sufficient to verify
 		// that access was denied without needing to inspect the response body.
 

--- a/test/api/suites/rbac_matrix_test.go
+++ b/test/api/suites/rbac_matrix_test.go
@@ -32,9 +32,8 @@ import (
 
 var _ = Describe("RBAC Enforcement", func() {
 	BeforeEach(func() {
-		if adminClient == nil || userClient == nil {
-			Skip("ADMIN_AUTH_TOKEN and USER_AUTH_TOKEN are required for RBAC enforcement testing")
-		}
+		Expect(adminClient).NotTo(BeNil(), "ADMIN_AUTH_TOKEN or API_AUTH_TOKEN must be set by integration fixtures")
+		Expect(userClient).NotTo(BeNil(), "USER_AUTH_TOKEN must be set by integration fixtures")
 	})
 
 	Context("When authenticated as an administrator", func() {
@@ -81,13 +80,9 @@ var _ = Describe("RBAC Enforcement", func() {
 			})
 
 			Describe("Given TEST_USER_SA_ID is configured", func() {
-				BeforeEach(func() {
-					if config.UserSAID == "" {
-						Skip("TEST_USER_SA_ID is not configured")
-					}
-				})
-
 				It("should include service accounts belonging to other principals", func() {
+					Expect(config.UserSAID).NotTo(BeEmpty(), "TEST_USER_SA_ID must be set by integration fixtures")
+
 					serviceAccounts, err := adminClient.ListServiceAccounts(ctx, config.OrgID)
 
 					Expect(err).NotTo(HaveOccurred())
@@ -124,13 +119,11 @@ var _ = Describe("RBAC Enforcement", func() {
 			})
 
 			Describe("Given TEST_USER_ID is configured", func() {
-				BeforeEach(func() {
-					if config.UserID == "" {
-						Skip("TEST_USER_ID is not configured")
-					}
-				})
-
 				It("should include the fixture user in the organization users list", func() {
+					Expect(config.UserID).NotTo(BeEmpty(), "TEST_USER_ID must be set by integration fixtures")
+					Expect(config.UserSubjectEmail).NotTo(BeEmpty(),
+						"TEST_USER_SUBJECT_EMAIL must be set by integration fixtures")
+
 					users, err := adminClient.ListUsers(ctx, config.OrgID)
 
 					Expect(err).NotTo(HaveOccurred())
@@ -141,10 +134,7 @@ var _ = Describe("RBAC Enforcement", func() {
 						if user.Metadata.Id == config.UserID {
 							found = true
 							Expect(user.Metadata.OrganizationId).To(Equal(config.OrgID))
-
-							if config.UserSubjectEmail != "" {
-								Expect(user.Spec.Subject).To(Equal(config.UserSubjectEmail))
-							}
+							Expect(user.Spec.Subject).To(Equal(config.UserSubjectEmail))
 
 							break
 						}
@@ -176,12 +166,6 @@ var _ = Describe("RBAC Enforcement", func() {
 	})
 
 	Context("When authenticated as a user", func() {
-		BeforeEach(func() {
-			if userClient == nil {
-				Skip("USER_AUTH_TOKEN is required for user RBAC tests")
-			}
-		})
-
 		// For denial tests, an error on any non-2xx response is sufficient to verify
 		// that access was denied without needing to inspect the response body.
 
@@ -351,23 +335,6 @@ var _ = Describe("RBAC Enforcement", func() {
 			})
 		})
 
-		Describe("Given a request against an organization the user is not a member of", func() {
-			BeforeEach(func() {
-				if config.UnauthorisedOrgID == "" {
-					Skip("UNAUTHORISED_ORG_ID is not configured")
-				}
-			})
-
-			It("should be denied with a forbidden response", func() {
-				resp, _, err := userClient.DoRequest(ctx, http.MethodGet,
-					api.NewEndpoints().ListProjects(config.UnauthorisedOrgID), nil, http.StatusForbidden)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(resp).NotTo(BeNil())
-				Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
-			})
-		})
-
 		Describe("Given a request to create an OAuth2 provider", func() {
 			It("should be denied with a forbidden response", func() {
 				_, err := userClient.CreateOauth2Provider(ctx, config.OrgID,
@@ -391,12 +358,9 @@ var _ = Describe("RBAC Enforcement", func() {
 
 	Context("When authenticated as a service account", func() {
 		BeforeEach(func() {
-			if serviceAccountClient == nil {
-				Skip("SERVICE_ACCOUNT_TOKEN is required for service account RBAC tests")
-			}
-			if config.UserSAID == "" {
-				Skip("TEST_USER_SA_ID is not configured")
-			}
+			Expect(serviceAccountClient).NotTo(BeNil(),
+				"SERVICE_ACCOUNT_TOKEN must be set by integration fixtures")
+			Expect(config.UserSAID).NotTo(BeEmpty(), "TEST_USER_SA_ID must be set by integration fixtures")
 		})
 
 		Describe("Given a request to list service accounts", func() {

--- a/test/api/suites/suite_test.go
+++ b/test/api/suites/suite_test.go
@@ -31,11 +31,13 @@ import (
 )
 
 var (
-	client      *api.APIClient
-	adminClient *api.APIClient
-	userClient  *api.APIClient
-	ctx         context.Context
-	config      *api.TestConfig
+	client               *api.APIClient
+	adminClient          *api.APIClient
+	userClient           *api.APIClient
+	auditClient          *api.APIClient
+	serviceAccountClient *api.APIClient
+	ctx                  context.Context
+	config               *api.TestConfig
 )
 
 var _ = BeforeSuite(func() {
@@ -60,6 +62,20 @@ var _ = BeforeEach(func() {
 		userConfig := *config
 		userConfig.AuthToken = config.UserToken
 		userClient = api.NewAPIClientWithConfig(&userConfig)
+	}
+
+	auditClient = nil
+	if config.AuditToken != "" {
+		auditConfig := *config
+		auditConfig.AuthToken = config.AuditToken
+		auditClient = api.NewAPIClientWithConfig(&auditConfig)
+	}
+
+	serviceAccountClient = nil
+	if config.ServiceAccountToken != "" {
+		saConfig := *config
+		saConfig.AuthToken = config.ServiceAccountToken
+		serviceAccountClient = api.NewAPIClientWithConfig(&saConfig)
 	}
 
 	ctx = context.Background()

--- a/test/api/suites/userinfo_test.go
+++ b/test/api/suites/userinfo_test.go
@@ -1,0 +1,179 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:revive,testpackage // dot imports and package naming standard for Ginkgo
+package suites
+
+import (
+	"errors"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	coreclient "github.com/unikorn-cloud/core/pkg/testing/client"
+	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/test/api"
+)
+
+var _ = Describe("Userinfo", func() {
+	Context("When calling the userinfo endpoint", func() {
+		Describe("Given valid authentication", func() {
+			It("should return claims including a non-empty sub", func() {
+				userinfo, err := client.GetUserinfo(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(userinfo).NotTo(BeNil())
+				Expect(userinfo.Sub).NotTo(BeEmpty(), "sub claim must be present in userinfo response")
+
+				GinkgoWriter.Printf("Userinfo sub: %s\n", userinfo.Sub)
+			})
+
+			It("should return consistent sub across repeated calls", func() {
+				first, err := client.GetUserinfo(ctx)
+				Expect(err).NotTo(HaveOccurred())
+
+				second, err := client.GetUserinfo(ctx)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(first.Sub).To(Equal(second.Sub),
+					"sub claim must be stable for the same token")
+			})
+
+			// From nscale-auth0-tests: userinfo.spec.ts §4.1
+			// The identity service issues custom authorisation claims under the
+			// https://unikorn-cloud.org/authz namespace.  Both acctype and orgIds
+			// are required for downstream RBAC consumers.
+			It("should include the custom authz claims with a valid acctype", func() {
+				userinfo, err := client.GetUserinfo(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(userinfo).NotTo(BeNil())
+				Expect(userinfo.HttpsunikornCloudOrgauthz).NotTo(BeNil(),
+					"https://unikorn-cloud.org/authz claim must be present")
+
+				authz := userinfo.HttpsunikornCloudOrgauthz
+				Expect(authz.Acctype).To(BeElementOf(
+					identityopenapi.Service,
+					identityopenapi.System,
+					identityopenapi.User,
+				), "acctype must be one of: service, system, user")
+
+				GinkgoWriter.Printf("acctype: %s\n", authz.Acctype)
+			})
+
+			// From nscale-auth0-tests: userinfo.spec.ts §4.1
+			// org_ids must be a non-empty list — the token must always carry at least
+			// one organisation membership for authorization to be meaningful.
+			It("should include a non-empty orgIds list in the custom authz claims", func() {
+				userinfo, err := client.GetUserinfo(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(userinfo.HttpsunikornCloudOrgauthz).NotTo(BeNil())
+				Expect(userinfo.HttpsunikornCloudOrgauthz.OrgIds).NotTo(BeEmpty(),
+					"orgIds must contain at least one organisation ID")
+
+				GinkgoWriter.Printf("orgIds count: %d\n",
+					len(userinfo.HttpsunikornCloudOrgauthz.OrgIds))
+			})
+
+			// From nscale-auth0-tests: userinfo.spec.ts §4.2
+			// The orgIds returned by userinfo must be consistent with the list of
+			// organisations returned by GET /api/v1/organizations for the same token.
+			It("should return orgIds that are consistent with the organizations list", func() {
+				userinfo, err := client.GetUserinfo(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(userinfo.HttpsunikornCloudOrgauthz).NotTo(BeNil())
+
+				orgs, err := client.ListOrganizations(ctx)
+				Expect(err).NotTo(HaveOccurred())
+
+				var orgIDs []string
+				for _, org := range orgs {
+					orgIDs = append(orgIDs, org.Metadata.Id)
+				}
+
+				for _, claimOrgID := range userinfo.HttpsunikornCloudOrgauthz.OrgIds {
+					Expect(orgIDs).To(ContainElement(claimOrgID),
+						"each orgId in authz claims must appear in the organizations list")
+				}
+
+				GinkgoWriter.Printf("orgIds from claims: %v match organizations list\n",
+					userinfo.HttpsunikornCloudOrgauthz.OrgIds)
+			})
+		})
+
+		Describe("Given no authentication", func() {
+			It("should reject the request", func() {
+				unauthClient := coreclient.NewAPIClient(config.BaseURL, "", config.RequestTimeout, &api.GinkgoLogger{})
+				_, _, err := unauthClient.DoRequest(ctx, http.MethodGet, api.NewEndpoints().GetUserinfo(), nil, http.StatusOK)
+
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrUnexpectedStatusCode)).To(BeTrue(),
+					"Unauthenticated userinfo request must be rejected")
+
+				GinkgoWriter.Printf("Unauthenticated userinfo rejected: %v\n", err)
+			})
+		})
+
+		// From nscale-auth0-tests: userinfo.spec.ts §4.3
+		// A real user token must report acctype "user" in the authz claims.
+		Context("When authenticated as a user", func() {
+			BeforeEach(func() {
+				if userClient == nil {
+					Skip("USER_AUTH_TOKEN is not configured")
+				}
+			})
+
+			It("should report acctype 'user' in the authz claims", func() {
+				userinfo, err := userClient.GetUserinfo(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(userinfo.HttpsunikornCloudOrgauthz).NotTo(BeNil())
+				Expect(userinfo.HttpsunikornCloudOrgauthz.Acctype).To(Equal(identityopenapi.User))
+				Expect(userinfo.HttpsunikornCloudOrgauthz.OrgIds).To(ContainElement(config.OrgID))
+
+				if config.UserSubjectEmail != "" {
+					Expect(userinfo.Sub).To(Equal(config.UserSubjectEmail))
+					Expect(userinfo.Email).NotTo(BeNil())
+					Expect(*userinfo.Email).To(Equal(config.UserSubjectEmail))
+				}
+
+				GinkgoWriter.Printf("User acctype: %s\n", userinfo.HttpsunikornCloudOrgauthz.Acctype)
+			})
+		})
+
+		// From nscale-auth0-tests: userinfo.spec.ts §4.3
+		// A service account token must report acctype "service" in the authz claims.
+		Context("When authenticated as a service account", func() {
+			BeforeEach(func() {
+				if serviceAccountClient == nil {
+					Skip("SERVICE_ACCOUNT_TOKEN is not configured")
+				}
+			})
+			It("should report acctype 'service' in the authz claims", func() {
+				userinfo, err := serviceAccountClient.GetUserinfo(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(userinfo.HttpsunikornCloudOrgauthz).NotTo(BeNil())
+				Expect(userinfo.HttpsunikornCloudOrgauthz.Acctype).To(Equal(identityopenapi.Service))
+				GinkgoWriter.Printf("Service account acctype: %s\n", userinfo.HttpsunikornCloudOrgauthz.Acctype)
+			})
+		})
+	})
+})

--- a/test/api/suites/userinfo_test.go
+++ b/test/api/suites/userinfo_test.go
@@ -21,7 +21,6 @@ limitations under the License.
 package suites
 
 import (
-	"errors"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -48,9 +47,11 @@ var _ = Describe("Userinfo", func() {
 			It("should return consistent sub across repeated calls", func() {
 				first, err := client.GetUserinfo(ctx)
 				Expect(err).NotTo(HaveOccurred())
+				Expect(first.Sub).NotTo(BeEmpty())
 
 				second, err := client.GetUserinfo(ctx)
 				Expect(err).NotTo(HaveOccurred())
+				Expect(second.Sub).NotTo(BeEmpty())
 
 				Expect(first.Sub).To(Equal(second.Sub),
 					"sub claim must be stable for the same token")
@@ -64,29 +65,34 @@ var _ = Describe("Userinfo", func() {
 				Expect(userinfo.HttpsunikornCloudOrgauthz).NotTo(BeNil(),
 					"https://unikorn-cloud.org/authz claim must be present")
 
-				authz := userinfo.HttpsunikornCloudOrgauthz
-				Expect(authz.Acctype).To(BeElementOf(
-					identityopenapi.Service,
-					identityopenapi.System,
-					identityopenapi.User,
-				), "acctype must be one of: service, system, user")
+				Expect(userinfo.HttpsunikornCloudOrgauthz.Acctype).To(Equal(identityopenapi.Service),
+					"default fixture token should be a service-account token")
 
-				GinkgoWriter.Printf("acctype: %s\n", authz.Acctype)
+				GinkgoWriter.Printf("acctype: %s\n", userinfo.HttpsunikornCloudOrgauthz.Acctype)
 			})
 
 			It("should include a non-empty orgIds list in the custom authz claims", func() {
+				Expect(config.UnauthorisedOrgID).NotTo(BeEmpty(),
+					"UNAUTHORISED_ORG_ID must be set by integration fixtures")
+
 				userinfo, err := client.GetUserinfo(ctx)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(userinfo.HttpsunikornCloudOrgauthz).NotTo(BeNil())
 				Expect(userinfo.HttpsunikornCloudOrgauthz.OrgIds).NotTo(BeEmpty(),
 					"orgIds must contain at least one organisation ID")
+				Expect(userinfo.HttpsunikornCloudOrgauthz.OrgIds).To(ContainElement(config.OrgID))
+				Expect(userinfo.HttpsunikornCloudOrgauthz.OrgIds).NotTo(ContainElement(config.UnauthorisedOrgID),
+					"authz claims must not include organizations outside the token scope")
 
 				GinkgoWriter.Printf("orgIds count: %d\n",
 					len(userinfo.HttpsunikornCloudOrgauthz.OrgIds))
 			})
 
 			It("should return orgIds that are consistent with the organizations list", func() {
+				Expect(config.UnauthorisedOrgID).NotTo(BeEmpty(),
+					"UNAUTHORISED_ORG_ID must be set by integration fixtures")
+
 				userinfo, err := client.GetUserinfo(ctx)
 
 				Expect(err).NotTo(HaveOccurred())
@@ -99,6 +105,10 @@ var _ = Describe("Userinfo", func() {
 				for _, org := range orgs {
 					orgIDs = append(orgIDs, org.Metadata.Id)
 				}
+
+				Expect(orgIDs).To(ContainElement(config.OrgID))
+				Expect(orgIDs).NotTo(ContainElement(config.UnauthorisedOrgID),
+					"organizations list must not include organizations outside the token scope")
 
 				expectedOrgIDs := make([]interface{}, 0, len(orgIDs))
 				for _, orgID := range orgIDs {
@@ -116,13 +126,15 @@ var _ = Describe("Userinfo", func() {
 		Describe("Given no authentication", func() {
 			It("should reject the request", func() {
 				unauthClient := coreclient.NewAPIClient(config.BaseURL, "", config.RequestTimeout, &api.GinkgoLogger{})
-				_, _, err := unauthClient.DoRequest(ctx, http.MethodGet, api.NewEndpoints().GetUserinfo(), nil, http.StatusOK)
+				resp, _, err := unauthClient.DoRequest(ctx, http.MethodGet,
+					api.NewEndpoints().GetUserinfo(), nil, http.StatusUnauthorized)
 
-				Expect(err).To(HaveOccurred())
-				Expect(errors.Is(err, coreclient.ErrUnexpectedStatusCode)).To(BeTrue(),
-					"Unauthenticated userinfo request must be rejected")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized),
+					"Unauthenticated userinfo request must be rejected with 401")
 
-				GinkgoWriter.Printf("Unauthenticated userinfo rejected: %v\n", err)
+				GinkgoWriter.Printf("Unauthenticated userinfo rejected with %d\n", resp.StatusCode)
 			})
 		})
 
@@ -156,12 +168,19 @@ var _ = Describe("Userinfo", func() {
 			BeforeEach(func() {
 				Expect(serviceAccountClient).NotTo(BeNil(),
 					"SERVICE_ACCOUNT_TOKEN must be set by integration fixtures")
+				Expect(config.UserSAID).NotTo(BeEmpty(), "TEST_USER_SA_ID must be set by integration fixtures")
+				Expect(config.UnauthorisedOrgID).NotTo(BeEmpty(),
+					"UNAUTHORISED_ORG_ID must be set by integration fixtures")
 			})
 			It("should report acctype 'service' in the authz claims", func() {
 				userinfo, err := serviceAccountClient.GetUserinfo(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(userinfo.HttpsunikornCloudOrgauthz).NotTo(BeNil())
 				Expect(userinfo.HttpsunikornCloudOrgauthz.Acctype).To(Equal(identityopenapi.Service))
+				Expect(userinfo.Sub).To(Equal(config.UserSAID))
+				Expect(userinfo.HttpsunikornCloudOrgauthz.OrgIds).To(ContainElement(config.OrgID))
+				Expect(userinfo.HttpsunikornCloudOrgauthz.OrgIds).NotTo(ContainElement(config.UnauthorisedOrgID),
+					"service-account authz claims must not include organizations outside the token scope")
 				GinkgoWriter.Printf("Service account acctype: %s\n", userinfo.HttpsunikornCloudOrgauthz.Acctype)
 			})
 		})

--- a/test/api/suites/userinfo_test.go
+++ b/test/api/suites/userinfo_test.go
@@ -56,10 +56,6 @@ var _ = Describe("Userinfo", func() {
 					"sub claim must be stable for the same token")
 			})
 
-			// From nscale-auth0-tests: userinfo.spec.ts §4.1
-			// The identity service issues custom authorisation claims under the
-			// https://unikorn-cloud.org/authz namespace.  Both acctype and orgIds
-			// are required for downstream RBAC consumers.
 			It("should include the custom authz claims with a valid acctype", func() {
 				userinfo, err := client.GetUserinfo(ctx)
 
@@ -78,9 +74,6 @@ var _ = Describe("Userinfo", func() {
 				GinkgoWriter.Printf("acctype: %s\n", authz.Acctype)
 			})
 
-			// From nscale-auth0-tests: userinfo.spec.ts §4.1
-			// org_ids must be a non-empty list — the token must always carry at least
-			// one organisation membership for authorization to be meaningful.
 			It("should include a non-empty orgIds list in the custom authz claims", func() {
 				userinfo, err := client.GetUserinfo(ctx)
 
@@ -93,9 +86,6 @@ var _ = Describe("Userinfo", func() {
 					len(userinfo.HttpsunikornCloudOrgauthz.OrgIds))
 			})
 
-			// From nscale-auth0-tests: userinfo.spec.ts §4.2
-			// The orgIds returned by userinfo must be consistent with the list of
-			// organisations returned by GET /api/v1/organizations for the same token.
 			It("should return orgIds that are consistent with the organizations list", func() {
 				userinfo, err := client.GetUserinfo(ctx)
 
@@ -110,10 +100,13 @@ var _ = Describe("Userinfo", func() {
 					orgIDs = append(orgIDs, org.Metadata.Id)
 				}
 
-				for _, claimOrgID := range userinfo.HttpsunikornCloudOrgauthz.OrgIds {
-					Expect(orgIDs).To(ContainElement(claimOrgID),
-						"each orgId in authz claims must appear in the organizations list")
+				expectedOrgIDs := make([]interface{}, 0, len(orgIDs))
+				for _, orgID := range orgIDs {
+					expectedOrgIDs = append(expectedOrgIDs, orgID)
 				}
+
+				Expect(userinfo.HttpsunikornCloudOrgauthz.OrgIds).To(ConsistOf(expectedOrgIDs...),
+					"orgIds in authz claims must exactly match the organizations list")
 
 				GinkgoWriter.Printf("orgIds from claims: %v match organizations list\n",
 					userinfo.HttpsunikornCloudOrgauthz.OrgIds)
@@ -133,8 +126,6 @@ var _ = Describe("Userinfo", func() {
 			})
 		})
 
-		// From nscale-auth0-tests: userinfo.spec.ts §4.3
-		// A real user token must report acctype "user" in the authz claims.
 		Context("When authenticated as a user", func() {
 			BeforeEach(func() {
 				if userClient == nil {
@@ -149,6 +140,11 @@ var _ = Describe("Userinfo", func() {
 				Expect(userinfo.HttpsunikornCloudOrgauthz.Acctype).To(Equal(identityopenapi.User))
 				Expect(userinfo.HttpsunikornCloudOrgauthz.OrgIds).To(ContainElement(config.OrgID))
 
+				if config.UnauthorisedOrgID != "" {
+					Expect(userinfo.HttpsunikornCloudOrgauthz.OrgIds).NotTo(ContainElement(config.UnauthorisedOrgID),
+						"user authz claims must not include organizations the user is not a member of")
+				}
+
 				if config.UserSubjectEmail != "" {
 					Expect(userinfo.Sub).To(Equal(config.UserSubjectEmail))
 					Expect(userinfo.Email).NotTo(BeNil())
@@ -159,8 +155,6 @@ var _ = Describe("Userinfo", func() {
 			})
 		})
 
-		// From nscale-auth0-tests: userinfo.spec.ts §4.3
-		// A service account token must report acctype "service" in the authz claims.
 		Context("When authenticated as a service account", func() {
 			BeforeEach(func() {
 				if serviceAccountClient == nil {

--- a/test/api/suites/userinfo_test.go
+++ b/test/api/suites/userinfo_test.go
@@ -128,9 +128,11 @@ var _ = Describe("Userinfo", func() {
 
 		Context("When authenticated as a user", func() {
 			BeforeEach(func() {
-				if userClient == nil {
-					Skip("USER_AUTH_TOKEN is not configured")
-				}
+				Expect(userClient).NotTo(BeNil(), "USER_AUTH_TOKEN must be set by integration fixtures")
+				Expect(config.UserSubjectEmail).NotTo(BeEmpty(),
+					"TEST_USER_SUBJECT_EMAIL must be set by integration fixtures")
+				Expect(config.UnauthorisedOrgID).NotTo(BeEmpty(),
+					"UNAUTHORISED_ORG_ID must be set by integration fixtures")
 			})
 
 			It("should report acctype 'user' in the authz claims", func() {
@@ -140,16 +142,11 @@ var _ = Describe("Userinfo", func() {
 				Expect(userinfo.HttpsunikornCloudOrgauthz.Acctype).To(Equal(identityopenapi.User))
 				Expect(userinfo.HttpsunikornCloudOrgauthz.OrgIds).To(ContainElement(config.OrgID))
 
-				if config.UnauthorisedOrgID != "" {
-					Expect(userinfo.HttpsunikornCloudOrgauthz.OrgIds).NotTo(ContainElement(config.UnauthorisedOrgID),
-						"user authz claims must not include organizations the user is not a member of")
-				}
-
-				if config.UserSubjectEmail != "" {
-					Expect(userinfo.Sub).To(Equal(config.UserSubjectEmail))
-					Expect(userinfo.Email).NotTo(BeNil())
-					Expect(*userinfo.Email).To(Equal(config.UserSubjectEmail))
-				}
+				Expect(userinfo.HttpsunikornCloudOrgauthz.OrgIds).NotTo(ContainElement(config.UnauthorisedOrgID),
+					"user authz claims must not include organizations the user is not a member of")
+				Expect(userinfo.Sub).To(Equal(config.UserSubjectEmail))
+				Expect(userinfo.Email).NotTo(BeNil())
+				Expect(*userinfo.Email).To(Equal(config.UserSubjectEmail))
 
 				GinkgoWriter.Printf("User acctype: %s\n", userinfo.HttpsunikornCloudOrgauthz.Acctype)
 			})
@@ -157,9 +154,8 @@ var _ = Describe("Userinfo", func() {
 
 		Context("When authenticated as a service account", func() {
 			BeforeEach(func() {
-				if serviceAccountClient == nil {
-					Skip("SERVICE_ACCOUNT_TOKEN is not configured")
-				}
+				Expect(serviceAccountClient).NotTo(BeNil(),
+					"SERVICE_ACCOUNT_TOKEN must be set by integration fixtures")
 			})
 			It("should report acctype 'service' in the authz claims", func() {
 				userinfo, err := serviceAccountClient.GetUserinfo(ctx)


### PR DESCRIPTION
Focused split from #462 for audit, userinfo, and account-type RBAC integration coverage.

Scope:
- Extends fixture generation only where needed for this PR-owned coverage: audit token, real user token, user/service-account IDs, and non-member organization ID.
- Adds typed API client/endpoints support for userinfo and the RBAC denial paths used by the tests.
- Adds userinfo coverage for fixture, user, and service-account tokens, including stable identity, account type, and organization-scope claims.
- Adds audit-token read coverage for console-visible identity resources and exact 403 coverage for write operations.
- Tightens RBAC matrix assertions so user-denied paths assert 403 instead of any error, and admin/audit reads assert response body fields.
- Extends service-account ACL coverage to assert the home org is present and the non-member org is absent.

Out of scope:
- No product behavior changes.
- No broad fixture foundation split or unrelated fixture refactor.
- No failure response body logging; that remains a separate low-priority PR.
- No group subject/userID runtime fix; that was handled in #483.

Validation:
- git diff --check
- go test ./hack/ci/fixtures/...
- go test -run "^$" -tags=integration ./test/api/...
- golangci-lint run ./hack/ci/fixtures/... ./test/api/...
- make touch
- make validate
- make generate
- GOTOOLCHAIN=go1.25.8 make test-unit