### PR TITLE
ci: surface integration failure diagnostics

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -62,6 +62,25 @@ jobs:
     - name: Run API integration tests
       run: make test-api-ci
 
+    - name: Dump identity diagnostics
+      if: failure()
+      env:
+        KIND_SUFFIX: ${{ steps.rand.outputs.suffix }}
+      run: |
+        if [ -f test/.env.install ]; then
+          . test/.env.install
+        fi
+
+        IDENTITY_NAMESPACE="${IDENTITY_NAMESPACE:-unikorn-identity-${KIND_SUFFIX}}"
+        IDENTITY_RELEASE="${IDENTITY_RELEASE:-identity-${KIND_SUFFIX}}"
+
+        kubectl -n "$IDENTITY_NAMESPACE" get pods -o wide || true
+        kubectl -n "$IDENTITY_NAMESPACE" get events --sort-by=.lastTimestamp || true
+        kubectl -n "$IDENTITY_NAMESPACE" logs "deploy/${IDENTITY_RELEASE}-server" --tail=300 || true
+        kubectl -n "$IDENTITY_NAMESPACE" logs "deploy/${IDENTITY_RELEASE}-organization-controller" --tail=200 || true
+        kubectl -n "$IDENTITY_NAMESPACE" logs "deploy/${IDENTITY_RELEASE}-project-controller" --tail=200 || true
+        kubectl -n "$IDENTITY_NAMESPACE" logs "deploy/${IDENTITY_RELEASE}-oauth2client-controller" --tail=200 || true
+
     - name: Upload test artifacts
       if: failure()
       uses: actions/upload-artifact@v4

--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -31,6 +31,7 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -63,6 +64,20 @@ func fatalf(format string, args ...interface{}) {
 
 func logf(format string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, "==> "+format+"\n", args...)
+}
+
+func responseDetail(status string, body []byte) string {
+	body = bytes.TrimSpace(body)
+	if len(body) == 0 {
+		return status
+	}
+
+	const maxBodyLength = 4096
+	if len(body) > maxBodyLength {
+		body = append(body[:maxBodyLength], []byte("...<truncated>")...)
+	}
+
+	return fmt.Sprintf("%s: %s", status, string(body))
 }
 
 // issueCert creates a cert-manager Certificate via controller-runtime and
@@ -217,7 +232,7 @@ func createGroup(ctx context.Context, ac *openapi.ClientWithResponses, orgID, na
 	}
 
 	if resp.JSON201 == nil {
-		fatalf("create group %q returned %s", name, resp.Status())
+		fatalf("create group %q returned %s", name, responseDetail(resp.Status(), resp.Body))
 	}
 
 	id := resp.JSON201.Metadata.Id
@@ -239,7 +254,7 @@ func createProject(ctx context.Context, ac *openapi.ClientWithResponses, orgID, 
 	}
 
 	if resp.JSON202 == nil {
-		fatalf("create project %q returned %s", name, resp.Status())
+		fatalf("create project %q returned %s", name, responseDetail(resp.Status(), resp.Body))
 	}
 
 	id := resp.JSON202.Metadata.Id
@@ -261,7 +276,7 @@ func createServiceAccount(ctx context.Context, ac *openapi.ClientWithResponses, 
 	}
 
 	if resp.JSON201 == nil {
-		fatalf("create service account %q returned %s", name, resp.Status())
+		fatalf("create service account %q returned %s", name, responseDetail(resp.Status(), resp.Body))
 	}
 
 	id := resp.JSON201.Metadata.Id
@@ -310,7 +325,7 @@ func resolveRoles(ctx context.Context, ac *openapi.ClientWithResponses, orgID st
 	}
 
 	if rolesResp.JSON200 == nil {
-		fatalf("list roles returned %s", rolesResp.Status())
+		fatalf("list roles returned %s", responseDetail(rolesResp.Status(), rolesResp.Body))
 	}
 
 	administratorRoleID := findRole(rolesResp.JSON200, "administrator")
@@ -381,7 +396,7 @@ func main() {
 	}
 
 	if orgResp.JSON202 == nil {
-		fatalf("create Organization returned %s", orgResp.Status())
+		fatalf("create Organization returned %s", responseDetail(orgResp.Status(), orgResp.Body))
 	}
 
 	orgID := orgResp.JSON202.Metadata.Id


### PR DESCRIPTION
Focused split from #462.\n\nIncludes:\n- dump identity pod, event, and controller/server logs when integration CI fails\n- include bounded OpenAPI response bodies in fixture fatal errors\n\nExcludes:\n- fixture env/token expansion from #484\n- group mutation/runtime fixes from #483\n\nValidation:\n- git diff --check\n- GOCACHE=/tmp/uni-identity-gocache go test ./hack/ci/fixtures/...