### PR TITLE
fix: map passport-exchange scope refusals to invalid_scope

### DIFF
--- a/pkg/middleware/openapi/README.md
+++ b/pkg/middleware/openapi/README.md
@@ -81,14 +81,26 @@ passport claims payload, and the per-entry TTL is derived from the passport's `e
 10 s clock-skew fudge. Identity caps the passport expiry to the source token's expiry before
 minting it, so middleware does not need to parse the source token locally.
 
-The exchange path fails closed: rejected source tokens and transport failures surface as
-access-denied. A malformed or temporally invalid passport returned after a *successful* exchange
-response is treated as an internal failure (500) rather than access-denied, because that outcome
-reflects an identity-side defect, not a user authorization decision. Passport decoding rejects both
-expired (`exp` ≤ now) and not-yet-valid (`nbf` > now) tokens. There is no fallback to the legacy
-userinfo path. Passports are consumed in-process and are never forwarded on outbound calls —
-internal service-to-service communication continues to use mTLS plus `X-Principal` exactly as
-before.
+The exchange path fails closed and preserves the authentication vs. authorization distinction:
+
+- A 401 from the token endpoint indicates the subject token itself was rejected (missing, expired,
+  malformed, principal not active). The middleware surfaces this as `access-denied` (401) with the
+  generic "token is invalid or has expired" description, so authentication failures cannot be
+  distinguished from "unknown principal" — both look identical to a caller.
+- A 400 with `error: "invalid_scope"` indicates the subject token is valid but the principal is not
+  authorized for the requested organization/project scope. The middleware surfaces this as
+  `forbidden` (403) at the API edge so refresh-loop logic does not treat a wrong-scope request as a
+  bad-token request, and so client UX can distinguish "you need to reauthenticate" from "you can't
+  do that".
+- Transport failures and 5xx responses surface as upstream unavailability.
+- A malformed or temporally invalid passport returned after a *successful* exchange response is
+  treated as an internal failure (500) rather than an authorization decision, because that outcome
+  reflects an identity-side defect.
+
+Passport decoding rejects both expired (`exp` ≤ now) and not-yet-valid (`nbf` > now) tokens. There
+is no fallback to the legacy userinfo path. Passports are consumed in-process and are never
+forwarded on outbound calls — internal service-to-service communication continues to use mTLS plus
+`X-Principal` exactly as before.
 
 ## Ingress And Header Invariants
 

--- a/pkg/middleware/openapi/README.md
+++ b/pkg/middleware/openapi/README.md
@@ -81,21 +81,12 @@ passport claims payload, and the per-entry TTL is derived from the passport's `e
 10 s clock-skew fudge. Identity caps the passport expiry to the source token's expiry before
 minting it, so middleware does not need to parse the source token locally.
 
-The exchange path fails closed and preserves the authentication vs. authorization distinction:
+The exchange path fails closed. Token-endpoint responses project to the API edge as follows:
 
-- A 401 from the token endpoint indicates the subject token itself was rejected (missing, expired,
-  malformed, principal not active). The middleware surfaces this as `access-denied` (401) with the
-  generic "token is invalid or has expired" description, so authentication failures cannot be
-  distinguished from "unknown principal" — both look identical to a caller.
-- A 400 with `error: "invalid_scope"` indicates the subject token is valid but the principal is not
-  authorized for the requested organization/project scope. The middleware surfaces this as
-  `forbidden` (403) at the API edge so refresh-loop logic does not treat a wrong-scope request as a
-  bad-token request, and so client UX can distinguish "you need to reauthenticate" from "you can't
-  do that".
-- Transport failures and 5xx responses surface as upstream unavailability.
-- A malformed or temporally invalid passport returned after a *successful* exchange response is
-  treated as an internal failure (500) rather than an authorization decision, because that outcome
-  reflects an identity-side defect.
+- 401 (subject token rejected) → `access-denied` (401)
+- 400 `invalid_scope` (subject token valid, scope not granted) → `forbidden` (403)
+- All other non-2xx, including 5xx and transport failures → `access-denied` (401)
+- Malformed or temporally invalid passport after a successful exchange → 500
 
 Passport decoding rejects both expired (`exp` ≤ now) and not-yet-valid (`nbf` > now) tokens. There
 is no fallback to the legacy userinfo path. Passports are consumed in-process and are never

--- a/pkg/middleware/openapi/README.md
+++ b/pkg/middleware/openapi/README.md
@@ -84,8 +84,12 @@ minting it, so middleware does not need to parse the source token locally.
 The exchange path fails closed. Token-endpoint responses project to the API edge as follows:
 
 - 401 (subject token rejected) → `access-denied` (401)
-- 400 `invalid_scope` (subject token valid, scope not granted) → `forbidden` (403)
-- All other non-2xx, including 5xx and transport failures → `access-denied` (401)
+- 400 with RFC 6749 §5.2 `error=invalid_scope` (subject token valid, scope not granted) →
+  `forbidden` (403)
+- All other non-2xx outcomes — including other 4xx (e.g. 400 with a different `error` code or a
+  malformed body), 5xx, transport failures, and timeouts — fall through to the catch-all
+  `access-denied` (401). This is the deliberate fail-closed default: the middleware refuses
+  ambiguous responses rather than guessing at intent.
 - Malformed or temporally invalid passport after a successful exchange → 500
 
 Passport decoding rejects both expired (`exp` ≤ now) and not-yet-valid (`nbf` > now) tokens. There

--- a/pkg/middleware/openapi/README.md
+++ b/pkg/middleware/openapi/README.md
@@ -83,12 +83,15 @@ minting it, so middleware does not need to parse the source token locally.
 
 The exchange path fails closed. Token-endpoint responses project to the API edge as follows:
 
-- 401 (subject token rejected) → `access-denied` (401)
-- 400 with RFC 6749 §5.2 `error=invalid_scope` (subject token valid, scope not granted) →
-  `forbidden` (403)
-- All other non-2xx outcomes — including other 4xx (e.g. 400 with a different `error` code or a
-  malformed body), 5xx, transport failures, and timeouts — fall through to the catch-all
-  `access-denied` (401). This is the deliberate fail-closed default: the middleware refuses
+- 401 (subject token rejected, `ErrTokenExchangeUnauthorized`) → `access-denied` (401)
+- 400 with RFC 6749 §5.2 `error=invalid_scope` (subject token valid, scope not granted,
+  `ErrTokenExchangeForbidden`) → `forbidden` (403)
+- 5xx and transport/timeout failures (`ErrTokenExchangeUnavailable`) → `access-denied` (401),
+  via the catch-all. The middleware deliberately does not surface 502/503/504 to the caller: a
+  transient identity outage must not let a request through, and exposing the upstream status
+  would invite retries that defeat the fail-closed contract.
+- Any other non-2xx outcome — including 400 with a different `error` code, malformed bodies, and
+  unclassified 4xx — also falls through to `access-denied` (401). Same rationale: refuse
   ambiguous responses rather than guessing at intent.
 - Malformed or temporally invalid passport after a successful exchange → 500
 

--- a/pkg/middleware/openapi/remote/authorizer.go
+++ b/pkg/middleware/openapi/remote/authorizer.go
@@ -175,8 +175,8 @@ func (a *Authorizer) authorizeOAuth2(r *http.Request, scope tokenExchangeOptions
 			return nil, errors.AccessDenied(r, "token is invalid or has expired")
 		}
 
-		// Scope refusal is authz, not authn — refresh-loop logic must not
-		// retry a wrong-scope request as if the token had expired.
+		// Scope refusal is authz; surface as 403 so callers do not retry
+		// as if the token had expired.
 		if goerrors.Is(err, ErrTokenExchangeForbidden) {
 			return nil, errors.HTTPForbidden("not authorized for the requested scope")
 		}

--- a/pkg/middleware/openapi/remote/authorizer.go
+++ b/pkg/middleware/openapi/remote/authorizer.go
@@ -175,6 +175,12 @@ func (a *Authorizer) authorizeOAuth2(r *http.Request, scope tokenExchangeOptions
 			return nil, errors.AccessDenied(r, "token is invalid or has expired")
 		}
 
+		// Scope refusal is authz, not authn — refresh-loop logic must not
+		// retry a wrong-scope request as if the token had expired.
+		if goerrors.Is(err, ErrTokenExchangeForbidden) {
+			return nil, errors.HTTPForbidden("not authorized for the requested scope")
+		}
+
 		return nil, errors.AccessDenied(r, "token exchange failed").WithError(err)
 	}
 

--- a/pkg/middleware/openapi/remote/authorizer_internal_test.go
+++ b/pkg/middleware/openapi/remote/authorizer_internal_test.go
@@ -491,9 +491,8 @@ func (s *stubTokenExchange) Exchange(_ context.Context, _ string, _ *tokenExchan
 	return "", s.err
 }
 
-// TestAuthorizeProjectsExchangeErrors pins the mapping from exchange sentinels
-// to API-edge error shapes. The 401/403 split is load-bearing: refresh-loop
-// logic depends on it to tell "bad token" from "wrong scope" apart.
+// TestAuthorizeProjectsExchangeErrors pins the exchange-sentinel → API-edge
+// error mapping so the 401/403 split cannot silently regress.
 func TestAuthorizeProjectsExchangeErrors(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/middleware/openapi/remote/authorizer_internal_test.go
+++ b/pkg/middleware/openapi/remote/authorizer_internal_test.go
@@ -517,6 +517,11 @@ func TestAuthorizeProjectsExchangeErrors(t *testing.T) {
 			exchangeErr:    ErrTokenExchangeFailed,
 			wantAccessDeny: true,
 		},
+		{
+			name:           "unavailable (5xx/transport) falls back to access denied",
+			exchangeErr:    ErrTokenExchangeUnavailable,
+			wantAccessDeny: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/middleware/openapi/remote/authorizer_internal_test.go
+++ b/pkg/middleware/openapi/remote/authorizer_internal_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	coreerrors "github.com/unikorn-cloud/core/pkg/server/errors"
 	"github.com/unikorn-cloud/core/pkg/util/cache"
 	"github.com/unikorn-cloud/identity/pkg/oauth2"
 	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
@@ -479,6 +480,71 @@ func TestCacheKeyedByTokenOnly(t *testing.T) {
 
 	assert.Equal(t, int32(1), exchange.calls.Load(),
 		"same bearer token should reuse cached passport claims across route scopes")
+}
+
+// stubTokenExchange returns a fixed error from Exchange.
+type stubTokenExchange struct {
+	err error
+}
+
+func (s *stubTokenExchange) Exchange(_ context.Context, _ string, _ *tokenExchangeOptions) (string, error) {
+	return "", s.err
+}
+
+// TestAuthorizeProjectsExchangeErrors pins the mapping from exchange sentinels
+// to API-edge error shapes. The 401/403 split is load-bearing: refresh-loop
+// logic depends on it to tell "bad token" from "wrong scope" apart.
+func TestAuthorizeProjectsExchangeErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		exchangeErr    error
+		wantForbidden  bool
+		wantAccessDeny bool
+	}{
+		{
+			name:           "401 from exchange becomes access denied",
+			exchangeErr:    ErrTokenExchangeUnauthorized,
+			wantAccessDeny: true,
+		},
+		{
+			name:          "forbidden sentinel from exchange becomes 403",
+			exchangeErr:   ErrTokenExchangeForbidden,
+			wantForbidden: true,
+		},
+		{
+			name:           "generic exchange failure falls back to access denied",
+			exchangeErr:    ErrTokenExchangeFailed,
+			wantAccessDeny: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			auth := newTestAuthorizer(&stubTokenExchange{err: tt.exchangeErr})
+
+			info, err := auth.Authorize(scopedAuthInput(t, "org-1", ""))
+			require.Error(t, err)
+			require.Nil(t, info)
+
+			if tt.wantForbidden {
+				assert.True(t, coreerrors.IsForbidden(err),
+					"forbidden sentinel must surface as a 403 at the API edge; got %v", err)
+				assert.False(t, coreerrors.IsAccessDenied(err),
+					"forbidden must not be conflated with access-denied")
+			}
+
+			if tt.wantAccessDeny {
+				assert.True(t, coreerrors.IsAccessDenied(err),
+					"authentication failures must surface as 401 access_denied; got %v", err)
+				assert.False(t, coreerrors.IsForbidden(err),
+					"authentication failures must not surface as 403")
+			}
+		})
+	}
 }
 
 // TestCacheHitWithinScope confirms repeated requests at the same scope still

--- a/pkg/middleware/openapi/remote/errors.go
+++ b/pkg/middleware/openapi/remote/errors.go
@@ -22,6 +22,12 @@ var (
 	// ErrTokenExchangeUnauthorized maps rejected source tokens to 401.
 	ErrTokenExchangeUnauthorized = errors.New("token exchange unauthorized")
 
+	// ErrTokenExchangeForbidden signals a valid subject token whose principal
+	// is not authorized for the requested scope. Identity emits this as
+	// 400 invalid_scope (RFC 6749 §5.2); the middleware projects it as 403
+	// at the API edge.
+	ErrTokenExchangeForbidden = errors.New("token exchange forbidden")
+
 	// ErrTokenExchangeUnavailable classifies transport and upstream availability failures.
 	ErrTokenExchangeUnavailable = errors.New("token exchange unavailable")
 

--- a/pkg/middleware/openapi/remote/errors.go
+++ b/pkg/middleware/openapi/remote/errors.go
@@ -22,10 +22,8 @@ var (
 	// ErrTokenExchangeUnauthorized maps rejected source tokens to 401.
 	ErrTokenExchangeUnauthorized = errors.New("token exchange unauthorized")
 
-	// ErrTokenExchangeForbidden signals a valid subject token whose principal
-	// is not authorized for the requested scope. Identity emits this as
-	// 400 invalid_scope (RFC 6749 §5.2); the middleware projects it as 403
-	// at the API edge.
+	// ErrTokenExchangeForbidden signals scope refusal from identity
+	// (400 invalid_scope, RFC 6749 §5.2); the middleware projects to 403.
 	ErrTokenExchangeForbidden = errors.New("token exchange forbidden")
 
 	// ErrTokenExchangeUnavailable classifies transport and upstream availability failures.

--- a/pkg/middleware/openapi/remote/token_exchange_http.go
+++ b/pkg/middleware/openapi/remote/token_exchange_http.go
@@ -117,8 +117,11 @@ func isInvalidScopeError(body []byte) bool {
 func decodeTokenExchangeResponse(resp *http.Response) (string, error) {
 	defer resp.Body.Close()
 
-	// Only 400 needs the body (RFC 6749 §5.2 error code). Cap the read
-	// here so the 200 path stream-decodes uncapped.
+	// The body is only needed on 400 — to distinguish RFC 6749 §5.2
+	// invalid_scope from other 400 error codes. The read is capped at
+	// errorBodySniffLimit (8 KiB) to bound exposure to a misbehaving or
+	// hostile upstream; the 200 path below stream-decodes uncapped so large
+	// passports (many org/project claims) are not truncated.
 	if resp.StatusCode == http.StatusBadRequest {
 		body, err := io.ReadAll(io.LimitReader(resp.Body, errorBodySniffLimit))
 		if err != nil {

--- a/pkg/middleware/openapi/remote/token_exchange_http.go
+++ b/pkg/middleware/openapi/remote/token_exchange_http.go
@@ -17,7 +17,6 @@ limitations under the License.
 package authorizer
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -87,9 +86,8 @@ func tokenExchangeForm(sourceToken string, options *tokenExchangeOptions) url.Va
 	return form
 }
 
-// classifyTokenExchangeStatus maps a token-endpoint response to the sentinel
-// the authorizer dispatches on. body is only consulted on 400, where the
-// RFC 6749 §5.2 error code distinguishes scope refusal from other failures.
+// classifyTokenExchangeStatus maps a token-endpoint status to the sentinel
+// the authorizer dispatches on. body is only consulted on 400.
 func classifyTokenExchangeStatus(statusCode int, body []byte) error {
 	switch {
 	case statusCode == http.StatusUnauthorized:
@@ -106,8 +104,7 @@ func classifyTokenExchangeStatus(statusCode int, body []byte) error {
 }
 
 // isInvalidScopeError returns true only for a parseable RFC 6749 §5.2 body
-// whose error code is invalid_scope. Malformed bodies fall through to
-// ErrTokenExchangeFailed in the caller.
+// with error code invalid_scope. Malformed bodies fall through.
 func isInvalidScopeError(body []byte) bool {
 	var oauthErr oauth2ErrorBody
 	if err := json.Unmarshal(body, &oauthErr); err != nil {
@@ -120,19 +117,23 @@ func isInvalidScopeError(body []byte) bool {
 func decodeTokenExchangeResponse(resp *http.Response) (string, error) {
 	defer resp.Body.Close()
 
-	// Read once: the classifier needs the body on 400, the success path needs
-	// it for access_token, and the response stream can only be drained once.
-	body, err := io.ReadAll(io.LimitReader(resp.Body, errorBodySniffLimit))
-	if err != nil {
-		return "", fmt.Errorf("%w: failed to read response body: %w", ErrTokenExchangeInvalidResponse, err)
+	// Only 400 needs the body (RFC 6749 §5.2 error code). Cap the read
+	// here so the 200 path stream-decodes uncapped.
+	if resp.StatusCode == http.StatusBadRequest {
+		body, err := io.ReadAll(io.LimitReader(resp.Body, errorBodySniffLimit))
+		if err != nil {
+			return "", fmt.Errorf("%w: failed to read response body: %w", ErrTokenExchangeInvalidResponse, err)
+		}
+
+		return "", classifyTokenExchangeStatus(http.StatusBadRequest, body)
 	}
 
-	if err := classifyTokenExchangeStatus(resp.StatusCode, body); err != nil {
+	if err := classifyTokenExchangeStatus(resp.StatusCode, nil); err != nil {
 		return "", err
 	}
 
 	var responseBody tokenExchangeResponse
-	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&responseBody); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&responseBody); err != nil {
 		return "", fmt.Errorf("%w: %w", ErrTokenExchangeInvalidResponse, err)
 	}
 

--- a/pkg/middleware/openapi/remote/token_exchange_http.go
+++ b/pkg/middleware/openapi/remote/token_exchange_http.go
@@ -17,9 +17,11 @@ limitations under the License.
 package authorizer
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -32,6 +34,13 @@ const (
 	tokenExchangeSubjectToken = "urn:ietf:params:oauth:token-type:access_token"
 	//nolint:gosec // OAuth token type URNs, not credentials.
 	tokenExchangeRequestedPassport = "urn:nscale:params:oauth:token-type:passport"
+
+	// RFC 6749 §5.2 error code identity returns for scope refusal.
+	oauth2ErrorInvalidScope = "invalid_scope"
+
+	// Token-endpoint error bodies are small JSON; the cap bounds the
+	// classifier's exposure to a misbehaving or hostile upstream.
+	errorBodySniffLimit = 8 * 1024
 )
 
 // HTTPTokenExchange exchanges source access tokens through an OAuth2 token endpoint.
@@ -42,6 +51,12 @@ type HTTPTokenExchange struct {
 
 type tokenExchangeResponse struct {
 	AccessToken string `json:"access_token"` //nolint:tagliatelle
+}
+
+// oauth2ErrorBody is the subset of the RFC 6749 §5.2 error shape consulted by
+// the classifier.
+type oauth2ErrorBody struct {
+	Error string `json:"error"`
 }
 
 // NewHTTPTokenExchange builds a token exchanger that performs RFC 8693 token exchange over HTTP.
@@ -72,10 +87,15 @@ func tokenExchangeForm(sourceToken string, options *tokenExchangeOptions) url.Va
 	return form
 }
 
-func classifyTokenExchangeStatus(statusCode int) error {
+// classifyTokenExchangeStatus maps a token-endpoint response to the sentinel
+// the authorizer dispatches on. body is only consulted on 400, where the
+// RFC 6749 §5.2 error code distinguishes scope refusal from other failures.
+func classifyTokenExchangeStatus(statusCode int, body []byte) error {
 	switch {
 	case statusCode == http.StatusUnauthorized:
 		return ErrTokenExchangeUnauthorized
+	case statusCode == http.StatusBadRequest && isInvalidScopeError(body):
+		return ErrTokenExchangeForbidden
 	case statusCode >= http.StatusInternalServerError:
 		return fmt.Errorf("%w: status code %d", ErrTokenExchangeUnavailable, statusCode)
 	case statusCode != http.StatusOK:
@@ -85,23 +105,42 @@ func classifyTokenExchangeStatus(statusCode int) error {
 	}
 }
 
+// isInvalidScopeError returns true only for a parseable RFC 6749 §5.2 body
+// whose error code is invalid_scope. Malformed bodies fall through to
+// ErrTokenExchangeFailed in the caller.
+func isInvalidScopeError(body []byte) bool {
+	var oauthErr oauth2ErrorBody
+	if err := json.Unmarshal(body, &oauthErr); err != nil {
+		return false
+	}
+
+	return oauthErr.Error == oauth2ErrorInvalidScope
+}
+
 func decodeTokenExchangeResponse(resp *http.Response) (string, error) {
 	defer resp.Body.Close()
 
-	if err := classifyTokenExchangeStatus(resp.StatusCode); err != nil {
+	// Read once: the classifier needs the body on 400, the success path needs
+	// it for access_token, and the response stream can only be drained once.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, errorBodySniffLimit))
+	if err != nil {
+		return "", fmt.Errorf("%w: failed to read response body: %w", ErrTokenExchangeInvalidResponse, err)
+	}
+
+	if err := classifyTokenExchangeStatus(resp.StatusCode, body); err != nil {
 		return "", err
 	}
 
-	var body tokenExchangeResponse
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+	var responseBody tokenExchangeResponse
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&responseBody); err != nil {
 		return "", fmt.Errorf("%w: %w", ErrTokenExchangeInvalidResponse, err)
 	}
 
-	if body.AccessToken == "" {
+	if responseBody.AccessToken == "" {
 		return "", ErrTokenExchangeMissingAccessToken
 	}
 
-	return body.AccessToken, nil
+	return responseBody.AccessToken, nil
 }
 
 // Exchange performs the RFC 8693 form-post against the configured token endpoint

--- a/pkg/middleware/openapi/remote/token_exchange_http_test.go
+++ b/pkg/middleware/openapi/remote/token_exchange_http_test.go
@@ -60,9 +60,21 @@ func TestExchangeClient(t *testing.T) {
 			expectErr: ErrTokenExchangeUnavailable,
 		},
 		{
-			name:      "returns failed sentinel on 400",
+			name:      "returns forbidden sentinel on 400 invalid_scope",
+			status:    http.StatusBadRequest,
+			body:      `{"error":"invalid_scope","error_description":"organization not in scope"}`,
+			expectErr: ErrTokenExchangeForbidden,
+		},
+		{
+			name:      "returns failed sentinel on other 400 oauth2 errors",
 			status:    http.StatusBadRequest,
 			body:      `{"error":"invalid_request"}`,
+			expectErr: ErrTokenExchangeFailed,
+		},
+		{
+			name:      "returns failed sentinel on 400 with malformed body",
+			status:    http.StatusBadRequest,
+			body:      `not-json`,
 			expectErr: ErrTokenExchangeFailed,
 		},
 		{

--- a/pkg/middleware/openapi/remote/token_exchange_http_test.go
+++ b/pkg/middleware/openapi/remote/token_exchange_http_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -139,6 +140,28 @@ func TestExchangeClient(t *testing.T) {
 			assert.Equal(t, "passport-token", passport)
 		})
 	}
+}
+
+// Regression: the error-body sniff cap must not apply to 200 — passports
+// with many claims (e.g. long org_ids list) would otherwise be truncated.
+func TestExchangeClientDecodesLargeSuccessBody(t *testing.T) {
+	t.Parallel()
+
+	// Comfortably larger than errorBodySniffLimit (8 KiB).
+	largePassport := strings.Repeat("a", 32*1024)
+	body := fmt.Sprintf(`{"access_token":%q}`, largePassport)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := fmt.Fprint(w, body)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client := NewHTTPTokenExchange(server.Client(), TokenExchangeURL(server.URL))
+	passport, err := client.Exchange(t.Context(), "raw-token", nil)
+	require.NoError(t, err)
+	assert.Equal(t, largePassport, passport)
 }
 
 func TestExchangeClientTimeout(t *testing.T) {

--- a/pkg/oauth2/README.md
+++ b/pkg/oauth2/README.md
@@ -107,6 +107,18 @@ embed an ACL. The exchange computes ACL only to authorize the requested organiza
 downstream services continue to resolve permissions through the normal remote authorizer path keyed
 off the passport-verified principal.
 
+Token-endpoint refusal preserves an authentication-vs-authorization split that downstream
+middleware projects to the API edge:
+
+- subject-token-related failures (missing, expired, malformed, principal not active) → `401`
+  `access_denied`
+- scope-related failures (valid subject token, but the principal is not a member of the requested
+  organization or project) → `400` `invalid_scope` per RFC 6749 section 5.2
+
+The 401/400 distinction is load-bearing for callers: it lets refresh-loop logic tell "your token is
+bad, reauthenticate" apart from "your token is fine, you don't have access to that scope". The
+remote middleware maps the latter to `403` `forbidden` at the downstream API edge.
+
 Passport exchange is intentionally handled by the existing `/oauth2/v2/token` endpoint rather than a
 separate route. Token-exchange parameters must be form-encoded in the POST body so credentials are not
 accepted from URL query strings.

--- a/pkg/oauth2/README.md
+++ b/pkg/oauth2/README.md
@@ -107,17 +107,13 @@ embed an ACL. The exchange computes ACL only to authorize the requested organiza
 downstream services continue to resolve permissions through the normal remote authorizer path keyed
 off the passport-verified principal.
 
-Token-endpoint refusal preserves an authentication-vs-authorization split that downstream
-middleware projects to the API edge:
+Token-endpoint refusals follow RFC 6749 §5.2:
 
-- subject-token-related failures (missing, expired, malformed, principal not active) → `401`
-  `access_denied`
-- scope-related failures (valid subject token, but the principal is not a member of the requested
-  organization or project) → `400` `invalid_scope` per RFC 6749 section 5.2
+- subject-token failures (missing, expired, malformed, principal not active) → `401 access_denied`
+- scope failures (valid subject token, principal not a member of the requested org/project) →
+  `400 invalid_scope`
 
-The 401/400 distinction is load-bearing for callers: it lets refresh-loop logic tell "your token is
-bad, reauthenticate" apart from "your token is fine, you don't have access to that scope". The
-remote middleware maps the latter to `403` `forbidden` at the downstream API edge.
+The remote middleware maps `invalid_scope` to `403 forbidden` at the API edge.
 
 Passport exchange is intentionally handled by the existing `/oauth2/v2/token` endpoint rather than a
 separate route. Token-exchange parameters must be form-encoded in the POST body so credentials are not

--- a/pkg/oauth2/README.md
+++ b/pkg/oauth2/README.md
@@ -109,7 +109,9 @@ off the passport-verified principal.
 
 Token-endpoint refusals follow RFC 6749 §5.2:
 
-- subject-token failures (missing, expired, malformed, principal not active) → `401 access_denied`
+- malformed token-exchange requests (missing or unsupported `subject_token` fields) →
+  `400 invalid_request`
+- presented subject-token failures (expired, malformed, principal not active) → `401 access_denied`
 - scope failures (valid subject token, principal not a member of the requested org/project) →
   `400 invalid_scope`
 

--- a/pkg/oauth2/errors/errors.go
+++ b/pkg/oauth2/errors/errors.go
@@ -136,18 +136,14 @@ func OAuth2InvalidClient(description string) *Error {
 	return newError(http.StatusBadRequest, openapi.InvalidClient, description)
 }
 
-// OAuth2AccessDenied indicates the subject token itself was rejected
-// (bad/expired credential, inactive principal). Use OAuth2InvalidScope for
-// scope refusals against an otherwise-valid token — the remote middleware
-// dispatches on the 401/400 split to keep authn and authz failures
-// distinguishable end to end.
+// OAuth2AccessDenied tells the client the authentication failed e.g.
+// username/password are wrong, or a token has expired and needs reauthentication.
 func OAuth2AccessDenied(description string) *Error {
 	return newError(http.StatusUnauthorized, openapi.AccessDenied, description)
 }
 
-// OAuth2InvalidScope indicates the subject token is valid but the requested
-// organization/project scope is not granted to the principal. See RFC 6749
-// section 5.2.
+// OAuth2InvalidScope tells the client it doesn't have the necessary scope
+// to access the resource.
 func OAuth2InvalidScope(description string) *Error {
 	return newError(http.StatusBadRequest, openapi.InvalidScope, description)
 }

--- a/pkg/oauth2/errors/errors.go
+++ b/pkg/oauth2/errors/errors.go
@@ -136,16 +136,20 @@ func OAuth2InvalidClient(description string) *Error {
 	return newError(http.StatusBadRequest, openapi.InvalidClient, description)
 }
 
-// OAuth2AccessDenied tells the client the authentication failed e.g.
-// username/password are wrong, or a token has expired and needs reauthentication.
+// OAuth2AccessDenied indicates the subject token itself was rejected
+// (bad/expired credential, inactive principal). Use OAuth2InvalidScope for
+// scope refusals against an otherwise-valid token — the remote middleware
+// dispatches on the 401/400 split to keep authn and authz failures
+// distinguishable end to end.
 func OAuth2AccessDenied(description string) *Error {
 	return newError(http.StatusUnauthorized, openapi.AccessDenied, description)
 }
 
-// OAuth2InvalidScope tells the client it doesn't have the necessary scope
-// to access the resource.
+// OAuth2InvalidScope indicates the subject token is valid but the requested
+// organization/project scope is not granted to the principal. See RFC 6749
+// section 5.2.
 func OAuth2InvalidScope(description string) *Error {
-	return newError(http.StatusUnauthorized, openapi.InvalidScope, description)
+	return newError(http.StatusBadRequest, openapi.InvalidScope, description)
 }
 
 // oAuth2ServerError tells the client we are at fault, this should never be seen

--- a/pkg/oauth2/passport.go
+++ b/pkg/oauth2/passport.go
@@ -304,7 +304,7 @@ func validateOrganizationScope(authz *openapi.AuthClaims, organizationID string)
 	// User principals also defer to RBAC because platform-administrator subjects
 	// are authorised by RBAC even when they are not members of the scoped
 	// organization. Ordinary users outside the organization are rejected by
-	// rbac.GetACL and normalized back to an OAuth2 access_denied response.
+	// rbac.GetACL and normalized back to an OAuth2 invalid_scope response.
 	if authz.Acctype == openapi.System || authz.Acctype == openapi.User {
 		return nil
 	}

--- a/pkg/oauth2/passport.go
+++ b/pkg/oauth2/passport.go
@@ -287,13 +287,18 @@ func passportExpiry(now time.Time, sourceClaims *Claims) (time.Time, error) {
 	return expiry, nil
 }
 
+// validateOrganizationScope rejects an exchange request whose scoped
+// organization is not reachable by the calling principal. Every rejection
+// path returns OAuth2InvalidScope (HTTP 400, RFC 6749 §5.2); the remote
+// middleware projects that to 403 forbidden at the API edge.
 func validateOrganizationScope(authz *openapi.AuthClaims, organizationID string) error {
 	if organizationID == "" {
 		return nil
 	}
 
 	// GetUserinfo normally populates authz for valid UNI tokens, but keep the
-	// nil guard so malformed or partially mocked callers still fail closed.
+	// nil guard so malformed or partially mocked callers fail closed with
+	// invalid_scope rather than panicking.
 	if authz == nil {
 		return errors.OAuth2InvalidScope("organization not in scope")
 	}
@@ -305,15 +310,18 @@ func validateOrganizationScope(authz *openapi.AuthClaims, organizationID string)
 	//   - User principals defer to RBAC because platform-administrator
 	//     subjects are authorised even when they are not members of the
 	//     scoped organization. Ordinary users outside the organization are
-	//     rejected downstream by rbac.GetACL, which the caller normalizes
-	//     into an OAuth2 invalid_scope response.
+	//     rejected downstream by rbac.GetACL (ErrNotInOrganization), which
+	//     the ExchangePassport caller re-wraps as OAuth2InvalidScope — so
+	//     the resulting wire response is identical to the early reject
+	//     below.
 	if authz.Acctype == openapi.System || authz.Acctype == openapi.User {
 		return nil
 	}
 
 	// Service accounts and other non-system/user principals carry an explicit
 	// organization membership list, so we can reject early on a mismatch
-	// without consulting RBAC.
+	// without consulting RBAC. Same wire response (invalid_scope) as the
+	// deferred RBAC path above.
 	if !slices.Contains(authz.OrgIds, organizationID) {
 		return errors.OAuth2InvalidScope("organization not in scope")
 	}

--- a/pkg/oauth2/passport.go
+++ b/pkg/oauth2/passport.go
@@ -298,17 +298,22 @@ func validateOrganizationScope(authz *openapi.AuthClaims, organizationID string)
 		return errors.OAuth2InvalidScope("organization not in scope")
 	}
 
-	// System principals do not carry explicit organization memberships in OrgIds.
-	// Their effective scope is derived from RBAC's system-account path instead.
-	//
-	// User principals also defer to RBAC because platform-administrator subjects
-	// are authorised by RBAC even when they are not members of the scoped
-	// organization. Ordinary users outside the organization are rejected by
-	// rbac.GetACL and normalized back to an OAuth2 invalid_scope response.
+	// System and user principals defer to RBAC and are not rejected here:
+	//   - System principals do not carry explicit organization memberships
+	//     in OrgIds; their effective scope is derived from RBAC's
+	//     system-account path.
+	//   - User principals defer to RBAC because platform-administrator
+	//     subjects are authorised even when they are not members of the
+	//     scoped organization. Ordinary users outside the organization are
+	//     rejected downstream by rbac.GetACL, which the caller normalizes
+	//     into an OAuth2 invalid_scope response.
 	if authz.Acctype == openapi.System || authz.Acctype == openapi.User {
 		return nil
 	}
 
+	// Service accounts and other non-system/user principals carry an explicit
+	// organization membership list, so we can reject early on a mismatch
+	// without consulting RBAC.
 	if !slices.Contains(authz.OrgIds, organizationID) {
 		return errors.OAuth2InvalidScope("organization not in scope")
 	}

--- a/pkg/oauth2/passport.go
+++ b/pkg/oauth2/passport.go
@@ -179,7 +179,7 @@ func (a *Authenticator) ExchangePassport(ctx context.Context, options *openapi.T
 				"organizationID", organizationID,
 			)
 
-			return nil, errors.OAuth2AccessDenied("organization not in scope").WithError(err)
+			return nil, errors.OAuth2InvalidScope("organization not in scope").WithError(err)
 		}
 
 		log.Error(err, "passport exchange failed: ACL computation failed",
@@ -295,7 +295,7 @@ func validateOrganizationScope(authz *openapi.AuthClaims, organizationID string)
 	// GetUserinfo normally populates authz for valid UNI tokens, but keep the
 	// nil guard so malformed or partially mocked callers still fail closed.
 	if authz == nil {
-		return errors.OAuth2AccessDenied("organization not in scope")
+		return errors.OAuth2InvalidScope("organization not in scope")
 	}
 
 	// System principals do not carry explicit organization memberships in OrgIds.
@@ -310,7 +310,7 @@ func validateOrganizationScope(authz *openapi.AuthClaims, organizationID string)
 	}
 
 	if !slices.Contains(authz.OrgIds, organizationID) {
-		return errors.OAuth2AccessDenied("organization not in scope")
+		return errors.OAuth2InvalidScope("organization not in scope")
 	}
 
 	return nil
@@ -604,7 +604,7 @@ func (a *Authenticator) validateProjectScope(ctx context.Context, acl *openapi.A
 	// the requested organization. Without the membership check, callers could
 	// inject an arbitrary project ID into the passport claims.
 	if !projectInACL(projectID, acl) && !hasBroaderScope(acl, organizationID) {
-		return errors.OAuth2AccessDenied("project not in scope")
+		return errors.OAuth2InvalidScope("project not in scope")
 	}
 
 	ok, err := a.projectInOrganization(ctx, organizationID, projectID)
@@ -613,7 +613,7 @@ func (a *Authenticator) validateProjectScope(ctx context.Context, acl *openapi.A
 	}
 
 	if !ok {
-		return errors.OAuth2AccessDenied("project not in scope")
+		return errors.OAuth2InvalidScope("project not in scope")
 	}
 
 	return nil

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -1291,7 +1291,7 @@ func TestExchangeRejectsNonFormContentType(t *testing.T) {
 	require.ErrorAs(t, err, &oauthErr)
 }
 
-func TestExchangeHandlerOutOfScopeOrganizationReturnsAccessDenied(t *testing.T) {
+func TestExchangeHandlerOutOfScopeOrganizationReturnsInvalidScope(t *testing.T) {
 	t.Parallel()
 
 	env := setupPassportTestEnv(t,
@@ -1335,11 +1335,11 @@ func TestExchangeHandlerOutOfScopeOrganizationReturnsAccessDenied(t *testing.T) 
 		require.NoError(t, resp.Body.Close())
 	})
 
-	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	var oauthResp openapi.Oauth2Error
 
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&oauthResp))
-	assert.Equal(t, openapi.AccessDenied, oauthResp.Error)
+	assert.Equal(t, openapi.InvalidScope, oauthResp.Error)
 	assert.Contains(t, oauthResp.ErrorDescription, "organization not in scope")
 }

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -515,8 +515,11 @@ func TestExchangeWithOrgScope(t *testing.T) {
 }
 
 // TestExchangeInvalidProjectID exercises the token-endpoint layer directly via
-// Authenticator.TokenExchange. The remote middleware projects invalid_scope to
-// 403 at the API edge; that mapping is covered by the authorizer tests.
+// Authenticator.TokenExchange. The assertions below pin the contract at that
+// layer: HTTP 400 + RFC 6749 §5.2 error=invalid_scope. The remote middleware
+// projects that to 403 forbidden at the API edge — that hop is covered by
+// TestAuthorizeProjectsExchangeErrors in pkg/middleware/openapi/remote, not
+// here.
 func TestExchangeInvalidProjectID(t *testing.T) {
 	t.Parallel()
 
@@ -585,7 +588,9 @@ func TestExchangeInvalidProjectID(t *testing.T) {
 }
 
 // TestExchangeInvalidOrganizationID exercises the token-endpoint layer
-// directly. See TestExchangeInvalidProjectID for the layer/contract note.
+// directly. The 400 + invalid_scope assertions are the token-endpoint
+// contract; the middleware's 403 projection is exercised by
+// TestAuthorizeProjectsExchangeErrors in pkg/middleware/openapi/remote.
 func TestExchangeInvalidOrganizationID(t *testing.T) {
 	t.Parallel()
 
@@ -766,7 +771,9 @@ func TestExchangeServiceAccount(t *testing.T) {
 }
 
 // TestExchangeServiceAccountWrongOrganization exercises the token-endpoint
-// layer directly. See TestExchangeInvalidProjectID for the layer/contract note.
+// layer directly. The 400 + invalid_scope assertions are the token-endpoint
+// contract; the middleware's 403 projection is exercised by
+// TestAuthorizeProjectsExchangeErrors in pkg/middleware/openapi/remote.
 func TestExchangeServiceAccountWrongOrganization(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -573,6 +573,12 @@ func TestExchangeInvalidProjectID(t *testing.T) {
 	_, err := env.authenticator.TokenExchange(nil, req)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "project not in scope")
+
+	var oauthErr *oauth2errors.Error
+
+	require.ErrorAs(t, err, &oauthErr)
+	assert.Equal(t, http.StatusBadRequest, oauthErr.StatusCode())
+	assert.Equal(t, openapi.InvalidScope, oauthErr.Code())
 }
 
 func TestExchangeInvalidOrganizationID(t *testing.T) {
@@ -636,6 +642,8 @@ func TestExchangeInvalidOrganizationID(t *testing.T) {
 	var oauthErr *oauth2errors.Error
 
 	require.ErrorAs(t, err, &oauthErr)
+	assert.Equal(t, http.StatusBadRequest, oauthErr.StatusCode())
+	assert.Equal(t, openapi.InvalidScope, oauthErr.Code())
 }
 
 func TestExchangePlatformAdminUserWithOrganizationScopeOutsideMembership(t *testing.T) {
@@ -808,6 +816,8 @@ func TestExchangeServiceAccountWrongOrganization(t *testing.T) {
 	var oauthErr *oauth2errors.Error
 
 	require.ErrorAs(t, err, &oauthErr)
+	assert.Equal(t, http.StatusBadRequest, oauthErr.StatusCode())
+	assert.Equal(t, openapi.InvalidScope, oauthErr.Code())
 }
 
 func TestExchangeSystemAccountWithOrganizationScope(t *testing.T) {

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -514,6 +514,9 @@ func TestExchangeWithOrgScope(t *testing.T) {
 	assert.Equal(t, "project1", claims.ProjectID)
 }
 
+// TestExchangeInvalidProjectID exercises the token-endpoint layer directly via
+// Authenticator.TokenExchange. The remote middleware projects invalid_scope to
+// 403 at the API edge; that mapping is covered by the authorizer tests.
 func TestExchangeInvalidProjectID(t *testing.T) {
 	t.Parallel()
 
@@ -581,6 +584,8 @@ func TestExchangeInvalidProjectID(t *testing.T) {
 	assert.Equal(t, openapi.InvalidScope, oauthErr.Code())
 }
 
+// TestExchangeInvalidOrganizationID exercises the token-endpoint layer
+// directly. See TestExchangeInvalidProjectID for the layer/contract note.
 func TestExchangeInvalidOrganizationID(t *testing.T) {
 	t.Parallel()
 
@@ -760,6 +765,8 @@ func TestExchangeServiceAccount(t *testing.T) {
 	assert.ElementsMatch(t, []string{"test-org"}, claims.OrgIDs)
 }
 
+// TestExchangeServiceAccountWrongOrganization exercises the token-endpoint
+// layer directly. See TestExchangeInvalidProjectID for the layer/contract note.
 func TestExchangeServiceAccountWrongOrganization(t *testing.T) {
 	t.Parallel()
 

--- a/test/api/suites/passport_test.go
+++ b/test/api/suites/passport_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Passport Token Exchange", func() {
 		})
 
 		Describe("Given an out-of-scope organization", func() {
-			It("should reject the exchange with an OAuth2 access_denied response", func() {
+			It("should reject the exchange with an OAuth2 invalid_scope response", func() {
 				invalidOrgID := "00000000-0000-0000-0000-000000000000"
 				options := &identityopenapi.TokenRequestOptions{
 					XOrganizationId: &invalidOrgID,
@@ -157,16 +157,16 @@ var _ = Describe("Passport Token Exchange", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp).NotTo(BeNil())
-				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 
 				oauthErr := decodeExchangeOAuth2Error(respBody)
-				Expect(oauthErr.Error).To(Equal(identityopenapi.AccessDenied))
+				Expect(oauthErr.Error).To(Equal(identityopenapi.InvalidScope))
 				Expect(oauthErr.ErrorDescription).To(ContainSubstring("organization not in scope"))
 			})
 		})
 
 		Describe("Given an invalid project scope", func() {
-			It("should reject the exchange with an OAuth2 access_denied response", func() {
+			It("should reject the exchange with an OAuth2 invalid_scope response", func() {
 				invalidProjectID := "00000000-0000-0000-0000-000000000000"
 				options := &identityopenapi.TokenRequestOptions{
 					XOrganizationId: &config.OrgID,
@@ -177,10 +177,10 @@ var _ = Describe("Passport Token Exchange", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp).NotTo(BeNil())
-				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 
 				oauthErr := decodeExchangeOAuth2Error(respBody)
-				Expect(oauthErr.Error).To(Equal(identityopenapi.AccessDenied))
+				Expect(oauthErr.Error).To(Equal(identityopenapi.InvalidScope))
 				Expect(oauthErr.ErrorDescription).To(ContainSubstring("project not in scope"))
 			})
 		})


### PR DESCRIPTION
## Summary

After the passport exchange phase landed (#490, shipped in v1.17.0), scope refusals during token exchange were surfacing as `401 access_denied` — indistinguishable from a rejected subject token. Caller-side refresh-loop logic cannot tell "your token is bad, reauthenticate" apart from "your token is fine, you don't have access to that scope" when both arrive as 401.

This change:

- Identity returns `400 invalid_scope` (RFC 6749 §5.2) when a valid subject token requests an organization or project the principal is not a member of.
- The remote middleware (`pkg/middleware/openapi/remote`) classifies the token-endpoint response and projects `invalid_scope` to `403 forbidden` at the downstream API edge, while keeping bad-token failures as `401 access_denied`.
- Adds a new `ErrTokenExchangeForbidden` sentinel and a unit test that pins the 401-vs-403 mapping in the authorizer, plus token-exchange HTTP coverage for the `invalid_scope` / malformed-body cases.
- Documents the authn-vs-authz split in `pkg/oauth2/README.md` and `pkg/middleware/openapi/README.md`.

## Why this was caught

The uni-region dependency bump https://github.com/nscaledev/uni-region/pull/531 (bumping `unikorn-cloud/identity` to v1.17.0) fails its Integration suite on:

> `Region Discovery > When listing regions > Given invalid parameters > should reject requests with invalid organization ID format`
> ([regions_test.go:78](https://github.com/nscaledev/uni-region/blob/deps/bump-identity-v1.17.0/test/api/suites/regions_test.go#L78))

The test asserts the error body contains `"forbidden"`, but with v1.17.0 it received:

```
{"error":"access_denied","error_description":"token is invalid or has expired"}
```

That is the regression introduced by the passport phase: a previously-`forbidden` (403) scope refusal became `access_denied` (401). This PR aligns identity back with the behaviour uni-region (and other downstream callers) were already relying on, and locks in the distinction at the OAuth2 layer per RFC 6749 §5.2 so it cannot silently regress again.

## Test plan

- [x] `make touch && make license && make validate && make lint`
- [x] `make generate` (tree clean)
- [x] `make test-unit` — new coverage in `pkg/middleware/openapi/remote/authorizer_internal_test.go` and `token_exchange_http_test.go`, updated assertion in `pkg/oauth2/passport_test.go`
- [ ] Re-run uni-region#531 against this branch to confirm the failing Integration spec passes