### PR TITLE
feat(oauth2): exchange Auth0 access tokens for UNI passports

### DIFF
--- a/charts/identity/templates/identity/deployment.yaml
+++ b/charts/identity/templates/identity/deployment.yaml
@@ -24,6 +24,14 @@ spec:
         - --host=https://{{ include "unikorn.identity.host" . }}
         - --jose-tls-secret={{ .Release.Name }}-jose-tls
         - --refresh-token-duration={{ printf "%dh" (mul .Values.issuer.maxTokenDurationDays 24) }}
+        {{- with .Values.identity.auth0Exchange }}
+        {{- if .issuer }}
+        - --auth0-exchange-issuer={{ .issuer }}
+        {{- end }}
+        {{- if .audience }}
+        - --auth0-exchange-audience={{ .audience }}
+        {{- end }}
+        {{- end }}
         {{- $adminRoles := list }}
         {{- range $index, $name := .Values.platformAdministrators.roles }}
           {{- $adminRoles = append $adminRoles (include "resource.id" $name) }}

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -63,6 +63,11 @@ projectController:
 # oauth2 issuer etc.
 identity:
   host: identity.acme.org
+  # Auth0 access tokens from this issuer/audience may be exchanged for UNI
+  # passports. Leave unset to disable Auth0 token exchange.
+  auth0Exchange:
+    issuer: ~
+    audience: ~
 
 # Issuer related configuration.
 issuer:

--- a/docs/passport-exchange-providers.md
+++ b/docs/passport-exchange-providers.md
@@ -1,0 +1,236 @@
+# Generic Passport Exchange — Design Note
+
+Status: draft for discussion
+Owner: @nscale-peter
+Last updated: 2026-06-01
+
+## Problem
+
+The passport token-exchange endpoint currently accepts subject tokens from two
+sources:
+
+- UNI-issued access tokens (validated via `GetUserinfo`)
+- Auth0 access tokens (validated via `pkg/oauth2/auth0`, gated by
+  `--auth0-exchange-issuer` / `--auth0-exchange-audience`)
+
+The Auth0 path was the first concrete external-IdP integration. The validator
+itself is mostly generic OIDC — but the package name, the passport `source`
+label, the CLI flags, and the chart values all bake `auth0` into the codebase.
+We want identity to be able to accept exchanges from any OIDC-compliant IdP
+(Okta, Cognito, Entra, a self-hosted dex, …) without further code changes —
+purely through configuration.
+
+## What is actually Auth0-specific today
+
+Walking the current implementation against the requirement:
+
+| Concern | Auth0-specific? | Notes |
+|---|---|---|
+| JWKS fetch (`/.well-known/jwks.json`) | No | Standard OIDC discovery convention. |
+| Signature, `iss`, `aud`, temporal claim validation | No | Pure OIDC. |
+| `email` + `email_verified` requirement | No | Reasonable for any IdP that proves a human identity. |
+| `https://unikorn-cloud.org/authz` claim sanity check | No, but contract-specific | UNI-defined claim. Could be emitted by any IdP that supports custom claims. Not actually load-bearing — see below. |
+| Org membership lookup by email | No | UNI is authoritative; claimed `orgIds` are discarded. |
+| Package name `pkg/oauth2/auth0` | Yes | Cosmetic. |
+| Passport `source = "auth0"` | Yes | Hard-coded. |
+| CLI flags `--auth0-exchange-{issuer,audience}` | Yes | Single-tenant only. |
+| Chart values `identity.auth0Exchange.{issuer,audience}` | Yes | Single-tenant only. |
+
+Net: the validator is ~95% generic. The remaining ~5% is naming and a
+single-tenant config surface. The UNI authz claim is *checked* but its
+`orgIds` are discarded; only the presence-and-shape sanity check influences
+acceptance. We can either keep that as an opt-in contract or drop it.
+
+## Federation vs. exchange: same provider, different capability
+
+The existing `OAuth2Provider` CRD already represents an external IdP. A
+reasonable first question is "isn't exchange just another OIDC provider
+registration?". It's not — they describe the same IdP but bind UNI to it in
+two different roles, with two different trust models. That's why the design
+adds a separate `tokenExchange` block rather than re-using the existing
+fields.
+
+| | Federation (today) | Exchange (new) |
+|---|---|---|
+| UNI role | OAuth2 *client* | *Resource server* |
+| Token type | `id_token` (with nonce, redirect, PKCE) | access token |
+| `aud` semantics | UNI's `client_id` | UNI's advertised exchange audience |
+| Credentials needed | `client_id` + `client_secret` | none — JWKS only |
+| Trust attestation | UNI drove the flow end-to-end | IdP minted a token UNI did not directly request |
+| Audience controlled by | UNI (its client registration) | IdP operator (when the token was minted) |
+
+The key implication is that **federation trust does not transitively imply
+exchange trust**. An Auth0 tenant configured for federated login attests to
+"this person authenticated to UNI's client". The same tenant can also mint
+access tokens for unrelated audiences — e.g. an internal analytics API —
+where UNI was never the intended recipient. Accepting those at the exchange
+endpoint would be a confused-deputy: UNI would be honouring an attestation
+that was never about UNI.
+
+Concretely this is why `tokenExchange.enabled` and `tokenExchange.audience`
+are mandatory and independent of the federation config:
+
+- `enabled` is the operator's explicit statement that *this IdP is allowed to
+  attest user identity to UNI's exchange endpoint*, separately from whether
+  it's allowed to drive browser logins.
+- `audience` is the value UNI requires in the `aud` claim — typically a URI
+  identifying UNI's exchange API, distinct from the federation `client_id`.
+  This is what stops tokens minted for unrelated audiences from being
+  replayed at the exchange endpoint.
+
+Same CRD object (one provider, one record), two capabilities, each with its
+own opt-in.
+
+## Proposed design
+
+### 1. Extend `OAuth2Provider` CRD with an exchange block
+
+Add an optional `tokenExchange` block to `OAuth2ProviderSpec`:
+
+```yaml
+apiVersion: identity.unikorn-cloud.org/v1alpha1
+kind: OAuth2Provider
+metadata:
+  name: auth0-prod
+spec:
+  type: custom
+  issuer: https://nscale.eu.auth0.com/
+  # existing fields (clientID, clientSecret*, etc.) unchanged
+  tokenExchange:
+    enabled: true                     # explicit opt-in, default false
+    audience: https://identity.nscale.com
+    # optional: claim contract
+    requireAuthzClaim: true           # default false; require UNI authz claim
+    requireVerifiedEmail: true        # default true
+    # optional: which signing algs the IdP is allowed to use
+    signingAlgorithms: [RS256]        # default [RS256]
+```
+
+Existing providers without `tokenExchange` are not exchange-eligible. This is
+the explicit-opt-in we need for the trust model (see below).
+
+### 2. Dispatch by issuer at exchange time
+
+Replace the current `if isCompactJWS && a.auth0Validator != nil` branch with:
+
+1. If the subject token is a compact JWS, peek at the unverified `iss` claim
+   (header.payload split — *no signature trust yet*).
+2. Look up an `OAuth2Provider` in the identity namespace whose `spec.issuer`
+   matches and whose `spec.tokenExchange.enabled` is true.
+3. Run the generic validator against that provider's `issuer` / `audience` /
+   claim contract.
+4. If no provider matches, fall through to the existing UNI userinfo path
+   (which will reject foreign tokens as it does today).
+
+The unverified `iss` peek is safe because it only selects *which* keyset to
+verify against — actual trust still comes from JWKS-validated signature plus
+`iss`/`aud` equality.
+
+### 3. Rename and generalize the validator package
+
+- Rename `pkg/oauth2/auth0` → `pkg/oauth2/external` (or fold into
+  `pkg/oauth2/oidc`).
+- Drop the `auth0`-named constants and replace with parameterized
+  `ExchangeOptions` derived from the matched `OAuth2Provider`.
+- Drop the `--auth0-exchange-*` flags and the
+  `identity.auth0Exchange` chart values. The validator is constructed
+  per-request (or per-provider, cached) from CRD state, not from process
+  flags.
+
+### 4. Stamp passport `source` from the provider
+
+`passport.source` becomes the `OAuth2Provider` resource name (e.g. `auth0-prod`,
+`okta-staging`). That keeps audit logs and downstream RBAC inspection
+informative without coupling them to a specific vendor.
+
+`PassportSourceUNI` stays as-is for the in-house path.
+
+### 5. JWKS caching
+
+Today the Auth0 validator builds a `gooidc.RemoteKeySet` lazily, once. With
+multiple providers we want one keyset per provider, cached. The remote keyset
+already handles rotation/refresh; we just need a `map[providerName]*Validator`
+on the authenticator with cache invalidation when the CRD changes (a watch on
+`OAuth2Provider` would handle this — same mechanism the federated-login flow
+uses today).
+
+## Trust model
+
+The hard part isn't the code — it's making sure operators can't accidentally
+trust the wrong IdP.
+
+- **Explicit opt-in.** `tokenExchange.enabled` defaults to `false`. A provider
+  configured only for federated login does *not* automatically accept exchange.
+- **Audience binding.** `tokenExchange.audience` is required when enabled.
+  Identity will only accept tokens whose `aud` matches — this prevents a
+  legitimate Auth0 token issued for an unrelated API from being replayed at
+  the exchange endpoint.
+- **Claim contract documented.** We need a single page (probably under
+  `docs/`) that specifies the contract any IdP must satisfy to be
+  exchange-eligible: required claims, normalization rules (we lowercase
+  `email`), how membership is resolved (always via UNI, never trust the
+  token's claimed orgs), and what happens when the optional UNI authz claim
+  is or isn't present.
+- **Email-verified required by default.** Operators can opt out per provider
+  but the default is "verified or reject".
+- **No wildcard issuers.** Issuer match is exact-string against
+  `spec.issuer`. We do not accept `iss` values that "look like" a known
+  provider.
+
+## Migration path
+
+1. Ship the generic implementation behind the new CRD field. The legacy
+   `--auth0-exchange-*` flags continue to work and are mapped internally to a
+   synthetic `OAuth2Provider` named `auth0-legacy`. (Or: gate this whole
+   change behind a feature flag and ship CRD-only from day one — see open
+   questions.)
+2. Update the chart so `identity.auth0Exchange.*` values render an
+   `OAuth2Provider` with `tokenExchange.enabled: true` instead of CLI flags.
+3. Mark the flags deprecated in a release; remove in the following one.
+
+This is expand-contract: the CRD field is purely additive in v1, and the
+deprecation of flags is a separate step.
+
+## Open questions
+
+1. **Feature flag vs. parallel deployment.** Do we want to keep
+   `--auth0-exchange-*` working through one release (lower risk, slightly
+   more code) or hard-cut to CRD on day one (cleaner, requires deployment
+   coordination)?
+2. **Per-provider rate limiting.** Today there's nothing stopping a misconfigured
+   IdP from being hammered. Probably out of scope for v1 but worth a stub.
+3. **What does `type: custom` mean for federation today?** If we keep the
+   existing enum (`google`, `microsoft`, `github`, `custom`) we need to
+   decide whether `tokenExchange` is valid for all of them or only `custom`.
+   I think: valid for all — exchange acceptance is independent of how the
+   provider is used for browser-based federation.
+4. **Should the UNI authz claim be required, optional, or removed?** It's not
+   load-bearing today. Argument for keeping it: defense-in-depth — an Auth0
+   tenant that hasn't been configured with the UNI Action shouldn't be
+   accidentally exchange-eligible. Argument against: extra coupling for
+   IdPs that can't easily emit custom claims.
+5. **Multi-audience.** Auth0 supports multiple audiences in one token.
+   Today we check a single audience. Should the CRD accept a list?
+
+## Out of scope
+
+- Federated login flow refactoring. The existing `providers` package handles
+  browser-based OIDC and is independently configurable. This design only
+  affects the token-exchange endpoint.
+- Service account or service-to-service token issuance.
+- Revocation / introspection of exchanged passports beyond the existing
+  expiry-cap rules.
+
+## Concrete code-touch estimate
+
+- `pkg/apis/unikorn/v1alpha1/types.go` + CRD regen — small.
+- `pkg/oauth2/auth0` → `pkg/oauth2/external` rename + parameterization — small.
+- `pkg/oauth2/passport.go` dispatcher — small.
+- `pkg/oauth2/oauth2.go` validator construction moves from flags to a
+  CRD-watching cache — medium.
+- `charts/identity` values plumbing — small.
+- Tests: extend `passport_test.go` to cover multiple providers and
+  CRD-driven dispatch — medium.
+- Docs: claim-contract page + update to `pkg/oauth2/README.md` — small.
+
+Total: a focused two- to three-PR change, not a multi-week effort.

--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -344,12 +344,16 @@ func issueUserToken(ctx context.Context, k8s client.Client, namespace, baseURL, 
 	}
 
 	jwtIssuer := jose.NewJWTIssuer(k8s, namespace, &jose.Options{})
-	authenticator := oauth2.New(&oauth2.Options{
+	authenticator, err := oauth2.New(&oauth2.Options{
 		AccessTokenDuration:  time.Hour,
 		RefreshTokenDuration: time.Hour,
 		TokenCacheSize:       8192,
 		CodeCacheSize:        8192,
 	}, namespace, issuer, k8s, jwtIssuer, nil, nil)
+
+	if err != nil {
+		fatalf("failed to create authenticator: %v", err)
+	}
 
 	tokens, err := authenticator.Issue(ctx, &oauth2.IssueInfo{
 		Issuer:   issuer.URL,

--- a/pkg/middleware/openapi/remote/authorizer_test.go
+++ b/pkg/middleware/openapi/remote/authorizer_test.go
@@ -337,7 +337,8 @@ func setupTestEnvironment(t *testing.T) (client.Client, *server, string) {
 
 	userdb := userdb.NewUserDatabase(fakeClient, testNamespace)
 
-	authenticator = oauth2.New(oauth2Options, testNamespace, iss, fakeClient, issuer, userdb, rbacClient)
+	authenticator, err = oauth2.New(oauth2Options, testNamespace, iss, fakeClient, issuer, userdb, rbacClient)
+	require.NoError(t, err)
 
 	// Issue a test token
 	ctx := t.Context()

--- a/pkg/oauth2/README.md
+++ b/pkg/oauth2/README.md
@@ -125,6 +125,26 @@ This keeps room for alternate authentication frontends to complement this packag
 it: external authentication can happen outside identity, while identity remains the issuer of the
 internal token shape consumed by downstream UNI services.
 
+### Source-token types
+
+The `subject_token` presented to passport exchange may be either:
+
+- a UNI-issued access token, validated through `GetUserinfo` against the local user database, or
+- an Auth0 access-token JWT, validated through `pkg/oauth2/auth0` against the Auth0 tenant JWKS.
+
+The Auth0 path is opt-in and requires both `--auth0-exchange-issuer` and `--auth0-exchange-audience`
+to be set; partial configuration fails closed at startup. When only one of the two is set, the
+identity process refuses to start. When neither is set, Auth0 tokens are not accepted and the
+existing UNI path is unaffected.
+
+For Auth0 tokens, validation covers signature, issuer, audience, temporal claims, verified email,
+and the UNI authorization claim emitted by the Auth0 post-login Action (`acctype` and non-empty
+`orgIds`). The claimed `orgIds` are required as a signal that the Action ran but are intentionally
+not used as organization membership: UNI's user database remains authoritative for which
+organizations a principal belongs to. The minted passport's `source` claim records whether the
+exchange originated from a UNI or Auth0 subject token, and the passport expiry is capped at the
+source token's `exp` so a passport never outlives the proof of identity that produced it.
+
 ## Caveats
 
 - The package mixes protocol handling, provider integration, local session persistence, local user

--- a/pkg/oauth2/README.md
+++ b/pkg/oauth2/README.md
@@ -139,7 +139,11 @@ existing UNI path is unaffected.
 
 For Auth0 tokens, validation covers signature, issuer, audience, temporal claims, verified email,
 and the UNI authorization claim emitted by the Auth0 post-login Action (`acctype` and non-empty
-`orgIds`). The claimed `orgIds` are required as a signal that the Action ran but are intentionally
+`orgIds`). Because Auth0 only places the standard `email`/`email_verified` claims on the ID token —
+and a post-login Action cannot set bare, non-namespaced claims on the access token — the Action
+surfaces them on the access token as the namespaced `https://unikorn-cloud.org/email` and
+`https://unikorn-cloud.org/email_verified` claims, which is where this validator reads them from.
+The claimed `orgIds` are required as a signal that the Action ran but are intentionally
 not used as organization membership: UNI's user database remains authoritative for which
 organizations a principal belongs to. The minted passport's `source` claim records whether the
 exchange originated from a UNI or Auth0 subject token, and the passport expiry is capped at the

--- a/pkg/oauth2/auth0/validator.go
+++ b/pkg/oauth2/auth0/validator.go
@@ -67,9 +67,14 @@ type authzClaims struct {
 type tokenClaims struct {
 	jwt.Claims
 
-	Email string `json:"email"`
+	// Auth0 only emits the standard email claims on the ID token, and a
+	// PostLogin action cannot set bare (non-namespaced) claims on the access
+	// token, so the enrich-token-claims action surfaces them under the
+	// unikorn-cloud.org namespace where this access-token validator reads them.
 	//nolint:tagliatelle
-	EmailVerified *bool `json:"email_verified"`
+	Email string `json:"https://unikorn-cloud.org/email"`
+	//nolint:tagliatelle
+	EmailVerified *bool `json:"https://unikorn-cloud.org/email_verified"`
 	//nolint:tagliatelle
 	Authz authzClaims `json:"https://unikorn-cloud.org/authz"`
 }

--- a/pkg/oauth2/auth0/validator.go
+++ b/pkg/oauth2/auth0/validator.go
@@ -67,9 +67,11 @@ type authzClaims struct {
 type tokenClaims struct {
 	jwt.Claims
 
-	Email         string      `json:"email"`
-	EmailVerified *bool       `json:"email_verified"`
-	Authz         authzClaims `json:"https://unikorn-cloud.org/authz"`
+	Email string `json:"email"`
+	//nolint:tagliatelle
+	EmailVerified *bool `json:"email_verified"`
+	//nolint:tagliatelle
+	Authz authzClaims `json:"https://unikorn-cloud.org/authz"`
 }
 
 // User is the validated identity extracted from an Auth0 access token.
@@ -89,9 +91,10 @@ type Validator struct {
 }
 
 // NewValidator returns a validator using the Auth0 tenant JWKS endpoint.
+// It returns ErrDisabled when no Auth0 exchange configuration is supplied.
 func NewValidator(options Options) (*Validator, error) {
 	if !options.Enabled() {
-		return nil, nil
+		return nil, ErrDisabled
 	}
 
 	if options.Issuer == "" || options.Audience == "" {

--- a/pkg/oauth2/auth0/validator.go
+++ b/pkg/oauth2/auth0/validator.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth0
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	gooidc "github.com/coreos/go-oidc/v3/oidc"
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+const (
+	// AuthzClaimName is the UNI authorization context claim emitted by the
+	// Auth0 post-login Action.
+	AuthzClaimName = "https://unikorn-cloud.org/authz"
+
+	accountTypeUser = "user"
+)
+
+var (
+	ErrDisabled          = errors.New("auth0 exchange validation is disabled")
+	ErrInvalidConfig     = errors.New("invalid auth0 exchange config")
+	ErrInvalidToken      = errors.New("invalid auth0 token")
+	ErrEmailUnverified   = errors.New("auth0 email is not verified")
+	ErrMissingEmail      = errors.New("auth0 email is missing")
+	ErrInvalidAuthzClaim = errors.New("invalid auth0 authz claim")
+)
+
+// Options configures Auth0 access-token validation for passport exchange.
+type Options struct {
+	Issuer                    string
+	Audience                  string
+	TokenVerificationLeeway   time.Duration
+	SupportedSigningAlgorithm string
+}
+
+// Enabled reports whether Auth0 exchange validation has enough configuration
+// to run.
+func (o Options) Enabled() bool {
+	return o.Issuer != "" || o.Audience != ""
+}
+
+type authzClaims struct {
+	Acctype string   `json:"acctype"`
+	OrgIDs  []string `json:"orgIds"`
+}
+
+type tokenClaims struct {
+	jwt.Claims
+
+	Email         string      `json:"email"`
+	EmailVerified *bool       `json:"email_verified"`
+	Authz         authzClaims `json:"https://unikorn-cloud.org/authz"`
+}
+
+// User is the validated identity extracted from an Auth0 access token.
+type User struct {
+	Email         string
+	Expiry        time.Time
+	ClaimedOrgIDs []string
+}
+
+// Validator validates Auth0 JWT access tokens using the tenant JWKS.
+type Validator struct {
+	options Options
+	now     func() time.Time
+
+	mu       sync.Mutex
+	verifier *gooidc.IDTokenVerifier
+}
+
+// NewValidator returns a validator using the Auth0 tenant JWKS endpoint.
+func NewValidator(options Options) (*Validator, error) {
+	if !options.Enabled() {
+		return nil, nil
+	}
+
+	if options.Issuer == "" || options.Audience == "" {
+		return nil, fmt.Errorf("%w: issuer and audience must both be specified", ErrInvalidConfig)
+	}
+
+	if options.SupportedSigningAlgorithm == "" {
+		options.SupportedSigningAlgorithm = "RS256"
+	}
+
+	return &Validator{
+		options: options,
+		now:     time.Now,
+	}, nil
+}
+
+// Validate verifies the token signature, issuer, audience, temporal claims,
+// verified email, and UNI authorization context emitted by Auth0.
+func (v *Validator) Validate(ctx context.Context, token string) (*User, error) {
+	if v == nil {
+		return nil, ErrDisabled
+	}
+
+	idToken, err := v.getVerifier(ctx).Verify(ctx, token)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidToken, err)
+	}
+
+	claims := &tokenClaims{}
+	if err := idToken.Claims(claims); err != nil {
+		return nil, fmt.Errorf("%w: failed to parse claims: %w", ErrInvalidToken, err)
+	}
+
+	expected := jwt.Expected{
+		Issuer: v.options.Issuer,
+		AnyAudience: jwt.Audience{
+			v.options.Audience,
+		},
+		Time: v.now(),
+	}
+
+	if err := claims.ValidateWithLeeway(expected, v.options.TokenVerificationLeeway); err != nil {
+		return nil, fmt.Errorf("%w: failed to validate claims: %w", ErrInvalidToken, err)
+	}
+
+	email := strings.ToLower(strings.TrimSpace(claims.Email))
+	if email == "" {
+		return nil, ErrMissingEmail
+	}
+
+	if claims.EmailVerified == nil || !*claims.EmailVerified {
+		return nil, ErrEmailUnverified
+	}
+
+	if claims.Authz.Acctype != accountTypeUser {
+		return nil, fmt.Errorf("%w: acctype must be %q", ErrInvalidAuthzClaim, accountTypeUser)
+	}
+
+	if len(claims.Authz.OrgIDs) == 0 {
+		return nil, fmt.Errorf("%w: orgIds must not be empty", ErrInvalidAuthzClaim)
+	}
+
+	return &User{
+		Email:         email,
+		Expiry:        claims.Expiry.Time(),
+		ClaimedOrgIDs: claims.Authz.OrgIDs,
+	}, nil
+}
+
+func (v *Validator) getVerifier(ctx context.Context) *gooidc.IDTokenVerifier {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if v.verifier != nil {
+		return v.verifier
+	}
+
+	jwksURL := strings.TrimRight(v.options.Issuer, "/") + "/.well-known/jwks.json"
+	keySet := gooidc.NewRemoteKeySet(ctx, jwksURL)
+
+	v.verifier = gooidc.NewVerifier(v.options.Issuer, keySet, &gooidc.Config{
+		ClientID: v.options.Audience,
+		SupportedSigningAlgs: []string{
+			v.options.SupportedSigningAlgorithm,
+		},
+		SkipExpiryCheck: true,
+	})
+
+	return v.verifier
+}

--- a/pkg/oauth2/auth0/validator.go
+++ b/pkg/oauth2/auth0/validator.go
@@ -75,10 +75,13 @@ type tokenClaims struct {
 }
 
 // User is the validated identity extracted from an Auth0 access token.
+//
+// UNI membership is authoritative for organization scope, so the claimed
+// orgIds from the Auth0 token are intentionally not surfaced here — they are
+// only validated as a non-empty signal that the post-login Action ran.
 type User struct {
-	Email         string
-	Expiry        time.Time
-	ClaimedOrgIDs []string
+	Email  string
+	Expiry time.Time
 }
 
 // Validator validates Auth0 JWT access tokens using the tenant JWKS.
@@ -118,7 +121,11 @@ func (v *Validator) Validate(ctx context.Context, token string) (*User, error) {
 		return nil, ErrDisabled
 	}
 
-	idToken, err := v.getVerifier(ctx).Verify(ctx, token)
+	// getVerifier intentionally does not receive ctx: the keyset it builds is
+	// long-lived and must use a background context for JWKS refreshes. The
+	// per-request ctx is still applied to the Verify call below.
+	//nolint:contextcheck
+	idToken, err := v.getVerifier().Verify(ctx, token)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidToken, err)
 	}
@@ -158,13 +165,12 @@ func (v *Validator) Validate(ctx context.Context, token string) (*User, error) {
 	}
 
 	return &User{
-		Email:         email,
-		Expiry:        claims.Expiry.Time(),
-		ClaimedOrgIDs: claims.Authz.OrgIDs,
+		Email:  email,
+		Expiry: claims.Expiry.Time(),
 	}, nil
 }
 
-func (v *Validator) getVerifier(ctx context.Context) *gooidc.IDTokenVerifier {
+func (v *Validator) getVerifier() *gooidc.IDTokenVerifier {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
@@ -172,8 +178,11 @@ func (v *Validator) getVerifier(ctx context.Context) *gooidc.IDTokenVerifier {
 		return v.verifier
 	}
 
+	// The keyset outlives any single request and must refresh its JWKS cache
+	// when Auth0 rotates signing keys, so it gets a background context.
+	// Per-request cancellation still applies via the ctx passed to Verify.
 	jwksURL := strings.TrimRight(v.options.Issuer, "/") + "/.well-known/jwks.json"
-	keySet := gooidc.NewRemoteKeySet(ctx, jwksURL)
+	keySet := gooidc.NewRemoteKeySet(context.Background(), jwksURL)
 
 	v.verifier = gooidc.NewVerifier(v.options.Issuer, keySet, &gooidc.Config{
 		ClientID: v.options.Audience,

--- a/pkg/oauth2/auth0/validator_test.go
+++ b/pkg/oauth2/auth0/validator_test.go
@@ -14,13 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package auth0
+package auth0_test
 
 import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -30,6 +29,8 @@ import (
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/identity/pkg/oauth2/auth0"
 )
 
 const validatorTestAudience = "https://identity.example.com"
@@ -54,7 +55,7 @@ func newValidatorTestIssuer(t *testing.T) *validatorTestIssuer {
 			Use:       "sig",
 		}
 
-		require.NoError(t, json.NewEncoder(w).Encode(gojose.JSONWebKeySet{
+		assert.NoError(t, json.NewEncoder(w).Encode(gojose.JSONWebKeySet{
 			Keys: []gojose.JSONWebKey{publicKey},
 		}))
 	})
@@ -72,12 +73,18 @@ func (i *validatorTestIssuer) issuer() string {
 	return i.server.URL + "/"
 }
 
+type testAuthzClaims struct {
+	Acctype string   `json:"acctype"`
+	OrgIDs  []string `json:"orgIds"`
+}
+
+//nolint:tagliatelle
 type testTokenClaims struct {
 	jwt.Claims
 
-	Email         string      `json:"email,omitempty"`
-	EmailVerified *bool       `json:"email_verified,omitempty"`
-	Authz         authzClaims `json:"https://unikorn-cloud.org/authz,omitempty"`
+	Email         string          `json:"email,omitempty"`
+	EmailVerified *bool           `json:"email_verified,omitempty"`
+	Authz         testAuthzClaims `json:"https://unikorn-cloud.org/authz,omitempty"`
 }
 
 func (i *validatorTestIssuer) token(t *testing.T, mutate func(*testTokenClaims)) string {
@@ -96,8 +103,8 @@ func (i *validatorTestIssuer) token(t *testing.T, mutate func(*testTokenClaims))
 		},
 		Email:         "User@Example.COM",
 		EmailVerified: &verified,
-		Authz: authzClaims{
-			Acctype: accountTypeUser,
+		Authz: testAuthzClaims{
+			Acctype: "user",
 			OrgIDs:  []string{"org-1"},
 		},
 	}
@@ -124,10 +131,10 @@ func (i *validatorTestIssuer) token(t *testing.T, mutate func(*testTokenClaims))
 	return token
 }
 
-func newTestValidator(t *testing.T, issuer string) *Validator {
+func newTestValidator(t *testing.T, issuer string) *auth0.Validator {
 	t.Helper()
 
-	validator, err := NewValidator(Options{
+	validator, err := auth0.NewValidator(auth0.Options{
 		Issuer:   issuer,
 		Audience: validatorTestAudience,
 	})
@@ -166,35 +173,35 @@ func TestValidateRejectsInvalidClaims(t *testing.T) {
 			mutate: func(claims *testTokenClaims) {
 				claims.Issuer = "https://wrong.example.com/"
 			},
-			target: ErrInvalidToken,
+			target: auth0.ErrInvalidToken,
 		},
 		{
 			name: "wrong audience",
 			mutate: func(claims *testTokenClaims) {
 				claims.Audience = jwt.Audience{"https://wrong.example.com"}
 			},
-			target: ErrInvalidToken,
+			target: auth0.ErrInvalidToken,
 		},
 		{
 			name: "expired",
 			mutate: func(claims *testTokenClaims) {
 				claims.Expiry = jwt.NewNumericDate(time.Now().Add(-1 * time.Minute))
 			},
-			target: ErrInvalidToken,
+			target: auth0.ErrInvalidToken,
 		},
 		{
 			name: "not yet valid",
 			mutate: func(claims *testTokenClaims) {
 				claims.NotBefore = jwt.NewNumericDate(time.Now().Add(time.Minute))
 			},
-			target: ErrInvalidToken,
+			target: auth0.ErrInvalidToken,
 		},
 		{
 			name: "missing email",
 			mutate: func(claims *testTokenClaims) {
 				claims.Email = ""
 			},
-			target: ErrMissingEmail,
+			target: auth0.ErrMissingEmail,
 		},
 		{
 			name: "unverified email",
@@ -202,21 +209,21 @@ func TestValidateRejectsInvalidClaims(t *testing.T) {
 				verified := false
 				claims.EmailVerified = &verified
 			},
-			target: ErrEmailUnverified,
+			target: auth0.ErrEmailUnverified,
 		},
 		{
 			name: "wrong account type",
 			mutate: func(claims *testTokenClaims) {
 				claims.Authz.Acctype = "service"
 			},
-			target: ErrInvalidAuthzClaim,
+			target: auth0.ErrInvalidAuthzClaim,
 		},
 		{
 			name: "empty org IDs",
 			mutate: func(claims *testTokenClaims) {
 				claims.Authz.OrgIDs = nil
 			},
-			target: ErrInvalidAuthzClaim,
+			target: auth0.ErrInvalidAuthzClaim,
 		},
 	}
 
@@ -228,7 +235,7 @@ func TestValidateRejectsInvalidClaims(t *testing.T) {
 
 			_, err := validator.Validate(t.Context(), issuer.token(t, test.mutate))
 			require.Error(t, err)
-			assert.True(t, errors.Is(err, test.target), "expected %v, got %v", test.target, err)
+			assert.ErrorIs(t, err, test.target)
 		})
 	}
 }
@@ -236,7 +243,7 @@ func TestValidateRejectsInvalidClaims(t *testing.T) {
 func TestNewValidatorRejectsPartialConfig(t *testing.T) {
 	t.Parallel()
 
-	validator, err := NewValidator(Options{Issuer: "https://tenant.auth0.com/"})
-	require.ErrorIs(t, err, ErrInvalidConfig)
+	validator, err := auth0.NewValidator(auth0.Options{Issuer: "https://tenant.auth0.com/"})
+	require.ErrorIs(t, err, auth0.ErrInvalidConfig)
 	assert.Nil(t, validator)
 }

--- a/pkg/oauth2/auth0/validator_test.go
+++ b/pkg/oauth2/auth0/validator_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth0
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	gojose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validatorTestAudience = "https://identity.example.com"
+
+type validatorTestIssuer struct {
+	server *httptest.Server
+	key    *rsa.PrivateKey
+}
+
+func newValidatorTestIssuer(t *testing.T) *validatorTestIssuer {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/jwks.json", func(w http.ResponseWriter, _ *http.Request) {
+		publicKey := gojose.JSONWebKey{
+			Key:       &key.PublicKey,
+			KeyID:     "test-key",
+			Algorithm: string(gojose.RS256),
+			Use:       "sig",
+		}
+
+		require.NoError(t, json.NewEncoder(w).Encode(gojose.JSONWebKeySet{
+			Keys: []gojose.JSONWebKey{publicKey},
+		}))
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	return &validatorTestIssuer{
+		server: server,
+		key:    key,
+	}
+}
+
+func (i *validatorTestIssuer) issuer() string {
+	return i.server.URL + "/"
+}
+
+type testTokenClaims struct {
+	jwt.Claims
+
+	Email         string      `json:"email,omitempty"`
+	EmailVerified *bool       `json:"email_verified,omitempty"`
+	Authz         authzClaims `json:"https://unikorn-cloud.org/authz,omitempty"`
+}
+
+func (i *validatorTestIssuer) token(t *testing.T, mutate func(*testTokenClaims)) string {
+	t.Helper()
+
+	now := time.Now()
+	verified := true
+
+	claims := &testTokenClaims{
+		Claims: jwt.Claims{
+			Issuer:   i.issuer(),
+			Subject:  "auth0|user",
+			Audience: jwt.Audience{validatorTestAudience},
+			IssuedAt: jwt.NewNumericDate(now),
+			Expiry:   jwt.NewNumericDate(now.Add(time.Minute)),
+		},
+		Email:         "User@Example.COM",
+		EmailVerified: &verified,
+		Authz: authzClaims{
+			Acctype: accountTypeUser,
+			OrgIDs:  []string{"org-1"},
+		},
+	}
+
+	if mutate != nil {
+		mutate(claims)
+	}
+
+	signer, err := gojose.NewSigner(
+		gojose.SigningKey{
+			Algorithm: gojose.RS256,
+			Key: gojose.JSONWebKey{
+				Key:   i.key,
+				KeyID: "test-key",
+			},
+		},
+		(&gojose.SignerOptions{}).WithType("at+jwt"),
+	)
+	require.NoError(t, err)
+
+	token, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+
+	return token
+}
+
+func newTestValidator(t *testing.T, issuer string) *Validator {
+	t.Helper()
+
+	validator, err := NewValidator(Options{
+		Issuer:   issuer,
+		Audience: validatorTestAudience,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, validator)
+
+	return validator
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	issuer := newValidatorTestIssuer(t)
+	validator := newTestValidator(t, issuer.issuer())
+
+	user, err := validator.Validate(t.Context(), issuer.token(t, nil))
+	require.NoError(t, err)
+
+	assert.Equal(t, "user@example.com", user.Email)
+	assert.ElementsMatch(t, []string{"org-1"}, user.ClaimedOrgIDs)
+	assert.True(t, user.Expiry.After(time.Now()))
+}
+
+func TestValidateRejectsInvalidClaims(t *testing.T) {
+	t.Parallel()
+
+	issuer := newValidatorTestIssuer(t)
+
+	testCases := []struct {
+		name   string
+		mutate func(*testTokenClaims)
+		target error
+	}{
+		{
+			name: "wrong issuer",
+			mutate: func(claims *testTokenClaims) {
+				claims.Issuer = "https://wrong.example.com/"
+			},
+			target: ErrInvalidToken,
+		},
+		{
+			name: "wrong audience",
+			mutate: func(claims *testTokenClaims) {
+				claims.Audience = jwt.Audience{"https://wrong.example.com"}
+			},
+			target: ErrInvalidToken,
+		},
+		{
+			name: "expired",
+			mutate: func(claims *testTokenClaims) {
+				claims.Expiry = jwt.NewNumericDate(time.Now().Add(-1 * time.Minute))
+			},
+			target: ErrInvalidToken,
+		},
+		{
+			name: "not yet valid",
+			mutate: func(claims *testTokenClaims) {
+				claims.NotBefore = jwt.NewNumericDate(time.Now().Add(time.Minute))
+			},
+			target: ErrInvalidToken,
+		},
+		{
+			name: "missing email",
+			mutate: func(claims *testTokenClaims) {
+				claims.Email = ""
+			},
+			target: ErrMissingEmail,
+		},
+		{
+			name: "unverified email",
+			mutate: func(claims *testTokenClaims) {
+				verified := false
+				claims.EmailVerified = &verified
+			},
+			target: ErrEmailUnverified,
+		},
+		{
+			name: "wrong account type",
+			mutate: func(claims *testTokenClaims) {
+				claims.Authz.Acctype = "service"
+			},
+			target: ErrInvalidAuthzClaim,
+		},
+		{
+			name: "empty org IDs",
+			mutate: func(claims *testTokenClaims) {
+				claims.Authz.OrgIDs = nil
+			},
+			target: ErrInvalidAuthzClaim,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			validator := newTestValidator(t, issuer.issuer())
+
+			_, err := validator.Validate(t.Context(), issuer.token(t, test.mutate))
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, test.target), "expected %v, got %v", test.target, err)
+		})
+	}
+}
+
+func TestNewValidatorRejectsPartialConfig(t *testing.T) {
+	t.Parallel()
+
+	validator, err := NewValidator(Options{Issuer: "https://tenant.auth0.com/"})
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	assert.Nil(t, validator)
+}

--- a/pkg/oauth2/auth0/validator_test.go
+++ b/pkg/oauth2/auth0/validator_test.go
@@ -82,8 +82,8 @@ type testAuthzClaims struct {
 type testTokenClaims struct {
 	jwt.Claims
 
-	Email         string          `json:"email,omitempty"`
-	EmailVerified *bool           `json:"email_verified,omitempty"`
+	Email         string          `json:"https://unikorn-cloud.org/email,omitempty"`
+	EmailVerified *bool           `json:"https://unikorn-cloud.org/email_verified,omitempty"`
 	Authz         testAuthzClaims `json:"https://unikorn-cloud.org/authz,omitempty"`
 }
 

--- a/pkg/oauth2/auth0/validator_test.go
+++ b/pkg/oauth2/auth0/validator_test.go
@@ -154,7 +154,6 @@ func TestValidate(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "user@example.com", user.Email)
-	assert.ElementsMatch(t, []string{"org-1"}, user.ClaimedOrgIDs)
 	assert.True(t, user.Expiry.After(time.Now()))
 }
 

--- a/pkg/oauth2/oauth2.go
+++ b/pkg/oauth2/oauth2.go
@@ -153,7 +153,7 @@ func New(options *Options, namespace string, issuer common.IssuerValue, client c
 		Audience:                options.Auth0ExchangeAudience,
 		TokenVerificationLeeway: options.TokenVerificationLeeway,
 	})
-	if err != nil {
+	if err != nil && !goerrors.Is(err, auth0.ErrDisabled) {
 		panic(err)
 	}
 

--- a/pkg/oauth2/oauth2.go
+++ b/pkg/oauth2/oauth2.go
@@ -42,6 +42,7 @@ import (
 	"github.com/unikorn-cloud/identity/pkg/handler/common"
 	"github.com/unikorn-cloud/identity/pkg/html"
 	"github.com/unikorn-cloud/identity/pkg/jose"
+	"github.com/unikorn-cloud/identity/pkg/oauth2/auth0"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/errors"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/oidc"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/providers"
@@ -92,6 +93,14 @@ type Options struct {
 
 	// CodeCacheSize is used to set the number of authorization code in flight.
 	CodeCacheSize int
+
+	// Auth0ExchangeIssuer is the Auth0 tenant issuer accepted as a passport
+	// exchange source token issuer.
+	Auth0ExchangeIssuer string
+
+	// Auth0ExchangeAudience is the Auth0 API audience accepted for passport
+	// exchange source tokens.
+	Auth0ExchangeAudience string
 }
 
 func (o *Options) AddFlags(f *pflag.FlagSet) {
@@ -101,6 +110,8 @@ func (o *Options) AddFlags(f *pflag.FlagSet) {
 	f.DurationVar(&o.TokenLeewayDuration, "token-leeway", time.Minute, "How long to remove from the provider token expiry to account for network and processing latency.")
 	f.IntVar(&o.TokenCacheSize, "token-cache-size", 8192, "How many token cache entries to allow.")
 	f.IntVar(&o.CodeCacheSize, "code-cache-size", 8192, "How many code cache entries to allow.")
+	f.StringVar(&o.Auth0ExchangeIssuer, "auth0-exchange-issuer", "", "Auth0 tenant issuer accepted for passport token exchange.")
+	f.StringVar(&o.Auth0ExchangeAudience, "auth0-exchange-audience", "", "Auth0 API audience accepted for passport token exchange.")
 }
 
 // Authenticator provides Keystone authentication functionality.
@@ -129,21 +140,34 @@ type Authenticator struct {
 
 	// codeCache is used to protect against authorization code reuse.
 	codeCache *cache.LRUExpireCache
+
+	// auth0Validator validates Auth0 access tokens accepted by passport exchange.
+	auth0Validator *auth0.Validator
 }
 
 // New returns a new authenticator with required fields populated.
 // You must call AddFlags after this.
 func New(options *Options, namespace string, issuer common.IssuerValue, client client.Client, jwtIssuer *jose.JWTIssuer, userdb *userdb.UserDatabase, rbac *rbac.RBAC) *Authenticator {
+	auth0Validator, err := auth0.NewValidator(auth0.Options{
+		Issuer:                  options.Auth0ExchangeIssuer,
+		Audience:                options.Auth0ExchangeAudience,
+		TokenVerificationLeeway: options.TokenVerificationLeeway,
+	})
+	if err != nil {
+		panic(err)
+	}
+
 	return &Authenticator{
-		options:    options,
-		namespace:  namespace,
-		client:     client,
-		issuer:     issuer,
-		jwtIssuer:  jwtIssuer,
-		userdb:     userdb,
-		rbac:       rbac,
-		tokenCache: cache.NewLRUExpireCache(options.TokenCacheSize),
-		codeCache:  cache.NewLRUExpireCache(options.CodeCacheSize),
+		options:        options,
+		namespace:      namespace,
+		client:         client,
+		issuer:         issuer,
+		jwtIssuer:      jwtIssuer,
+		userdb:         userdb,
+		rbac:           rbac,
+		tokenCache:     cache.NewLRUExpireCache(options.TokenCacheSize),
+		codeCache:      cache.NewLRUExpireCache(options.CodeCacheSize),
+		auth0Validator: auth0Validator,
 	}
 }
 

--- a/pkg/oauth2/oauth2.go
+++ b/pkg/oauth2/oauth2.go
@@ -106,7 +106,7 @@ type Options struct {
 func (o *Options) AddFlags(f *pflag.FlagSet) {
 	f.DurationVar(&o.AccessTokenDuration, "access-token-duration", time.Hour, "Maximum time an access token can be active for.")
 	f.DurationVar(&o.RefreshTokenDuration, "refresh-token-duration", 0, "Maximum time a refresh token can be active for.")
-	f.DurationVar(&o.TokenVerificationLeeway, "token-verification-leeway", 0, "How mush leeway to permit for verification of token validity.")
+	f.DurationVar(&o.TokenVerificationLeeway, "token-verification-leeway", 0, "How much leeway to permit for verification of token validity.")
 	f.DurationVar(&o.TokenLeewayDuration, "token-leeway", time.Minute, "How long to remove from the provider token expiry to account for network and processing latency.")
 	f.IntVar(&o.TokenCacheSize, "token-cache-size", 8192, "How many token cache entries to allow.")
 	f.IntVar(&o.CodeCacheSize, "code-cache-size", 8192, "How many code cache entries to allow.")
@@ -147,14 +147,18 @@ type Authenticator struct {
 
 // New returns a new authenticator with required fields populated.
 // You must call AddFlags after this.
-func New(options *Options, namespace string, issuer common.IssuerValue, client client.Client, jwtIssuer *jose.JWTIssuer, userdb *userdb.UserDatabase, rbac *rbac.RBAC) *Authenticator {
+//
+// Returns an error if the Auth0 exchange options are partially specified
+// (e.g. issuer set without audience). When Auth0 exchange is fully unset the
+// returned authenticator simply has no Auth0 validator wired up.
+func New(options *Options, namespace string, issuer common.IssuerValue, client client.Client, jwtIssuer *jose.JWTIssuer, userdb *userdb.UserDatabase, rbac *rbac.RBAC) (*Authenticator, error) {
 	auth0Validator, err := auth0.NewValidator(auth0.Options{
 		Issuer:                  options.Auth0ExchangeIssuer,
 		Audience:                options.Auth0ExchangeAudience,
 		TokenVerificationLeeway: options.TokenVerificationLeeway,
 	})
 	if err != nil && !goerrors.Is(err, auth0.ErrDisabled) {
-		panic(err)
+		return nil, err
 	}
 
 	return &Authenticator{
@@ -168,7 +172,7 @@ func New(options *Options, namespace string, issuer common.IssuerValue, client c
 		tokenCache:     cache.NewLRUExpireCache(options.TokenCacheSize),
 		codeCache:      cache.NewLRUExpireCache(options.CodeCacheSize),
 		auth0Validator: auth0Validator,
-	}
+	}, nil
 }
 
 type Error string

--- a/pkg/oauth2/oauth2_test.go
+++ b/pkg/oauth2/oauth2_test.go
@@ -109,7 +109,8 @@ func TestTokens(t *testing.T) {
 		Hostname: "foo.com",
 	}
 
-	authenticator := oauth2.New(options, josetesting.Namespace, issuerVal, client, issuer, userDatabase, rbac)
+	authenticator, err := oauth2.New(options, josetesting.Namespace, issuerVal, client, issuer, userDatabase, rbac)
+	require.NoError(t, err)
 
 	time.Sleep(2 * josetesting.RefreshPeriod)
 
@@ -373,13 +374,14 @@ func TestUserinfoCustomClaims(t *testing.T) {
 				Hostname: tc.issueInfo.Audience, // setting this from the audience is somewhat arbitrary; but it's not under test here.
 			}
 
-			authenticator := oauth2.New(&oauth2.Options{
+			authenticator, err := oauth2.New(&oauth2.Options{
 				AccessTokenDuration:  accessTokenDuration,
 				RefreshTokenDuration: refreshTokenDuration,
 				TokenLeewayDuration:  accessTokenDuration,
 				TokenCacheSize:       1024,
 				CodeCacheSize:        1024,
 			}, josetesting.Namespace, issuerHost, client, issuer, userDatabase, rbac)
+			require.NoError(t, err)
 
 			time.Sleep(2 * josetesting.RefreshPeriod)
 

--- a/pkg/oauth2/passport.go
+++ b/pkg/oauth2/passport.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/go-jose/go-jose/v4/jwt"
@@ -35,6 +36,7 @@ import (
 	"github.com/unikorn-cloud/identity/pkg/oauth2/errors"
 	"github.com/unikorn-cloud/identity/pkg/openapi"
 	"github.com/unikorn-cloud/identity/pkg/rbac"
+	"github.com/unikorn-cloud/identity/pkg/userdb"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -57,6 +59,9 @@ const (
 
 	// PassportSourceUNI indicates the source token was a UNI access token.
 	PassportSourceUNI = "uni"
+
+	// PassportSourceAuth0 indicates the source token was an Auth0 access token.
+	PassportSourceAuth0 = "auth0"
 )
 
 // ActorClaim is the RFC 8693 section 4.1 "act" claim. It identifies the
@@ -145,7 +150,7 @@ func (a *Authenticator) ExchangePassport(ctx context.Context, options *openapi.T
 
 	subjectToken := *options.SubjectToken
 
-	userinfo, sourceClaims, err := a.GetUserinfo(ctx, request, subjectToken)
+	userinfo, sourceClaims, source, err := a.exchangeUserinfo(ctx, request, subjectToken)
 	if err != nil {
 		log.Info("passport exchange failed: token validation failed")
 
@@ -194,14 +199,74 @@ func (a *Authenticator) ExchangePassport(ctx context.Context, options *openapi.T
 		return nil, err
 	}
 
-	return a.mintPassport(ctx, userinfo, sourceClaims, audience, organizationID, projectID)
+	return a.mintPassport(ctx, userinfo, sourceClaims, source, audience, organizationID, projectID)
+}
+
+func (a *Authenticator) exchangeUserinfo(ctx context.Context, r *http.Request, token string) (*openapi.Userinfo, *Claims, string, error) {
+	if isCompactJWS(token) && a.auth0Validator != nil {
+		userinfo, claims, err := a.getAuth0Userinfo(ctx, r, token)
+
+		return userinfo, claims, PassportSourceAuth0, err
+	}
+
+	userinfo, claims, err := a.GetUserinfo(ctx, r, token)
+
+	return userinfo, claims, PassportSourceUNI, err
+}
+
+func isCompactJWS(token string) bool {
+	return strings.Count(token, ".") == 2
+}
+
+func (a *Authenticator) getAuth0Userinfo(ctx context.Context, r *http.Request, token string) (*openapi.Userinfo, *Claims, error) {
+	user, err := a.auth0Validator.Validate(ctx, token)
+	if err != nil {
+		return nil, nil, coreerrors.AccessDenied(r, "token validation failed").WithError(err)
+	}
+
+	// Auth0 proves the human identity and that the UNI Action ran; UNI remains
+	// authoritative for active user state and organization membership.
+	orgIDs, err := a.userdb.GetOrganizationIDs(ctx, user.Email)
+	if err != nil {
+		if goerrors.Is(err, userdb.ErrResourceReference) {
+			return nil, nil, errors.OAuth2AccessDenied("user identity not found or inactive").WithError(err)
+		}
+
+		return nil, nil, fmt.Errorf("%w: failed to query organization IDs", err)
+	}
+
+	verified := true
+	email := user.Email
+
+	userinfo := &openapi.Userinfo{
+		Sub:           user.Email,
+		Email:         &email,
+		EmailVerified: &verified,
+		HttpsunikornCloudOrgauthz: &openapi.AuthClaims{
+			Acctype: openapi.User,
+			OrgIds:  orgIDs,
+		},
+	}
+
+	sourceClaims := &Claims{
+		Claims: jwt.Claims{
+			Subject: user.Email,
+			Issuer:  a.options.Auth0ExchangeIssuer,
+			Audience: jwt.Audience{
+				a.options.Auth0ExchangeAudience,
+			},
+			Expiry: jwt.NewNumericDate(user.Expiry),
+		},
+	}
+
+	return userinfo, sourceClaims, nil
 }
 
 // mintPassport encodes the signed passport once scope authorisation has
 // completed. It also enforces the source-token expiry precondition: a passport
 // with expires_in ≤ 0 would be internally inconsistent, so the exchange fails
 // closed when the source token's exp is already at or before now.
-func (a *Authenticator) mintPassport(ctx context.Context, userinfo *openapi.Userinfo, sourceClaims *Claims, audience jwt.Audience, organizationID, projectID string) (*openapi.Token, error) {
+func (a *Authenticator) mintPassport(ctx context.Context, userinfo *openapi.Userinfo, sourceClaims *Claims, source string, audience jwt.Audience, organizationID, projectID string) (*openapi.Token, error) {
 	log := log.FromContext(ctx)
 
 	now := time.Now()
@@ -228,7 +293,7 @@ func (a *Authenticator) mintPassport(ctx context.Context, userinfo *openapi.User
 		},
 		Type:      PassportType,
 		Acctype:   authz.Acctype,
-		Source:    PassportSourceUNI,
+		Source:    source,
 		OrgIDs:    authz.OrgIds,
 		OrgID:     organizationID,
 		ProjectID: projectID,
@@ -249,7 +314,7 @@ func (a *Authenticator) mintPassport(ctx context.Context, userinfo *openapi.User
 
 	log.Info("passport exchanged",
 		"acctype", authz.Acctype,
-		"source", PassportSourceUNI,
+		"source", source,
 		"organizationID", organizationID,
 		"passportID", passportID,
 	)

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package oauth2_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -74,6 +76,19 @@ func setupPassportTestEnvWithRBACOptions(t *testing.T, rbacOptions *rbac.Options
 func setupPassportTestEnvWithOptions(t *testing.T, rbacOptions *rbac.Options, tokenVerificationLeeway time.Duration, objects ...client.Object) *passportTestEnv {
 	t.Helper()
 
+	return setupPassportTestEnvWithOAuth2Options(t, rbacOptions, &oauth2.Options{
+		AccessTokenDuration:     accessTokenDuration,
+		RefreshTokenDuration:    refreshTokenDuration,
+		TokenLeewayDuration:     accessTokenDuration,
+		TokenVerificationLeeway: tokenVerificationLeeway,
+		TokenCacheSize:          1024,
+		CodeCacheSize:           1024,
+	}, objects...)
+}
+
+func setupPassportTestEnvWithOAuth2Options(t *testing.T, rbacOptions *rbac.Options, oauth2Options *oauth2.Options, objects ...client.Object) *passportTestEnv {
+	t.Helper()
+
 	cli := fake.NewClientBuilder().WithScheme(getScheme(t)).WithObjects(objects...).Build()
 
 	josetesting.RotateCertificate(t, cli)
@@ -99,14 +114,7 @@ func setupPassportTestEnvWithOptions(t *testing.T, rbacOptions *rbac.Options, to
 		Hostname: "test.com",
 	}
 
-	authenticator := oauth2.New(&oauth2.Options{
-		AccessTokenDuration:     accessTokenDuration,
-		RefreshTokenDuration:    refreshTokenDuration,
-		TokenLeewayDuration:     accessTokenDuration,
-		TokenVerificationLeeway: tokenVerificationLeeway,
-		TokenCacheSize:          1024,
-		CodeCacheSize:           1024,
-	}, josetesting.Namespace, issuerVal, cli, jwtIssuer, userDatabase, rbacInst)
+	authenticator := oauth2.New(oauth2Options, josetesting.Namespace, issuerVal, cli, jwtIssuer, userDatabase, rbacInst)
 
 	time.Sleep(2 * josetesting.RefreshPeriod)
 
@@ -115,6 +123,93 @@ func setupPassportTestEnvWithOptions(t *testing.T, rbacOptions *rbac.Options, to
 		jwtIssuer:     jwtIssuer,
 		client:        cli,
 	}
+}
+
+type auth0TestIssuer struct {
+	server *httptest.Server
+	key    *rsa.PrivateKey
+}
+
+func newAuth0TestIssuer(t *testing.T) *auth0TestIssuer {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/jwks.json", func(w http.ResponseWriter, _ *http.Request) {
+		publicKey := gojose.JSONWebKey{
+			Key:       &key.PublicKey,
+			KeyID:     "test-key",
+			Algorithm: string(gojose.RS256),
+			Use:       "sig",
+		}
+
+		require.NoError(t, json.NewEncoder(w).Encode(gojose.JSONWebKeySet{
+			Keys: []gojose.JSONWebKey{publicKey},
+		}))
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	return &auth0TestIssuer{
+		server: server,
+		key:    key,
+	}
+}
+
+func (i *auth0TestIssuer) issuer() string {
+	return i.server.URL + "/"
+}
+
+func (i *auth0TestIssuer) token(t *testing.T, audience, email string, expiry time.Time) string {
+	t.Helper()
+
+	verified := true
+
+	type auth0Claims struct {
+		jwt.Claims
+
+		Email         string `json:"email"`
+		EmailVerified *bool  `json:"email_verified"`
+		Authz         struct {
+			Acctype string   `json:"acctype"`
+			OrgIDs  []string `json:"orgIds"`
+		} `json:"https://unikorn-cloud.org/authz"`
+	}
+
+	claims := &auth0Claims{
+		Claims: jwt.Claims{
+			Issuer:    i.issuer(),
+			Subject:   "auth0|user",
+			Audience:  jwt.Audience{audience},
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			NotBefore: jwt.NewNumericDate(time.Now().Add(-1 * time.Second)),
+			Expiry:    jwt.NewNumericDate(expiry),
+		},
+		Email:         email,
+		EmailVerified: &verified,
+	}
+	claims.Authz.Acctype = "user"
+	claims.Authz.OrgIDs = []string{"auth0-org"}
+
+	signer, err := gojose.NewSigner(
+		gojose.SigningKey{
+			Algorithm: gojose.RS256,
+			Key: gojose.JSONWebKey{
+				Key:   i.key,
+				KeyID: "test-key",
+			},
+		},
+		(&gojose.SignerOptions{}).WithType("at+jwt"),
+	)
+	require.NoError(t, err)
+
+	token, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+
+	return token
 }
 
 func issueTestToken(t *testing.T, env *passportTestEnv, info *oauth2.IssueInfo) string {
@@ -275,6 +370,74 @@ func TestExchangeFederatedUser(t *testing.T) {
 	assert.False(t,
 		claims.Expiry.Time().After(claims.IssuedAt.Time().Add(oauth2.PassportTTL)),
 		"passport expiry must not exceed the configured passport TTL",
+	)
+}
+
+func TestExchangeAuth0User(t *testing.T) {
+	t.Parallel()
+
+	auth0Issuer := newAuth0TestIssuer(t)
+	auth0Audience := "https://identity.example.com"
+	sourceExpiry := time.Now().Add(45 * time.Second)
+
+	env := setupPassportTestEnvWithOAuth2Options(t, &rbac.Options{}, &oauth2.Options{
+		AccessTokenDuration:     accessTokenDuration,
+		RefreshTokenDuration:    refreshTokenDuration,
+		TokenLeewayDuration:     accessTokenDuration,
+		TokenVerificationLeeway: 0,
+		TokenCacheSize:          1024,
+		CodeCacheSize:           1024,
+		Auth0ExchangeIssuer:     auth0Issuer.issuer(),
+		Auth0ExchangeAudience:   auth0Audience,
+	}, &unikornv1.Organization{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: josetesting.Namespace,
+			Name:      "org1",
+		},
+		Status: unikornv1.OrganizationStatus{
+			Namespace: josetesting.Namespace + "-org1",
+		},
+	}, &unikornv1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: josetesting.Namespace,
+			Name:      "test-user",
+		},
+		Spec: unikornv1.UserSpec{
+			Subject: "user@example.com",
+			State:   unikornv1.UserStateActive,
+		},
+	}, &unikornv1.OrganizationUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: josetesting.Namespace,
+			Name:      "org1-user",
+			Labels: map[string]string{
+				constants.UserLabel:         "test-user",
+				constants.OrganizationLabel: "org1",
+			},
+		},
+		Spec: unikornv1.OrganizationUserSpec{
+			State: unikornv1.UserStateActive,
+		},
+	})
+
+	token := auth0Issuer.token(t, auth0Audience, "User@Example.COM", sourceExpiry)
+	req := exchangeRequest(t, token, nil)
+
+	result, err := env.authenticator.TokenExchange(nil, req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	claims := parsePassport(t, env, result.AccessToken)
+
+	assert.Equal(t, "passport", claims.Type)
+	assert.Equal(t, openapi.User, claims.Acctype)
+	assert.Equal(t, oauth2.PassportSourceAuth0, claims.Source)
+	assert.Equal(t, "user@example.com", claims.Subject)
+	assert.Equal(t, "user@example.com", claims.Email)
+	assert.ElementsMatch(t, []string{"org1"}, claims.OrgIDs, "UNI membership remains authoritative")
+	assert.False(t,
+		claims.Expiry.Time().After(sourceExpiry),
+		"passport expiry must not outlive the Auth0 source token expiry",
 	)
 }
 

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -443,6 +443,90 @@ func TestExchangeAuth0User(t *testing.T) {
 	)
 }
 
+// TestExchangeFederatedUserWithAuth0Enabled is a regression test ensuring
+// that enabling Auth0 exchange does not break the existing UNI token path.
+// UNI access tokens are JWE (signed-then-encrypted, four dots), Auth0 tokens
+// are compact JWS (two dots), so the isCompactJWS discriminator must route
+// each to the correct verifier. If a future change ever caused UNI tokens to
+// be misrouted to the Auth0 validator they would fail at signature/issuer
+// validation and this test would fail.
+func TestExchangeFederatedUserWithAuth0Enabled(t *testing.T) {
+	t.Parallel()
+
+	auth0Issuer := newAuth0TestIssuer(t)
+
+	env := setupPassportTestEnvWithOAuth2Options(t, &rbac.Options{}, &oauth2.Options{
+		AccessTokenDuration:     accessTokenDuration,
+		RefreshTokenDuration:    refreshTokenDuration,
+		TokenLeewayDuration:     accessTokenDuration,
+		TokenVerificationLeeway: 0,
+		TokenCacheSize:          1024,
+		CodeCacheSize:           1024,
+		Auth0ExchangeIssuer:     auth0Issuer.issuer(),
+		Auth0ExchangeAudience:   "https://identity.example.com",
+	}, &unikornv1.Organization{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: josetesting.Namespace,
+			Name:      "org1",
+		},
+		Status: unikornv1.OrganizationStatus{
+			Namespace: josetesting.Namespace + "-org1",
+		},
+	}, &unikornv1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: josetesting.Namespace,
+			Name:      "test-user",
+		},
+		Spec: unikornv1.UserSpec{
+			Subject: "user@example.com",
+			State:   unikornv1.UserStateActive,
+		},
+	}, &unikornv1.OrganizationUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: josetesting.Namespace,
+			Name:      "org1-user",
+			Labels: map[string]string{
+				constants.UserLabel:         "test-user",
+				constants.OrganizationLabel: "org1",
+			},
+		},
+		Spec: unikornv1.OrganizationUserSpec{
+			State: unikornv1.UserStateActive,
+		},
+	})
+
+	token := issueTestToken(t, env, &oauth2.IssueInfo{
+		Issuer:   "https://test.com",
+		Audience: "test.com",
+		Subject:  "user@example.com",
+		Type:     oauth2.TokenTypeFederated,
+		Federated: &oauth2.FederatedClaims{
+			UserID: "test-user",
+			Scope:  oauth2.NewScope("openid email"),
+		},
+	})
+
+	// Sanity-check the test premise: the UNI access token is JWE (4 dots),
+	// not compact JWS, so isCompactJWS will return false and the Auth0
+	// validator never sees it.
+	require.Equal(t, 4, strings.Count(token, "."), "UNI access token should be JWE (4 dots)")
+
+	req := exchangeRequest(t, token, nil)
+
+	result, err := env.authenticator.TokenExchange(nil, req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	claims := parsePassport(t, env, result.AccessToken)
+
+	assert.Equal(t, "passport", claims.Type)
+	assert.Equal(t, openapi.User, claims.Acctype)
+	assert.Equal(t, oauth2.PassportSourceUNI, claims.Source,
+		"UNI tokens must continue to route through the UNI path when Auth0 is enabled")
+	assert.Equal(t, "user@example.com", claims.Subject)
+	assert.ElementsMatch(t, []string{"org1"}, claims.OrgIDs)
+}
+
 func TestExchangeCapsPassportExpiryAtSourceTokenExpiry(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -145,7 +145,7 @@ func newAuth0TestIssuer(t *testing.T) *auth0TestIssuer {
 			Use:       "sig",
 		}
 
-		require.NoError(t, json.NewEncoder(w).Encode(gojose.JSONWebKeySet{
+		assert.NoError(t, json.NewEncoder(w).Encode(gojose.JSONWebKeySet{
 			Keys: []gojose.JSONWebKey{publicKey},
 		}))
 	})
@@ -168,6 +168,7 @@ func (i *auth0TestIssuer) token(t *testing.T, audience, email string, expiry tim
 
 	verified := true
 
+	//nolint:tagliatelle
 	type auth0Claims struct {
 		jwt.Claims
 

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -114,7 +114,8 @@ func setupPassportTestEnvWithOAuth2Options(t *testing.T, rbacOptions *rbac.Optio
 		Hostname: "test.com",
 	}
 
-	authenticator := oauth2.New(oauth2Options, josetesting.Namespace, issuerVal, cli, jwtIssuer, userDatabase, rbacInst)
+	authenticator, err := oauth2.New(oauth2Options, josetesting.Namespace, issuerVal, cli, jwtIssuer, userDatabase, rbacInst)
+	require.NoError(t, err)
 
 	time.Sleep(2 * josetesting.RefreshPeriod)
 

--- a/pkg/oauth2/passport_test.go
+++ b/pkg/oauth2/passport_test.go
@@ -173,8 +173,8 @@ func (i *auth0TestIssuer) token(t *testing.T, audience, email string, expiry tim
 	type auth0Claims struct {
 		jwt.Claims
 
-		Email         string `json:"email"`
-		EmailVerified *bool  `json:"email_verified"`
+		Email         string `json:"https://unikorn-cloud.org/email"`
+		EmailVerified *bool  `json:"https://unikorn-cloud.org/email_verified"`
 		Authz         struct {
 			Acctype string   `json:"acctype"`
 			OrgIDs  []string `json:"orgIds"`

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -126,7 +126,11 @@ func (s *Server) GetServer(client client.Client, directclient client.Client) (*h
 
 	userdb := userdb.NewUserDatabase(client, s.CoreOptions.Namespace)
 	rbac := rbac.New(client, s.CoreOptions.Namespace, &s.RBACOptions)
-	oauth2 := oauth2.New(&s.OAuth2Options, s.CoreOptions.Namespace, s.HandlerOptions.Issuer, client, issuer, userdb, rbac)
+	oauth2, err := oauth2.New(&s.OAuth2Options, s.CoreOptions.Namespace, s.HandlerOptions.Issuer, client, issuer, userdb, rbac)
+
+	if err != nil {
+		return nil, err
+	}
 
 	// Setup middleware.
 	authorizer := local.NewAuthorizer(oauth2, rbac)


### PR DESCRIPTION
## Summary

Adds an Auth0-source path to the passport token-exchange endpoint so an Auth0 access token can be exchanged for a UNI passport. Identity remains authoritative for user state and organization membership — Auth0 only proves the human identity and that the UNI post-login Action ran.

- New `pkg/oauth2/auth0` validator: fetches the tenant JWKS and verifies signature, issuer, audience, temporal claims, verified email, and the UNI authz claim emitted by the post-login Action (`https://unikorn-cloud.org/authz`).
- `pkg/oauth2/passport`: compact-JWS subject tokens are routed through the Auth0 validator; everything else falls back to the existing UNI userinfo path. Passport `source` is stamped `auth0` vs. `uni` accordingly, and passport expiry is capped at the source token's `exp` (existing invariant, now exercised for Auth0).
- `pkg/oauth2/oauth2`: new `--auth0-exchange-issuer` and `--auth0-exchange-audience` flags wire the validator into the authenticator. Validator is `nil` (and the exchange disabled) when both are unset.
- `charts/identity`: `identity.auth0Exchange.{issuer,audience}` values plumb the flags through the deployment template. Defaults are unset, so the path stays off until a deployment opts in.

## Behaviour notes

- UNI membership wins: claimed `orgIds` in the Auth0 token are ignored; the exchange queries `userdb.GetOrganizationIDs` for the verified email. Inactive or unknown users get `access_denied`.
- Email is lowercased and trimmed before lookup; `email_verified` is required.
- The Auth0 token's `acctype` must be `user` and `orgIds` must be non-empty (sanity checks on the Action's output).

## Test plan

- [x] `pkg/oauth2/auth0` unit tests cover signature, issuer, audience, email, and authz-claim failure modes.
- [x] `pkg/oauth2/passport_test.go` adds an end-to-end exchange against a fake JWKS issuer, asserting passport `source=auth0`, identity, org membership comes from UNI (not the token's claimed orgs), and expiry does not outlive the source token.
- [ ] `make touch license validate lint generate test-unit` clean locally.
- [ ] Smoke-test a deployment with `identity.auth0Exchange.issuer` / `.audience` set and confirm an Auth0-issued token exchanges to a passport.
- [ ] Confirm the path stays disabled (no Auth0 exchanges accepted) when the values are unset.