### PR TITLE
ci: publish test history via OTLP

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -68,7 +68,7 @@ jobs:
       run: make test-api-ci
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-history-post-results
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
       if: ${{ !cancelled() && (steps.api-tests.outcome == 'success' || steps.api-tests.outcome == 'failure') }}
       with:
         test-results-path: test-results.json

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -13,6 +13,10 @@ permissions:
 jobs:
   Integration:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for Teleport-backed OTLP collector shipping.
+      id-token: write
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -63,62 +67,18 @@ jobs:
       id: api-tests
       run: make test-api-ci
 
-    - name: Analyze API test failures with Claude
-      if: always() && steps.api-tests.outcome == 'failure'
-      env:
-        CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      run: |
-        if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
-          {
-            echo "## API Integration Test Failure Analysis"
-            echo
-            echo "Claude analysis skipped because CLAUDE_CODE_OAUTH_TOKEN is not configured."
-          } >> "$GITHUB_STEP_SUMMARY"
-          exit 0
-        fi
-
-        if [ ! -s junit.xml ]; then
-          {
-            echo "## API Integration Test Failure Analysis"
-            echo
-            echo "Claude analysis skipped because junit.xml was not generated."
-          } >> "$GITHUB_STEP_SUMMARY"
-          exit 0
-        fi
-
-        if ! grep -Eq '<(failure|error)[ >]' junit.xml; then
-          {
-            echo "## API Integration Test Failure Analysis"
-            echo
-            echo "Claude analysis skipped because junit.xml does not contain failure or error elements."
-          } >> "$GITHUB_STEP_SUMMARY"
-          exit 0
-        fi
-
-        PROMPT=$(cat <<'EOF'
-        Analyze this Ginkgo JUnit XML from the identity API integration suite. Output markdown for a GitHub Actions step summary with:
-        - a '## API Integration Test Failure Analysis' heading
-        - a concise '### Failed Tests' table with columns Test, Error, Likely Cause
-        - a short '### Suggested Next Steps' list
-        Keep it specific to the failures shown and avoid generic advice.
-        EOF
-        )
-
-        OUTPUT=$(npx --yes @anthropic-ai/claude-code -p \
-          "$PROMPT" \
-          < junit.xml 2>/dev/null || true)
-
-        if [ -z "$OUTPUT" ]; then
-          {
-            echo "## API Integration Test Failure Analysis"
-            echo
-            echo "Claude did not return an analysis for junit.xml."
-          } >> "$GITHUB_STEP_SUMMARY"
-          exit 0
-        fi
-
-        printf '%s\n' "$OUTPUT" >> "$GITHUB_STEP_SUMMARY"
-        exit 0
+    - name: Report API Test Results
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-history-post-results
+      if: ${{ !cancelled() && (steps.api-tests.outcome == 'success' || steps.api-tests.outcome == 'failure') }}
+      with:
+        test-results-path: test-results.json
+        format: ginkgo-json
+        workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        environment: ci
+        title: 'Identity API Integration Test Results'
+        test-history-suite: uni-identity-api
+        enable-ai-analysis: 'true'
+        claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
     - name: Upload test artifacts
       if: failure()


### PR DESCRIPTION
## Summary
- replace the hand-written Claude failure summary with the shared test-results-report action
- publish identity integration test history with the uni-identity-api suite name
- grant GitHub OIDC id-token permission for Teleport-backed collector shipping

Depends on nscaledev/quality-tooling#11 for the action defaults.

## Validation
- ruby YAML parse for .github/workflows/integration.yaml

## Recent Retest
Small focused run against the latest shared action branch. Slack notifications were disabled where the workflow supports it.

| Suite | Result | Build | Reporter logs | Logs query |
| --- | --- | --- | --- | --- |
| uni-identity integration | success, attempt 2 | [27152492219](https://github.com/nscaledev/uni-identity/actions/runs/27152492219) | [reporter logs](https://wo11y-grafana-dev.nscale.teleport.sh/explore?orgId=1&schemaVersion=1&panes=%7B%22test-history%22%3A%7B%22datasource%22%3A%22logs-all%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%7Bservice_name%3D%5C%22test-results-report%5C%22%7D+%7C+github_run_id%3D%6027152492219%60%22%2C%22queryType%22%3A%22range%22%2C%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22logs-all%22%7D%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-6h%22%2C%22to%22%3A%22now%22%7D%7D%7D) | <code>{service_name="test-results-report"} &#124; github_run_id=`27152492219`</code> |
