### PR TITLE
Pin helm to v4.2.0 in integration workflow

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -29,6 +29,12 @@ jobs:
 
     - name: Install Helm
       uses: azure/setup-helm@v4
+      with:
+        # Pinned: helm v4.2.1 regressed --wait, stalling chart installs for ~40
+        # minutes (cert-manager, ingress-nginx) until they eventually succeed or
+        # time out. v4.2.0 installs the same charts in seconds. Drop the pin once
+        # a fixed helm release is available.
+        version: v4.2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
helm v4.2.1 regressed --wait: chart installs (cert-manager, ingress-nginx)
stall for ~40 minutes before completing, hanging the integration job. The
same charts install in seconds on v4.2.0, which all green runs used. Pin to
v4.2.0 until a fixed helm release ships.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
