### PR TITLE
chore: version v1.17.2

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's IdP
 
 type: application
 
-version: 1.17.1
-appVersion: 1.17.1
+version: 1.17.2
+appVersion: 1.17.2
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 


### PR DESCRIPTION
Version bump to v1.17.2 for release. Bumps `charts/identity/Chart.yaml` version + appVersion 1.17.1 → 1.17.2.

Releases the Auth0 access-token → UNI passport exchange feature (#496). Tag `v1.17.2` will be cut on the merge commit, triggering the image + chart release workflow.