### PR TITLE
feat(handler): accept Auth0 access tokens at the userinfo endpoint

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -228,7 +228,11 @@ func (h *Handler) GetOauth2V2Userinfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userinfo, _, err := h.oauth2.GetUserinfo(r.Context(), r, parts[1])
+	// Dispatch on the JOSE header: a JWS (Auth0 access token) is validated by
+	// the Auth0 validator when --auth0-exchange-* is configured; a UNI JWE
+	// access token follows the existing userinfo path. Mirrors the local
+	// authorizer so a bearer accepted at /api/v1/... is also accepted here.
+	userinfo, _, err := h.oauth2.GetUserinfoFromBearer(r.Context(), r, parts[1])
 	if err != nil {
 		errors.HandleError(w, r, err)
 		return
@@ -252,7 +256,9 @@ func (h *Handler) PostOauth2V2Userinfo(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		userinfo, _, err := h.oauth2.GetUserinfo(r.Context(), r, parts[1])
+		// Same JWS/JWE dispatch as the GET handler: accept Auth0 access tokens
+		// when --auth0-exchange-* is configured, UNI JWEs otherwise.
+		userinfo, _, err := h.oauth2.GetUserinfoFromBearer(r.Context(), r, parts[1])
 		if err != nil {
 			errors.HandleError(w, r, err)
 			return
@@ -269,7 +275,7 @@ func (h *Handler) PostOauth2V2Userinfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userinfo, _, err := h.oauth2.GetUserinfo(r.Context(), r, r.Form.Get("access_token"))
+	userinfo, _, err := h.oauth2.GetUserinfoFromBearer(r.Context(), r, r.Form.Get("access_token"))
 	if err != nil {
 		errors.HandleError(w, r, errors.AccessDenied(r, "access token is invalid").WithError(err))
 		return


### PR DESCRIPTION
## Summary

Routes the OIDC userinfo handlers through `GetUserinfoFromBearer` so `/oauth2/v2/userinfo` accepts Auth0 access tokens directly, the same way #502 did for the local authorizer (`/api/v1/...`). This is the follow-up #502 missed: it factored the JWS/JWE dispatch into `GetUserinfoFromBearer` and adopted it at the local authorizer, but the userinfo handlers still called `GetUserinfo` (the JWE-only path).

### Why

After #502, an Auth0 bearer works at `/api/v1/...` but still fails at `/oauth2/v2/userinfo` with:

```
failed to decrypt claims: failed to parse jwe: go-jose/go-jose: compact JWE format must have five parts
```

`GetUserinfo` only decrypts JWEs, so the RS256 3-part Auth0 JWS never reaches the Auth0 validator. The nscale console hits this endpoint to resolve the caller's verified email in three flows — the feature-flags proxy, dev-token (service-account) login, and the CLI device callback — all of which 401 post-Auth0-migration.

### Changes

- `pkg/handler/handler.go`: `GetOauth2V2Userinfo` (GET) and `PostOauth2V2Userinfo` (POST, both the Authorization-header and the `access_token` form paths) now call `GetUserinfoFromBearer` instead of `GetUserinfo`. Drop-in — identical signature. A comment per handler explains the dispatch, mirroring the local authorizer.

### Behaviour notes

- **Fully backwards-compatible.** When `--auth0-exchange-issuer` / `--auth0-exchange-audience` are unset, `auth0Validator` is nil and `GetUserinfoFromBearer` returns `GetUserinfo` verbatim — a JWS falls back to the UNI JWE path. Deployments without Auth0 exchange configured see no change.
- For Auth0 bearers the response is the Auth0-derived userinfo (`sub`, `email`, `email_verified`, and the namespaced authz claim with `acctype=User` and `orgIds` resolved from `userdb` by verified email, per #496). The handler discards the `Claims` return value, so the empty `Claims.Type` on the Auth0 path is irrelevant here.

## Test plan

- [x] `go test ./pkg/oauth2/...` — the `TestGetUserinfoFromBearer*` dispatch matrix from #502 (which this change relies on) passes.
- [x] `go test ./pkg/...` — clean, including `pkg/middleware/openapi/remote`.
- [x] `gofmt` / `go vet ./pkg/handler/... ./pkg/middleware/...` clean.
- [x] `make touch license validate lint generate test-unit` locally.
- [ ] Smoke-test a deployment with `auth0Exchange.*` set: present an Auth0 access token to `/oauth2/v2/userinfo` and observe 200 instead of the prior 401 with `failed to parse jwe`.
- [ ] Confirm a deployment with `auth0Exchange.*` unset is unchanged: Auth0 bearers fall back to the JWE path, UNI JWEs validate normally.