### PR TITLE
chore: version v1.17.0

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: 1.16.1
-appVersion: 1.16.1
+version: 1.17.0
+appVersion: 1.17.0
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 


### PR DESCRIPTION
## Summary
- Bump `charts/identity/Chart.yaml` `version` + `appVersion` to `1.17.0`.

## Why minor
Since v1.16.1, main has picked up `feat(oauth2): implement passport token exchange endpoint` (#450) and follow-on passport token exchange work (#490), plus removal of Onboarding and Email Notifications (#491). Per the release process rollup rule, any backwards-compatible new feature in a service bumps the constellation to a minor; this bump matches.

## Process
Follows the standard service-bump flow documented in `uni/release-process.md`:
1. Bump on `release` branch, PR to `main`.
2. After merge, tag the merge commit on `main` as `v1.17.0` and push — Release workflow publishes the image and chart to `https://nscaledev.github.io/uni-identity`.
3. Bump the pin in `k8s-deploy-unikorn:nightly` `componentVersions.uni-identity` to soak in dev.

## Test plan
- [ ] CI green on PR (Conventional Commits prefix present).
- [ ] After merge + tag, confirm `gh release view v1.17.0` shows `unikorn-identity-1.17.0.tgz` asset published.