### PR TITLE
version v1.17.1

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: 1.17.0
-appVersion: 1.17.0
+version: 1.17.1
+appVersion: 1.17.1
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 


### PR DESCRIPTION
Bump identity chart version/appVersion to 1.17.1 for the v1.17.1 release.

Includes the post-1.17.0 fix already on main (#494, map passport-exchange scope refusals to invalid_scope).

After merge, tag `v1.17.1` on the merge commit.