### PR TITLE
test(WIP): add passport token exchange API coverage (Phase2)

### DIFF
--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -639,6 +639,24 @@ func (c *APIClient) ExchangePassportRaw(ctx context.Context, expectedStatus int,
 	return c.doFormRequest(ctx, http.MethodPost, path, c.exchangeForm(options), expectedStatus)
 }
 
+// GetJWKS returns the public JSON Web Key Set used to verify tokens issued by identity.
+func (c *APIClient) GetJWKS(ctx context.Context) (*identityopenapi.JwksResponse, error) {
+	path := c.endpoints.GetJWKS()
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	_, respBody, err := c.DoRequest(ctx, http.MethodGet, path, nil, http.StatusOK)
+	if err != nil {
+		return nil, fmt.Errorf("getting JWKS: %w", err)
+	}
+
+	var jwks identityopenapi.JwksResponse
+	if err := json.Unmarshal(respBody, &jwks); err != nil {
+		return nil, fmt.Errorf("unmarshaling JWKS: %w", err)
+	}
+
+	return &jwks, nil
+}
+
 // UpdateServiceAccount updates an existing service account.
 func (c *APIClient) UpdateServiceAccount(ctx context.Context, orgID, saID string, sa identityopenapi.ServiceAccountWrite) (*identityopenapi.ServiceAccountRead, error) {
 	return putResource[identityopenapi.ServiceAccountWrite, identityopenapi.ServiceAccountRead](

--- a/test/api/endpoints.go
+++ b/test/api/endpoints.go
@@ -129,6 +129,11 @@ func (e *Endpoints) Token() string {
 	return "/oauth2/v2/token"
 }
 
+// GetJWKS returns the OAuth2 JWKS endpoint path.
+func (e *Endpoints) GetJWKS() string {
+	return "/oauth2/v2/jwks"
+}
+
 // ListGlobalOauth2Providers returns the endpoint for listing platform-level OAuth2 providers.
 func (e *Endpoints) ListGlobalOauth2Providers() string {
 	return "/api/v1/oauth2providers"

--- a/test/api/suites/passport_test.go
+++ b/test/api/suites/passport_test.go
@@ -27,6 +27,7 @@ import (
 
 	gojose "github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -70,6 +71,55 @@ func decodePassportClaims(passport string) passportClaims {
 	return claims
 }
 
+func decodePassportClaimMap(passport string) map[string]any {
+	parsed, err := jwt.ParseSigned(passport, []gojose.SignatureAlgorithm{gojose.ES512})
+	Expect(err).NotTo(HaveOccurred(), "Passport should be a valid ES512 JWS")
+
+	var claims map[string]any
+
+	Expect(parsed.UnsafeClaimsWithoutVerification(&claims)).To(Succeed())
+
+	return claims
+}
+
+func passportTTLSeconds(claims passportClaims) int64 {
+	Expect(claims.IssuedAt).NotTo(BeNil(), "Passport iat claim should be present")
+	Expect(claims.Expiry).NotTo(BeNil(), "Passport exp claim should be present")
+
+	return int64(*claims.Expiry) - int64(*claims.IssuedAt)
+}
+
+func keySetFromJWKS(jwks *identityopenapi.JwksResponse) *gojose.JSONWebKeySet {
+	Expect(jwks).NotTo(BeNil())
+
+	encoded, err := json.Marshal(jwks)
+	Expect(err).NotTo(HaveOccurred(), "JWKS should marshal from the OpenAPI response")
+
+	var keySet gojose.JSONWebKeySet
+
+	Expect(json.Unmarshal(encoded, &keySet)).To(Succeed(), "JWKS should decode as a JOSE key set")
+
+	return &keySet
+}
+
+func verifyPassportClaims(passport string, jwks *identityopenapi.JwksResponse) passportClaims {
+	parsed, err := jwt.ParseSigned(passport, []gojose.SignatureAlgorithm{gojose.ES512})
+	Expect(err).NotTo(HaveOccurred(), "Passport should be a valid ES512 JWS")
+	Expect(parsed.Headers).To(HaveLen(1))
+	Expect(parsed.Headers[0].Algorithm).To(Equal(string(gojose.ES512)))
+	Expect(parsed.Headers[0].KeyID).NotTo(BeEmpty(), "Passport header should carry a kid")
+
+	keySet := keySetFromJWKS(jwks)
+	Expect(keySet.Key(parsed.Headers[0].KeyID)).NotTo(BeEmpty(),
+		"JWKS should contain the passport signing key")
+
+	var claims passportClaims
+
+	Expect(parsed.Claims(keySet, &claims)).To(Succeed(), "Passport signature should verify against JWKS")
+
+	return claims
+}
+
 func decodeExchangeOAuth2Error(respBody []byte) identityopenapi.Oauth2Error {
 	var oauthErr identityopenapi.Oauth2Error
 
@@ -94,11 +144,57 @@ var _ = Describe("Passport Token Exchange", func() {
 
 				claims := decodePassportClaims(result.AccessToken)
 				Expect(claims.Type).To(Equal("passport"))
+				Expect(claims.Issuer).To(Equal("uni-identity"))
 				Expect(claims.Source).To(Equal("uni"))
 				Expect(claims.Subject).NotTo(BeEmpty())
+				Expect(claims.ID).NotTo(BeEmpty())
+				_, err = uuid.Parse(claims.ID)
+				Expect(err).NotTo(HaveOccurred(), "Passport jti should be a UUID")
+				Expect(passportTTLSeconds(claims)).To(Equal(int64(120)))
+				Expect(claims.OrgIDs).To(ContainElement(config.OrgID))
 				Expect(claims.Actor).To(BeNil(), "act claim must be omitted when subject is the acting party")
+				Expect(decodePassportClaimMap(result.AccessToken)).NotTo(HaveKey("acl"),
+					"Passport must not embed ACLs; authorization stays on the remote authorizer path")
 
 				GinkgoWriter.Printf("Passport exchanged successfully, expires_in: %d\n", result.ExpiresIn)
+			})
+		})
+
+		Describe("Given valid authentication with response inspection", func() {
+			It("should return a JSON token response", func() {
+				resp, respBody, err := client.ExchangePassportRaw(ctx, http.StatusOK, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.Header.Get("Content-Type")).To(ContainSubstring("application/json"))
+
+				var result identityopenapi.Token
+
+				Expect(json.Unmarshal(respBody, &result)).To(Succeed())
+				Expect(result.AccessToken).NotTo(BeEmpty())
+				Expect(result.ExpiresIn).To(Equal(120))
+				Expect(result.TokenType).To(Equal("Bearer"))
+				Expect(result.IssuedTokenType).NotTo(BeNil())
+				Expect(*result.IssuedTokenType).To(Equal(passportIssuedTokenType()))
+			})
+		})
+
+		Describe("Given repeated valid authentication", func() {
+			It("should mint a unique passport for each exchange", func() {
+				first, err := client.ExchangePassport(ctx, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				second, err := client.ExchangePassport(ctx, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(first.AccessToken).NotTo(Equal(second.AccessToken))
+
+				firstClaims := decodePassportClaims(first.AccessToken)
+				secondClaims := decodePassportClaims(second.AccessToken)
+
+				Expect(firstClaims.ID).NotTo(BeEmpty())
+				Expect(secondClaims.ID).NotTo(BeEmpty())
+				Expect(firstClaims.ID).NotTo(Equal(secondClaims.ID))
 			})
 		})
 
@@ -146,6 +242,52 @@ var _ = Describe("Passport Token Exchange", func() {
 			})
 		})
 
+		Describe("Given valid authentication with audience and resource hints", func() {
+			It("should include the requested audience values in the passport", func() {
+				audience := "uni-region"
+				resource := "https://region.identity.test/"
+				options := &identityopenapi.TokenRequestOptions{
+					Audience: &audience,
+					Resource: &resource,
+				}
+
+				result, err := client.ExchangePassport(ctx, options)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+
+				claims := decodePassportClaims(result.AccessToken)
+				Expect([]string(claims.Audience)).To(ConsistOf(resource, audience))
+			})
+		})
+
+		Describe("Given project-scoped fixture user authentication", func() {
+			BeforeEach(func() {
+				if userClient == nil {
+					Skip("USER_AUTH_TOKEN is required for project-scoped passport testing")
+				}
+			})
+
+			It("should return a passport scoped to the fixture project", func() {
+				options := &identityopenapi.TokenRequestOptions{
+					XOrganizationId: &config.OrgID,
+					XProjectId:      &config.ProjectID,
+				}
+
+				result, err := userClient.ExchangePassport(ctx, options)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.AccessToken).NotTo(BeEmpty())
+
+				claims := decodePassportClaims(result.AccessToken)
+				Expect(claims.Acctype).To(Equal(identityopenapi.Service))
+				Expect(claims.OrgIDs).To(ContainElement(config.OrgID))
+				Expect(claims.OrgID).To(Equal(config.OrgID))
+				Expect(claims.ProjectID).To(Equal(config.ProjectID))
+			})
+		})
+
 		Describe("Given an out-of-scope organization", func() {
 			It("should reject the exchange with an OAuth2 access_denied response", func() {
 				invalidOrgID := "00000000-0000-0000-0000-000000000000"
@@ -185,6 +327,82 @@ var _ = Describe("Passport Token Exchange", func() {
 			})
 		})
 
+		Describe("Given project scope without organization scope", func() {
+			It("should reject the exchange with an OAuth2 invalid_request response", func() {
+				options := &identityopenapi.TokenRequestOptions{
+					XProjectId: &config.ProjectID,
+				}
+
+				resp, respBody, err := client.ExchangePassportRaw(ctx, 0, options)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				oauthErr := decodeExchangeOAuth2Error(respBody)
+				Expect(oauthErr.Error).To(Equal(identityopenapi.InvalidRequest))
+				Expect(oauthErr.ErrorDescription).To(ContainSubstring("x_organization_id must be specified"))
+			})
+		})
+
+		Describe("Given an invalid resource URI", func() {
+			It("should reject the exchange with an OAuth2 invalid_request response", func() {
+				resource := "not-a-uri"
+				options := &identityopenapi.TokenRequestOptions{
+					Resource: &resource,
+				}
+
+				resp, respBody, err := client.ExchangePassportRaw(ctx, 0, options)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				oauthErr := decodeExchangeOAuth2Error(respBody)
+				Expect(oauthErr.Error).To(Equal(identityopenapi.InvalidRequest))
+				Expect(oauthErr.ErrorDescription).To(ContainSubstring("resource must be an absolute URI"))
+			})
+		})
+
+		Describe("Given an unsupported requested token type", func() {
+			It("should reject the exchange with an OAuth2 invalid_request response", func() {
+				requestedTokenType := "urn:ietf:params:oauth:token-type:id_token"
+				options := &identityopenapi.TokenRequestOptions{
+					RequestedTokenType: &requestedTokenType,
+				}
+
+				resp, respBody, err := client.ExchangePassportRaw(ctx, 0, options)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				oauthErr := decodeExchangeOAuth2Error(respBody)
+				Expect(oauthErr.Error).To(Equal(identityopenapi.InvalidRequest))
+				Expect(oauthErr.ErrorDescription).To(ContainSubstring("requested_token_type is not supported"))
+			})
+		})
+
+		Describe("Given a passport is presented as the source token", func() {
+			It("should reject the exchange with an OAuth2 access_denied response", func() {
+				result, err := client.ExchangePassport(ctx, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				passportConfig := *config
+				passportConfig.AuthToken = result.AccessToken
+				passportClient := api.NewAPIClientWithConfig(&passportConfig)
+
+				resp, respBody, err := passportClient.ExchangePassportRaw(ctx, 0, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+
+				oauthErr := decodeExchangeOAuth2Error(respBody)
+				Expect(oauthErr.Error).To(Equal(identityopenapi.AccessDenied))
+			})
+		})
+
 		Describe("Given no authentication", func() {
 			It("should reject the exchange request", func() {
 				unauthConfig := *config
@@ -202,6 +420,31 @@ var _ = Describe("Passport Token Exchange", func() {
 				Expect(oauthErr.ErrorDescription).To(ContainSubstring("subject_token must be specified"))
 
 				GinkgoWriter.Printf("Expected error for missing authentication: %v\n", err)
+			})
+		})
+	})
+
+	Context("When verifying a passport with the published JWKS", func() {
+		Describe("Given a valid passport", func() {
+			It("should verify the signature using the key identified by kid", func() {
+				result, err := client.ExchangePassport(ctx, &identityopenapi.TokenRequestOptions{
+					XOrganizationId: &config.OrgID,
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.AccessToken).NotTo(BeEmpty())
+
+				jwks, err := client.GetJWKS(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(jwks.Keys).NotTo(BeNil(), "JWKS keys should be present")
+				Expect(*jwks.Keys).NotTo(BeEmpty(), "JWKS should expose at least one signing key")
+
+				claims := verifyPassportClaims(result.AccessToken, jwks)
+				Expect(claims.Type).To(Equal("passport"))
+				Expect(claims.Issuer).To(Equal("uni-identity"))
+				Expect(claims.OrgID).To(Equal(config.OrgID))
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

- Expand the Phase 2 passport token-exchange integration coverage for `/oauth2/v2/token`.
- Add typed JWKS test helpers and verify issued passports against the published key set.
- Cover response shape, passport claims, TTL, unique `jti`, audience/resource propagation, scope validation, no embedded ACL claim, and passport-as-source rejection.

## Notes

The tests follow the current Phase 2 PRD and Alan's passport PR behaviour: token exchange is the RFC 8693 grant on `/oauth2/v2/token`, and passports carry identity claims only. ACL remains resolved via the existing remote authorizer path.

## Verification

- `go test -run '^$' -tags=integration ./test/api/...`
- `git diff --check`

`golangci-lint` was not available in the local environment.