### PR TITLE
feat: scope-reader interfaces for cleaner, type-safe scope handling

### DIFF
--- a/pkg/client/README.md
+++ b/pkg/client/README.md
@@ -81,6 +81,11 @@ This is an important forward-looking deletion mechanism because it is based on
 explicit dependency registration rather than only namespace-local descendant
 discovery.
 
+`References` recovers the typed organization and project IDs that own the target
+resource via [`ids.ProjectScopeReader`](../ids/README.md) when the resource
+implements it (region CRDs do), falling back to parsing the standard
+organization/project labels otherwise.
+
 ### Allocations
 
 `Allocations` wraps the identity quota/allocation API used by API handlers and

--- a/pkg/client/export_test.go
+++ b/pkg/client/export_test.go
@@ -32,6 +32,11 @@ func ParsePrincipalIDs(p *principal.Principal) (ids.OrganizationID, ids.ProjectI
 	return parsePrincipalIDs(p)
 }
 
+// OrganizationAndProjectID exposes organizationAndProjectID for unit testing.
+func OrganizationAndProjectID(resource crClient.Object) (ids.OrganizationID, ids.ProjectID, error) {
+	return organizationAndProjectID(resource)
+}
+
 // SetClientFactory replaces the HTTP client factory on r, allowing tests to
 // inject a mock without going through the full Kubernetes service-discovery path.
 func (r *References) SetClientFactory(f func(ctx context.Context, c crClient.Client, resource crClient.Object) (openapi.ClientWithResponsesInterface, error)) {

--- a/pkg/client/references.go
+++ b/pkg/client/references.go
@@ -36,9 +36,13 @@ import (
 )
 
 // organizationAndProjectID recovers the typed organization and project IDs that own a
-// resource. If the resource implements ids.ProjectScopeReader (region CRDs do) the typed
-// accessor is used directly; otherwise it falls back to parsing the standard organization
-// and project labels.
+// resource. If the resource implements ids.ProjectScopeReader the typed accessor is used
+// directly; otherwise it parses the standard organization and project labels.
+//
+// The label path is a backwards-compatibility ramp, not a fallback to nowhere: resources
+// that have not yet adopted the ids.ProjectScopeReader accessors (and callers in repos that
+// pre-date it) keep working unchanged, while resources that do implement it are read through
+// the typed accessor. Both paths read the same labels, so they agree by construction.
 func organizationAndProjectID(resource client.Object) (ids.OrganizationID, ids.ProjectID, error) {
 	if r, ok := resource.(ids.ProjectScopeReader); ok {
 		return r.OrganizationAndProjectID()

--- a/pkg/client/references.go
+++ b/pkg/client/references.go
@@ -35,21 +35,38 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// getOrganizationAndProjectID extracts the organization and project IDs from a resource.
-func getOrganizationAndProjectID(resource client.Object) (string, string, error) {
+// organizationAndProjectID recovers the typed organization and project IDs that own a
+// resource. If the resource implements ids.ProjectScopeReader (region CRDs do) the typed
+// accessor is used directly; otherwise it falls back to parsing the standard organization
+// and project labels.
+func organizationAndProjectID(resource client.Object) (ids.OrganizationID, ids.ProjectID, error) {
+	if r, ok := resource.(ids.ProjectScopeReader); ok {
+		return r.OrganizationAndProjectID()
+	}
+
 	labels := resource.GetLabels()
 
 	organizationID, ok := labels[constants.OrganizationLabel]
 	if !ok {
-		return "", "", fmt.Errorf("%w: resource missing organization ID label", errors.ErrConsistency)
+		return ids.OrganizationID{}, ids.ProjectID{}, fmt.Errorf("%w: resource missing organization ID label", errors.ErrConsistency)
 	}
 
 	projectID, ok := labels[constants.ProjectLabel]
 	if !ok {
-		return "", "", fmt.Errorf("%w: resource missing project ID label", errors.ErrConsistency)
+		return ids.OrganizationID{}, ids.ProjectID{}, fmt.Errorf("%w: resource missing project ID label", errors.ErrConsistency)
 	}
 
-	return organizationID, projectID, nil
+	orgID, err := ids.ParseOrganizationID(organizationID)
+	if err != nil {
+		return ids.OrganizationID{}, ids.ProjectID{}, fmt.Errorf("%w: invalid organization ID on resource", err)
+	}
+
+	projID, err := ids.ParseProjectID(projectID)
+	if err != nil {
+		return ids.OrganizationID{}, ids.ProjectID{}, fmt.Errorf("%w: invalid project ID on resource", err)
+	}
+
+	return orgID, projID, nil
 }
 
 // References allows references to be added and removed on identity
@@ -95,19 +112,9 @@ func (r *References) AddReferenceToProject(ctx context.Context, resource client.
 		return err
 	}
 
-	organizationID, projectID, err := getOrganizationAndProjectID(resource)
+	orgID, projID, err := organizationAndProjectID(resource)
 	if err != nil {
 		return err
-	}
-
-	orgID, err := ids.ParseOrganizationID(organizationID)
-	if err != nil {
-		return fmt.Errorf("%w: invalid organization ID on resource", err)
-	}
-
-	projID, err := ids.ParseProjectID(projectID)
-	if err != nil {
-		return fmt.Errorf("%w: invalid project ID on resource", err)
 	}
 
 	response, err := httpClient.PutApiV1OrganizationsOrganizationIDProjectsProjectIDReferencesReferenceWithResponse(ctx, orgID, projID, url.PathEscape(reference))
@@ -138,19 +145,9 @@ func (r *References) RemoveReferenceFromProject(ctx context.Context, resource cl
 		return err
 	}
 
-	organizationID, projectID, err := getOrganizationAndProjectID(resource)
+	orgID, projID, err := organizationAndProjectID(resource)
 	if err != nil {
 		return err
-	}
-
-	orgID, err := ids.ParseOrganizationID(organizationID)
-	if err != nil {
-		return fmt.Errorf("%w: invalid organization ID on resource", err)
-	}
-
-	projID, err := ids.ParseProjectID(projectID)
-	if err != nil {
-		return fmt.Errorf("%w: invalid project ID on resource", err)
 	}
 
 	response, err := httpClient.DeleteApiV1OrganizationsOrganizationIDProjectsProjectIDReferencesReferenceWithResponse(ctx, orgID, projID, url.PathEscape(reference))

--- a/pkg/client/references_test.go
+++ b/pkg/client/references_test.go
@@ -79,6 +79,74 @@ func newTestResource() crClient.Object {
 	}
 }
 
+const (
+	testOrgID  = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	testProjID = "550e8400-e29b-41d4-a716-446655440000"
+)
+
+// scopeReaderResource is a resource that reports its scope via the typed
+// ids.ProjectScopeReader interface rather than via labels. Embedding *Project
+// makes it a crClient.Object; the accessor methods return fixed IDs.
+type scopeReaderResource struct {
+	*identityv1.Project
+}
+
+func (scopeReaderResource) OrganizationID() (ids.OrganizationID, error) {
+	return ids.MustParseOrganizationID(testOrgID), nil
+}
+
+func (scopeReaderResource) OrganizationAndProjectID() (ids.OrganizationID, ids.ProjectID, error) {
+	return ids.MustParseOrganizationID(testOrgID), ids.MustParseProjectID(testProjID), nil
+}
+
+func TestOrganizationAndProjectID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reads via ProjectScopeReader interface", func(t *testing.T) {
+		t.Parallel()
+
+		// No labels at all: the typed accessor must be used, not label parsing.
+		resource := scopeReaderResource{&identityv1.Project{}}
+
+		orgID, projID, err := client.OrganizationAndProjectID(resource)
+		require.NoError(t, err)
+		require.Equal(t, ids.MustParseOrganizationID(testOrgID), orgID)
+		require.Equal(t, ids.MustParseProjectID(testProjID), projID)
+	})
+
+	t.Run("falls back to label parsing", func(t *testing.T) {
+		t.Parallel()
+
+		orgID, projID, err := client.OrganizationAndProjectID(newTestResource())
+		require.NoError(t, err)
+		require.Equal(t, ids.MustParseOrganizationID(testOrgID), orgID)
+		require.Equal(t, ids.MustParseProjectID(testProjID), projID)
+	})
+
+	t.Run("missing label errors", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := client.OrganizationAndProjectID(&identityv1.Project{})
+		require.Error(t, err)
+	})
+
+	t.Run("invalid label value errors", func(t *testing.T) {
+		t.Parallel()
+
+		resource := &identityv1.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					constants.OrganizationLabel: "not-a-uuid",
+					constants.ProjectLabel:      testProjID,
+				},
+			},
+		}
+
+		_, _, err := client.OrganizationAndProjectID(resource)
+		require.Error(t, err)
+	})
+}
+
 // newTestReferences creates a References with the given mock injected as the HTTP client factory.
 func newTestReferences(mock openapi.ClientWithResponsesInterface) *client.References {
 	r := client.NewReferences(util.ServiceDescriptor{}, nil, nil)

--- a/pkg/handler/allocations/client.go
+++ b/pkg/handler/allocations/client.go
@@ -126,14 +126,14 @@ func generateAllocationList(in openapi.ResourceAllocationList) []unikornv1.Resou
 
 func generate(ctx context.Context, namespace *corev1.Namespace, organizationID ids.OrganizationID, projectID ids.ProjectID, in *openapi.AllocationWrite) (*unikornv1.Allocation, error) {
 	out := &unikornv1.Allocation{
-		ObjectMeta: conversion.NewObjectMetadata(&in.Metadata, namespace.Name).WithOrganization(organizationID.String()).WithProject(projectID.String()).WithLabel(constants.ReferencedResourceKindLabel, in.Spec.Kind).WithLabel(constants.ReferencedResourceIDLabel, in.Spec.Id).Get(),
+		ObjectMeta: conversion.NewObjectMetadata(&in.Metadata, namespace.Name).WithLabel(constants.ReferencedResourceKindLabel, in.Spec.Kind).WithLabel(constants.ReferencedResourceIDLabel, in.Spec.Id).Get(),
 		Spec: unikornv1.AllocationSpec{
 			Tags:        conversion.GenerateTagList(in.Metadata.Tags),
 			Allocations: generateAllocationList(in.Spec.Allocations),
 		},
 	}
 
-	if err := common.SetIdentityMetadata(ctx, &out.ObjectMeta); err != nil {
+	if err := common.SetIdentityMetadataProjectScope(ctx, &out.ObjectMeta, organizationID, projectID); err != nil {
 		return nil, fmt.Errorf("%w: failed to set identity metadata", err)
 	}
 

--- a/pkg/handler/common/common.go
+++ b/pkg/handler/common/common.go
@@ -264,7 +264,46 @@ func checkQuotaConsistency(quota *unikornv1.Quota, allocations *unikornv1.Alloca
 	return nil
 }
 
+// SetIdentityMetadataOrganizationScope stamps the organization placement label from a typed
+// ID and then sets the identity attribution metadata (see SetIdentityMetadata).
+//
+// Prefer this over conversion.NewObjectMetadata(...).WithOrganization(organizationID.String()):
+// core's builder is necessarily string-based (core cannot import pkg/ids without a circular
+// dependency), so calling it forces a .String() at the call site. This keeps the typed ID to
+// the lowest layer and stamps placement plus attribution scope in a single call.
+func SetIdentityMetadataOrganizationScope(ctx context.Context, meta *metav1.ObjectMeta, organizationID ids.OrganizationID) error {
+	if meta.Labels == nil {
+		meta.Labels = map[string]string{}
+	}
+
+	meta.Labels[constants.OrganizationLabel] = organizationID.String()
+
+	return SetIdentityMetadata(ctx, meta)
+}
+
+// SetIdentityMetadataProjectScope stamps the organization and project placement labels from
+// typed IDs and then sets the identity attribution metadata (see SetIdentityMetadata).
+//
+// Prefer this over conversion.NewObjectMetadata(...).WithOrganization(...).WithProject(...) for
+// the same reason as SetIdentityMetadataOrganizationScope: it keeps the typed IDs to the lowest
+// layer rather than forcing .String() at the call site.
+func SetIdentityMetadataProjectScope(ctx context.Context, meta *metav1.ObjectMeta, organizationID ids.OrganizationID, projectID ids.ProjectID) error {
+	if meta.Labels == nil {
+		meta.Labels = map[string]string{}
+	}
+
+	meta.Labels[constants.OrganizationLabel] = organizationID.String()
+	meta.Labels[constants.ProjectLabel] = projectID.String()
+
+	return SetIdentityMetadata(ctx, meta)
+}
+
 // SetIdentityMetadata sets identity specific metadata on a resource during generation.
+//
+// This sets attribution only (creator and principal scope). For resources that also carry
+// placement labels prefer SetIdentityMetadataOrganizationScope or
+// SetIdentityMetadataProjectScope, which set the placement organization/project from typed IDs
+// in the same call.
 func SetIdentityMetadata(ctx context.Context, meta *metav1.ObjectMeta) error {
 	info, err := authorization.FromContext(ctx)
 	if err != nil {

--- a/pkg/handler/groups/client.go
+++ b/pkg/handler/groups/client.go
@@ -383,7 +383,7 @@ func (c *Client) generate(ctx context.Context, organization *organizations.Meta,
 
 	// TODO: validate user and service account existence.
 	out := &unikornv1.Group{
-		ObjectMeta: conversion.NewObjectMetadata(&in.Metadata, organization.Namespace).WithOrganization(organization.ID.String()).Get(),
+		ObjectMeta: conversion.NewObjectMetadata(&in.Metadata, organization.Namespace).Get(),
 		Spec: unikornv1.GroupSpec{
 			Tags:              conversion.GenerateTagList(in.Metadata.Tags),
 			UserIDs:           userIDs,
@@ -393,7 +393,7 @@ func (c *Client) generate(ctx context.Context, organization *organizations.Meta,
 		},
 	}
 
-	if err := common.SetIdentityMetadata(ctx, &out.ObjectMeta); err != nil {
+	if err := common.SetIdentityMetadataOrganizationScope(ctx, &out.ObjectMeta, organization.ID); err != nil {
 		return nil, fmt.Errorf("%w: failed to set identity metadata", err)
 	}
 

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -604,10 +604,15 @@ func (h *Handler) GetApiV1OrganizationsOrganizationIDProjects(w http.ResponseWri
 	ctx := r.Context()
 
 	// Apply RBAC after listing as a filter.  resource.Metadata.Id is sourced from the
-	// API response body (a plain string), not a path parameter, so use the string
-	// overload here; typed IDs for response bodies are out of scope for this change.
+	// API response body (a plain string), so parse it to a typed ID here; a malformed
+	// value from our own response should never happen and is filtered from the result.
 	result = slices.DeleteFunc(result, func(resource openapi.ProjectRead) bool {
-		return rbac.AllowProjectScope(ctx, "identity:projects", openapi.Read, organizationID.String(), resource.Metadata.Id) != nil
+		projectID, err := ids.ParseProjectID(resource.Metadata.Id)
+		if err != nil {
+			return true
+		}
+
+		return rbac.AllowProjectScopeID(ctx, "identity:projects", openapi.Read, organizationID, projectID) != nil
 	})
 
 	h.setUncacheable(w)

--- a/pkg/handler/oauth2providers/client.go
+++ b/pkg/handler/oauth2providers/client.go
@@ -131,14 +131,14 @@ func (c *Client) List(ctx context.Context, organizationID ids.OrganizationID) (o
 
 func (c *Client) generate(ctx context.Context, organization *organizations.Meta, in *openapi.Oauth2ProviderWrite) (*unikornv1.OAuth2Provider, error) {
 	out := &unikornv1.OAuth2Provider{
-		ObjectMeta: conversion.NewObjectMetadata(&in.Metadata, organization.Namespace).WithOrganization(organization.ID.String()).Get(),
+		ObjectMeta: conversion.NewObjectMetadata(&in.Metadata, organization.Namespace).Get(),
 		Spec: unikornv1.OAuth2ProviderSpec{
 			Issuer:   in.Spec.Issuer,
 			ClientID: in.Spec.ClientID,
 		},
 	}
 
-	if err := common.SetIdentityMetadata(ctx, &out.ObjectMeta); err != nil {
+	if err := common.SetIdentityMetadataOrganizationScope(ctx, &out.ObjectMeta, organization.ID); err != nil {
 		return nil, fmt.Errorf("%w: failed to set identity metadata", err)
 	}
 

--- a/pkg/handler/projects/client.go
+++ b/pkg/handler/projects/client.go
@@ -128,14 +128,14 @@ func (c *Client) Get(ctx context.Context, organizationID ids.OrganizationID, pro
 
 func (c *Client) generate(ctx context.Context, organization *organizations.Meta, in *openapi.ProjectWrite) (*unikornv1.Project, error) {
 	out := &unikornv1.Project{
-		ObjectMeta: conversion.NewObjectMetadata(&in.Metadata, organization.Namespace).WithOrganization(organization.ID.String()).Get(),
+		ObjectMeta: conversion.NewObjectMetadata(&in.Metadata, organization.Namespace).Get(),
 		Spec: unikornv1.ProjectSpec{
 			Tags:     conversion.GenerateTagList(in.Metadata.Tags),
 			GroupIDs: in.Spec.GroupIDs,
 		},
 	}
 
-	if err := common.SetIdentityMetadata(ctx, &out.ObjectMeta); err != nil {
+	if err := common.SetIdentityMetadataOrganizationScope(ctx, &out.ObjectMeta, organization.ID); err != nil {
 		return nil, fmt.Errorf("%w: failed to set identity metadata", err)
 	}
 

--- a/pkg/handler/quotas/client.go
+++ b/pkg/handler/quotas/client.go
@@ -85,13 +85,13 @@ func generate(ctx context.Context, organization *organizations.Meta, in *openapi
 	}
 
 	out := &unikornv1.Quota{
-		ObjectMeta: conversion.NewObjectMetadata(metadata, organization.Namespace).WithOrganization(organization.ID.String()).Get(),
+		ObjectMeta: conversion.NewObjectMetadata(metadata, organization.Namespace).Get(),
 		Spec: unikornv1.QuotaSpec{
 			Quotas: generateQuotaList(in.Quotas),
 		},
 	}
 
-	if err := common.SetIdentityMetadata(ctx, &out.ObjectMeta); err != nil {
+	if err := common.SetIdentityMetadataOrganizationScope(ctx, &out.ObjectMeta, organization.ID); err != nil {
 		return nil, fmt.Errorf("%w: failed to set identity metadata", err)
 	}
 

--- a/pkg/handler/serviceaccounts/client.go
+++ b/pkg/handler/serviceaccounts/client.go
@@ -155,13 +155,13 @@ func (c *Client) generateAccessToken(ctx context.Context, organization *organiza
 // a new access token.
 func (c *Client) generate(ctx context.Context, organization *organizations.Meta, in *openapi.ServiceAccountWrite) (*unikornv1.ServiceAccount, error) {
 	out := &unikornv1.ServiceAccount{
-		ObjectMeta: conversion.NewObjectMetadata(&in.Metadata, organization.Namespace).WithOrganization(organization.ID.String()).Get(),
+		ObjectMeta: conversion.NewObjectMetadata(&in.Metadata, organization.Namespace).Get(),
 		Spec: unikornv1.ServiceAccountSpec{
 			Tags: conversion.GenerateTagList(in.Metadata.Tags),
 		},
 	}
 
-	if err := common.SetIdentityMetadata(ctx, &out.ObjectMeta); err != nil {
+	if err := common.SetIdentityMetadataOrganizationScope(ctx, &out.ObjectMeta, organization.ID); err != nil {
 		return nil, fmt.Errorf("%w: failed to set identity metadata", err)
 	}
 

--- a/pkg/handler/users/client.go
+++ b/pkg/handler/users/client.go
@@ -215,13 +215,13 @@ func generateOrganizationUser(ctx context.Context, organization *organizations.M
 	}
 
 	out := &unikornv1.OrganizationUser{
-		ObjectMeta: conversion.NewObjectMetadata(metadata, organization.Namespace).WithOrganization(organization.ID.String()).WithLabel(constants.UserLabel, userID).Get(),
+		ObjectMeta: conversion.NewObjectMetadata(metadata, organization.Namespace).WithLabel(constants.UserLabel, userID).Get(),
 		Spec: unikornv1.OrganizationUserSpec{
 			State: generateUserState(in.Spec.State),
 		},
 	}
 
-	if err := common.SetIdentityMetadata(ctx, &out.ObjectMeta); err != nil {
+	if err := common.SetIdentityMetadataOrganizationScope(ctx, &out.ObjectMeta, organization.ID); err != nil {
 		return nil, fmt.Errorf("%w: failed to set identity metadata", err)
 	}
 

--- a/pkg/ids/README.md
+++ b/pkg/ids/README.md
@@ -35,3 +35,45 @@ that has already passed the binding layer).
 **Outward (typed ID → string):** Call `.String()` to produce the canonical
 hyphenated UUID string for Kubernetes object names, label values, or log
 messages.
+
+## Scope readers
+
+Two interfaces let scope-aware code accept a resource directly instead of bare
+IDs, performing the "read labels, parse to typed ID" step in one place:
+
+| Interface | Method(s) |
+|---|---|
+| `OrganizationScopeReader` | `OrganizationID() (OrganizationID, error)` |
+| `ProjectScopeReader` | embeds `OrganizationScopeReader` plus `OrganizationAndProjectID() (OrganizationID, ProjectID, error)` |
+
+`ProjectScopeReader` **embeds** `OrganizationScopeReader` because a project
+always belongs to an organization — anything that knows its project also knows
+its organization. A consumer can therefore accept the narrower
+`OrganizationScopeReader` and still be passed a project-scoped resource.
+
+These are implemented by CRDs in other services (e.g. `region`'s `Server`,
+`Network`, `SecurityGroup`, …), whose accessor methods recover the IDs from the
+standard organization/project labels. Consumers in this repo include the RBAC
+`*Reader` helpers (`pkg/rbac`), the principal-enrichment helpers
+(`pkg/principal`), and the `References` SDK client (`pkg/client`).
+
+Three comparison helpers operate over these interfaces. All are
+referential-integrity (ownership-equality) checks, **not** RBAC checks: they ask
+whether resources belong to a given tenancy, not whether a caller may act in it.
+Routing these through an RBAC scope check would let a caller authorized for
+several projects relate resources across tenancy boundaries. All return an error
+only when a resource's scope cannot be read, and a `bool` otherwise — callers map
+a `false` result to their own transport error (the convention is `404`, so
+resource existence is not leaked); this package stays free of transport concerns.
+
+| Helper | Question |
+|---|---|
+| `SameProject(a, b ProjectScopeReader)` | do two resources share an org+project? |
+| `OwnedByProject(scope ProjectScopeReader, organizationID, projectID)` | does a resource live in this org+project? |
+| `OwnedByOrganization(scope OrganizationScopeReader, organizationID)` | does a resource live in this organization? |
+
+`SameProject` guards relationships between two resources (e.g. a server and the
+SSH certificate authority it references). `OwnedByProject` / `OwnedByOrganization`
+are the typed equivalents of core's `AssertProjectOwnership` /
+`AssertOrganizationOwnership`, for verifying a resource fetched by ID actually
+belongs to the org/project from the request path.

--- a/pkg/ids/interfaces.go
+++ b/pkg/ids/interfaces.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ids
+
+// OrganizationScopeReader is implemented by resources that can report the typed
+// organization ID that owns them, recovered from their Kubernetes labels. It lets
+// scope-aware code (RBAC checks, principal enrichment, reference management) accept
+// a resource directly and perform the label-read-and-parse step in one place.
+type OrganizationScopeReader interface {
+	OrganizationID() (OrganizationID, error)
+}
+
+// ProjectScopeReader is implemented by resources that can report the typed
+// organization and project IDs that own them. It embeds OrganizationScopeReader
+// because every project-scoped resource necessarily belongs to an organization, so
+// anything that knows its project also knows its organization.
+type ProjectScopeReader interface {
+	OrganizationScopeReader
+	OrganizationAndProjectID() (OrganizationID, ProjectID, error)
+}
+
+// SameProject reports whether a and b are owned by the same organization and project.
+// It returns an error if either resource's owning scope cannot be determined (e.g. missing
+// or malformed labels).
+//
+// Use this before establishing a relationship between two project-scoped resources — for
+// example, ensuring a server and the SSH certificate authority it references live in the
+// same project. Callers decide how to treat a false result (typically a forbidden/bad-request
+// response); this package stays free of transport-error concerns.
+func SameProject(a, b ProjectScopeReader) (bool, error) {
+	aOrganizationID, aProjectID, err := a.OrganizationAndProjectID()
+	if err != nil {
+		return false, err
+	}
+
+	bOrganizationID, bProjectID, err := b.OrganizationAndProjectID()
+	if err != nil {
+		return false, err
+	}
+
+	return aOrganizationID == bOrganizationID && aProjectID == bProjectID, nil
+}
+
+// OwnedByOrganization reports whether scope is owned by the given organization. It returns
+// an error if the resource's owning scope cannot be determined (e.g. a missing or malformed
+// label).
+//
+// This is a referential-integrity check — does this resource live in the expected
+// organization — and is the typed equivalent of core's AssertOrganizationOwnership. It is
+// deliberately NOT an RBAC check: RBAC asks whether the caller may act in an organization,
+// whereas this asks whether a specific resource belongs to one. Using an RBAC scope check
+// here would let a caller authorized for several organizations relate resources across
+// tenancy boundaries. Callers map a false result to their own transport error (the convention
+// is 404, so resource existence is not leaked); this package stays free of transport-error
+// concerns.
+func OwnedByOrganization(scope OrganizationScopeReader, organizationID OrganizationID) (bool, error) {
+	resourceOrganizationID, err := scope.OrganizationID()
+	if err != nil {
+		return false, err
+	}
+
+	return resourceOrganizationID == organizationID, nil
+}
+
+// OwnedByProject reports whether scope is owned by the given organization and project. It
+// returns an error if the resource's owning scope cannot be determined. It is the typed
+// equivalent of core's AssertProjectOwnership; see OwnedByOrganization for why this is an
+// ownership-equality check rather than an RBAC check.
+func OwnedByProject(scope ProjectScopeReader, organizationID OrganizationID, projectID ProjectID) (bool, error) {
+	resourceOrganizationID, resourceProjectID, err := scope.OrganizationAndProjectID()
+	if err != nil {
+		return false, err
+	}
+
+	return resourceOrganizationID == organizationID && resourceProjectID == projectID, nil
+}

--- a/pkg/ids/interfaces_test.go
+++ b/pkg/ids/interfaces_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ids_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/unikorn-cloud/identity/pkg/ids"
+)
+
+var errScope = errors.New("scope unavailable")
+
+// scopeStub implements both scope-reader interfaces, standing in for a CRD that
+// recovers its owning organization and project from labels.
+type scopeStub struct {
+	orgID  ids.OrganizationID
+	projID ids.ProjectID
+	err    error
+}
+
+func (s scopeStub) OrganizationID() (ids.OrganizationID, error) {
+	return s.orgID, s.err
+}
+
+func (s scopeStub) OrganizationAndProjectID() (ids.OrganizationID, ids.ProjectID, error) {
+	return s.orgID, s.projID, s.err
+}
+
+// Compile-time assertions that the interfaces are satisfiable, and that a
+// ProjectScopeReader is usable wherever an OrganizationScopeReader is required
+// (the embedding contract).
+var (
+	_ ids.OrganizationScopeReader = scopeStub{}
+	_ ids.ProjectScopeReader      = scopeStub{}
+	_ ids.OrganizationScopeReader = ids.ProjectScopeReader(scopeStub{})
+)
+
+func TestSameProject(t *testing.T) {
+	t.Parallel()
+
+	org1 := ids.MustParseOrganizationID("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	org2 := ids.MustParseOrganizationID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	proj1 := ids.MustParseProjectID("550e8400-e29b-41d4-a716-446655440000")
+	proj2 := ids.MustParseProjectID("123e4567-e89b-12d3-a456-426614174000")
+
+	tests := []struct {
+		name    string
+		a       scopeStub
+		b       scopeStub
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "same organization and project",
+			a:    scopeStub{orgID: org1, projID: proj1},
+			b:    scopeStub{orgID: org1, projID: proj1},
+			want: true,
+		},
+		{
+			name: "same organization, different project",
+			a:    scopeStub{orgID: org1, projID: proj1},
+			b:    scopeStub{orgID: org1, projID: proj2},
+			want: false,
+		},
+		{
+			name: "different organization, same project ID",
+			a:    scopeStub{orgID: org1, projID: proj1},
+			b:    scopeStub{orgID: org2, projID: proj1},
+			want: false,
+		},
+		{
+			name:    "first resource scope error",
+			a:       scopeStub{err: errScope},
+			b:       scopeStub{orgID: org1, projID: proj1},
+			wantErr: true,
+		},
+		{
+			name:    "second resource scope error",
+			a:       scopeStub{orgID: org1, projID: proj1},
+			b:       scopeStub{err: errScope},
+			wantErr: true,
+		},
+	}
+
+	for i := range tests {
+		test := &tests[i]
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ids.SameProject(test.a, test.b)
+
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != test.want {
+				t.Fatalf("SameProject = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestOwnedByProject(t *testing.T) {
+	t.Parallel()
+
+	org1 := ids.MustParseOrganizationID("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	org2 := ids.MustParseOrganizationID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	proj1 := ids.MustParseProjectID("550e8400-e29b-41d4-a716-446655440000")
+	proj2 := ids.MustParseProjectID("123e4567-e89b-12d3-a456-426614174000")
+
+	tests := []struct {
+		name    string
+		scope   scopeStub
+		orgID   ids.OrganizationID
+		projID  ids.ProjectID
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:   "owned by the expected organization and project",
+			scope:  scopeStub{orgID: org1, projID: proj1},
+			orgID:  org1,
+			projID: proj1,
+			want:   true,
+		},
+		{
+			name:   "wrong project",
+			scope:  scopeStub{orgID: org1, projID: proj1},
+			orgID:  org1,
+			projID: proj2,
+			want:   false,
+		},
+		{
+			name:   "wrong organization",
+			scope:  scopeStub{orgID: org1, projID: proj1},
+			orgID:  org2,
+			projID: proj1,
+			want:   false,
+		},
+		{
+			name:    "scope error",
+			scope:   scopeStub{err: errScope},
+			orgID:   org1,
+			projID:  proj1,
+			wantErr: true,
+		},
+	}
+
+	for i := range tests {
+		test := &tests[i]
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ids.OwnedByProject(test.scope, test.orgID, test.projID)
+
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != test.want {
+				t.Fatalf("OwnedByProject = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestOwnedByOrganization(t *testing.T) {
+	t.Parallel()
+
+	org1 := ids.MustParseOrganizationID("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	org2 := ids.MustParseOrganizationID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+	tests := []struct {
+		name    string
+		scope   scopeStub
+		orgID   ids.OrganizationID
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:  "owned by the expected organization",
+			scope: scopeStub{orgID: org1},
+			orgID: org1,
+			want:  true,
+		},
+		{
+			name:  "wrong organization",
+			scope: scopeStub{orgID: org1},
+			orgID: org2,
+			want:  false,
+		},
+		{
+			name:    "scope error",
+			scope:   scopeStub{err: errScope},
+			orgID:   org1,
+			wantErr: true,
+		},
+	}
+
+	for i := range tests {
+		test := &tests[i]
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ids.OwnedByOrganization(test.scope, test.orgID)
+
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != test.want {
+				t.Fatalf("OwnedByOrganization = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/principal/README.md
+++ b/pkg/principal/README.md
@@ -78,6 +78,29 @@ That distinction allows downstream services to answer questions like:
 - where does it live?
 - who should quota or billing be attributed to?
 
+## Principal Enrichment
+
+`EnrichUserPrincipal{Organization,Project}Scope*()` fill the context principal's organization (and
+project) **attribution**, but **only when the principal does not already carry an organization**.
+Mirroring the [`pkg/rbac`](../rbac/README.md) scope helpers, each comes in two flavours so callers
+pass whatever they already hold:
+
+- `…ScopeID` takes typed `ids.OrganizationID` / `ids.ProjectID` — for callers holding a decoded
+  path parameter at create time, before a resource implementing the interface exists.
+- `…ScopeReader` takes a resource implementing the [`ids`](../ids/README.md) scope-reader
+  interfaces and recovers the IDs from it; it delegates to the `…ScopeID` primitive.
+
+That guard is deliberate and reflects the attribution-vs-placement distinction above:
+
+- In the common v2 path the organization/project come from the request body or a parent resource,
+  so the context principal arrives without an organization and is filled here.
+- When a principal was propagated from an upstream system service (mTLS, `X-Principal`) it may
+  already carry the originating organization. That is authoritative attribution and must not be
+  overwritten by the resource's *placement* organization, so enrichment is skipped.
+
+These helpers are the typed home for what downstream services previously did with a bespoke
+per-repo helper.
+
 ## Caveats
 
 - Attribution does not imply visibility. A principal may be the correct audit or billing subject

--- a/pkg/principal/enrich.go
+++ b/pkg/principal/enrich.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package principal
+
+import (
+	"context"
+
+	"github.com/unikorn-cloud/identity/pkg/ids"
+)
+
+// EnrichUserPrincipalOrganizationScopeID fills the context principal's organization
+// (attribution) from a typed ID, but ONLY if it is not already set.
+//
+// In the common v2 path the organization comes from the request body or a parent
+// resource (i.e. a path parameter), so the principal arrives without an organization and
+// is filled here. When a principal was propagated from an upstream system service (mTLS,
+// X-Principal) it may already carry the originating organization; the guard preserves that
+// attribution rather than overwriting it with the resource's placement organization.
+// Attribution and placement are distinct concerns and must not be collapsed.
+//
+// Mirroring the rbac scope helpers, the ID variant is for callers holding a typed ID (e.g. a
+// decoded path parameter); the Reader variant is for callers holding a resource.
+func EnrichUserPrincipalOrganizationScopeID(ctx context.Context, organizationID ids.OrganizationID) error {
+	p, err := FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	if p.OrganizationID != "" {
+		return nil
+	}
+
+	p.OrganizationID = organizationID.String()
+
+	return nil
+}
+
+// EnrichUserPrincipalProjectScopeID fills the context principal's organization and project
+// (attribution) from typed IDs, with the same "enrich only when unset" guard as
+// EnrichUserPrincipalOrganizationScopeID; see that function for the attribution-vs-placement
+// rationale.
+func EnrichUserPrincipalProjectScopeID(ctx context.Context, organizationID ids.OrganizationID, projectID ids.ProjectID) error {
+	p, err := FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	if p.OrganizationID != "" {
+		return nil
+	}
+
+	p.OrganizationID = organizationID.String()
+	p.ProjectID = projectID.String()
+
+	return nil
+}
+
+// EnrichUserPrincipalOrganizationScopeReader recovers the organization ID from a resource
+// implementing ids.OrganizationScopeReader (e.g. a region CRD) and delegates to
+// EnrichUserPrincipalOrganizationScopeID. Callers holding a typed path-parameter ID should use
+// the ID variant instead.
+func EnrichUserPrincipalOrganizationScopeReader(ctx context.Context, scope ids.OrganizationScopeReader) error {
+	organizationID, err := scope.OrganizationID()
+	if err != nil {
+		return err
+	}
+
+	return EnrichUserPrincipalOrganizationScopeID(ctx, organizationID)
+}
+
+// EnrichUserPrincipalProjectScopeReader recovers the organization and project IDs from a
+// resource implementing ids.ProjectScopeReader and delegates to
+// EnrichUserPrincipalProjectScopeID.
+func EnrichUserPrincipalProjectScopeReader(ctx context.Context, scope ids.ProjectScopeReader) error {
+	organizationID, projectID, err := scope.OrganizationAndProjectID()
+	if err != nil {
+		return err
+	}
+
+	return EnrichUserPrincipalProjectScopeID(ctx, organizationID, projectID)
+}

--- a/pkg/principal/enrich_test.go
+++ b/pkg/principal/enrich_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package principal_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/identity/pkg/ids"
+	"github.com/unikorn-cloud/identity/pkg/principal"
+)
+
+const (
+	enrichOrgID  = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	enrichProjID = "550e8400-e29b-41d4-a716-446655440000"
+)
+
+var errScope = errors.New("scope accessor failed")
+
+// scopeStub stands in for a CRD that reports its scope via the ids scope-reader
+// interfaces, returning fixed IDs (or an error).
+type scopeStub struct {
+	orgID  ids.OrganizationID
+	projID ids.ProjectID
+	err    error
+}
+
+func (s scopeStub) OrganizationID() (ids.OrganizationID, error) {
+	return s.orgID, s.err
+}
+
+func (s scopeStub) OrganizationAndProjectID() (ids.OrganizationID, ids.ProjectID, error) {
+	return s.orgID, s.projID, s.err
+}
+
+func TestEnrichUserPrincipalProjectScopeID(t *testing.T) {
+	t.Parallel()
+
+	orgID := ids.MustParseOrganizationID(enrichOrgID)
+	projID := ids.MustParseProjectID(enrichProjID)
+
+	t.Run("missing principal errors", func(t *testing.T) {
+		t.Parallel()
+
+		err := principal.EnrichUserPrincipalProjectScopeID(t.Context(), orgID, projID)
+		require.Error(t, err)
+	})
+
+	t.Run("fills organization and project when unset", func(t *testing.T) {
+		t.Parallel()
+
+		p := &principal.Principal{}
+		ctx := principal.NewContext(t.Context(), p)
+
+		require.NoError(t, principal.EnrichUserPrincipalProjectScopeID(ctx, orgID, projID))
+		require.Equal(t, enrichOrgID, p.OrganizationID)
+		require.Equal(t, enrichProjID, p.ProjectID)
+	})
+
+	t.Run("preserves existing attribution", func(t *testing.T) {
+		t.Parallel()
+
+		p := &principal.Principal{OrganizationID: "existing-org", ProjectID: "existing-project"}
+		ctx := principal.NewContext(t.Context(), p)
+
+		require.NoError(t, principal.EnrichUserPrincipalProjectScopeID(ctx, orgID, projID))
+		require.Equal(t, "existing-org", p.OrganizationID)
+		require.Equal(t, "existing-project", p.ProjectID)
+	})
+}
+
+func TestEnrichUserPrincipalOrganizationScopeID(t *testing.T) {
+	t.Parallel()
+
+	orgID := ids.MustParseOrganizationID(enrichOrgID)
+
+	t.Run("missing principal errors", func(t *testing.T) {
+		t.Parallel()
+
+		err := principal.EnrichUserPrincipalOrganizationScopeID(t.Context(), orgID)
+		require.Error(t, err)
+	})
+
+	t.Run("fills organization when unset", func(t *testing.T) {
+		t.Parallel()
+
+		p := &principal.Principal{}
+		ctx := principal.NewContext(t.Context(), p)
+
+		require.NoError(t, principal.EnrichUserPrincipalOrganizationScopeID(ctx, orgID))
+		require.Equal(t, enrichOrgID, p.OrganizationID)
+	})
+
+	t.Run("preserves existing attribution", func(t *testing.T) {
+		t.Parallel()
+
+		p := &principal.Principal{OrganizationID: "existing-org"}
+		ctx := principal.NewContext(t.Context(), p)
+
+		require.NoError(t, principal.EnrichUserPrincipalOrganizationScopeID(ctx, orgID))
+		require.Equal(t, "existing-org", p.OrganizationID)
+	})
+}
+
+func TestEnrichUserPrincipalProjectScopeReader(t *testing.T) {
+	t.Parallel()
+
+	scope := scopeStub{
+		orgID:  ids.MustParseOrganizationID(enrichOrgID),
+		projID: ids.MustParseProjectID(enrichProjID),
+	}
+
+	t.Run("fills organization and project from the resource", func(t *testing.T) {
+		t.Parallel()
+
+		p := &principal.Principal{}
+		ctx := principal.NewContext(t.Context(), p)
+
+		require.NoError(t, principal.EnrichUserPrincipalProjectScopeReader(ctx, scope))
+		require.Equal(t, enrichOrgID, p.OrganizationID)
+		require.Equal(t, enrichProjID, p.ProjectID)
+	})
+
+	t.Run("accessor error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := principal.NewContext(t.Context(), &principal.Principal{})
+
+		err := principal.EnrichUserPrincipalProjectScopeReader(ctx, scopeStub{err: errScope})
+		require.ErrorIs(t, err, errScope)
+	})
+}
+
+func TestEnrichUserPrincipalOrganizationScopeReader(t *testing.T) {
+	t.Parallel()
+
+	scope := scopeStub{orgID: ids.MustParseOrganizationID(enrichOrgID)}
+
+	t.Run("fills organization from the resource", func(t *testing.T) {
+		t.Parallel()
+
+		p := &principal.Principal{}
+		ctx := principal.NewContext(t.Context(), p)
+
+		require.NoError(t, principal.EnrichUserPrincipalOrganizationScopeReader(ctx, scope))
+		require.Equal(t, enrichOrgID, p.OrganizationID)
+	})
+
+	t.Run("accessor error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := principal.NewContext(t.Context(), &principal.Principal{})
+
+		err := principal.EnrichUserPrincipalOrganizationScopeReader(ctx, scopeStub{err: errScope})
+		require.ErrorIs(t, err, errScope)
+	})
+}

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -55,7 +55,9 @@ Each scope check comes in three argument flavours so callers pass whatever they 
 without re-deriving it:
 
 - `AllowOrganizationScope` / `AllowProjectScope` / `AllowProjectScopeCreate` take plain `string`
-  IDs, retained for callers in other repositories that pre-date the typed ID types.
+  IDs. These are **deprecated** (marked `// Deprecated:` so tooling flags new use) but **retained
+  for backwards compatibility** — they are not slated for removal, since IDs sourced from API
+  response bodies and callers in repos that pre-date the typed ID types still need them.
 - `…ID` variants (`AllowOrganizationScopeID`, `AllowProjectScopeID`, `AllowProjectScopeCreateID`)
   take typed `ids.OrganizationID` / `ids.ProjectID`. **API handlers use these**, since the IDs
   arrive already decoded from URL path parameters.

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -51,6 +51,21 @@ project permissions remain the narrowest scope.
 This scoped structure is used both for direct authorization decisions and for query limiting in list
 operations.
 
+Each scope check comes in three argument flavours so callers pass whatever they already hold,
+without re-deriving it:
+
+- `AllowOrganizationScope` / `AllowProjectScope` / `AllowProjectScopeCreate` take plain `string`
+  IDs, retained for callers in other repositories that pre-date the typed ID types.
+- `…ID` variants (`AllowOrganizationScopeID`, `AllowProjectScopeID`, `AllowProjectScopeCreateID`)
+  take typed `ids.OrganizationID` / `ids.ProjectID`. **API handlers use these**, since the IDs
+  arrive already decoded from URL path parameters.
+- `…Reader` variants (`AllowOrganizationScopeReader`, `AllowProjectScopeReader`,
+  `AllowProjectScopeCreateReader`) take a resource implementing `ids.OrganizationScopeReader` /
+  `ids.ProjectScopeReader` and recover the IDs from it. **Callers holding a CRD use these** — the
+  label-read-and-parse happens in one place behind the interface rather than at every call.
+
+Rule of thumb: path-parameter handler → `…ID`; you have a CRD object in hand → `…Reader`.
+
 ## Actor Model
 
 The package distinguishes three important actor classes:

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -56,8 +56,9 @@ without re-deriving it:
 
 - `AllowOrganizationScope` / `AllowProjectScope` / `AllowProjectScopeCreate` take plain `string`
   IDs. These are **deprecated** (marked `// Deprecated:` so tooling flags new use) but **retained
-  for backwards compatibility** — they are not slated for removal, since IDs sourced from API
-  response bodies and callers in repos that pre-date the typed ID types still need them.
+  for backwards compatibility** while callers that still deal in plain strings (IDs sourced from
+  API response bodies, and repos that pre-date the typed ID types) migrate; they will be removed
+  once that is done.
 - `…ID` variants (`AllowOrganizationScopeID`, `AllowProjectScopeID`, `AllowProjectScopeCreateID`)
   take typed `ids.OrganizationID` / `ids.ProjectID`. **API handlers use these**, since the IDs
   arrive already decoded from URL path parameters.

--- a/pkg/rbac/handler.go
+++ b/pkg/rbac/handler.go
@@ -92,7 +92,7 @@ func AllowOrganizationScopeReader(ctx context.Context, endpoint string, operatio
 // AllowOrganizationScopeReader (for a resource implementing ids.OrganizationScopeReader).
 // This string overload is retained for backwards compatibility with callers that still
 // deal in plain strings (e.g. IDs from API response bodies or pre-typed-ID repositories)
-// and is not slated for removal.
+// and will be removed once those callers have migrated.
 func AllowOrganizationScope(ctx context.Context, endpoint string, operation openapi.AclOperation, organizationID string) error {
 	if AllowGlobalScope(ctx, endpoint, operation) == nil {
 		return nil
@@ -144,7 +144,7 @@ func AllowProjectScopeReader(ctx context.Context, endpoint string, operation ope
 // AllowProjectScopeReader (for a resource implementing ids.ProjectScopeReader). This
 // string overload is retained for backwards compatibility with callers that still deal
 // in plain strings (e.g. IDs from API response bodies or pre-typed-ID repositories) and
-// is not slated for removal.
+// will be removed once those callers have migrated.
 func AllowProjectScope(ctx context.Context, endpoint string, operation openapi.AclOperation, organizationID, projectID string) error {
 	if AllowOrganizationScope(ctx, endpoint, operation, organizationID) == nil {
 		return nil
@@ -239,8 +239,8 @@ func AllowProjectScopeCreateReader(ctx context.Context, client openapi.ClientWit
 // Deprecated: prefer the typed AllowProjectScopeCreateID (for path-parameter IDs) or
 // AllowProjectScopeCreateReader (for a resource implementing ids.ProjectScopeReader). This
 // string overload is retained for backwards compatibility with callers that pre-date the
-// typed ID types and is not slated for removal; the typed variants delegate here after
-// converting to strings.
+// typed ID types and will be removed once those callers have migrated; the typed variants
+// delegate here after converting to strings.
 func AllowProjectScopeCreate(ctx context.Context, client openapi.ClientWithResponsesInterface, endpoint string, operation openapi.AclOperation, organizationID, projectID string) error {
 	// If the project is explicitly present in the ACL it was fetched from storage
 	// when the ACL was built, so it must exist.

--- a/pkg/rbac/handler.go
+++ b/pkg/rbac/handler.go
@@ -72,6 +72,19 @@ func AllowOrganizationScopeID(ctx context.Context, endpoint string, operation op
 	return AllowOrganizationScope(ctx, endpoint, operation, organizationID.String())
 }
 
+// AllowOrganizationScopeReader is the variant of AllowOrganizationScope for callers that
+// hold a resource implementing ids.OrganizationScopeReader (e.g. a region CRD). It recovers
+// the organization ID from the resource. API handlers holding a path-parameter ID should use
+// AllowOrganizationScopeID instead.
+func AllowOrganizationScopeReader(ctx context.Context, endpoint string, operation openapi.AclOperation, scope ids.OrganizationScopeReader) error {
+	organizationID, err := scope.OrganizationID()
+	if err != nil {
+		return err
+	}
+
+	return AllowOrganizationScopeID(ctx, endpoint, operation, organizationID)
+}
+
 // AllowOrganizationScope tries to allow the requested operation at the global scope, then
 // the organization scope.
 func AllowOrganizationScope(ctx context.Context, endpoint string, operation openapi.AclOperation, organizationID string) error {
@@ -103,6 +116,19 @@ func AllowOrganizationScope(ctx context.Context, endpoint string, operation open
 // AllowProjectScopeID is the typed variant of AllowProjectScope.
 func AllowProjectScopeID(ctx context.Context, endpoint string, operation openapi.AclOperation, organizationID ids.OrganizationID, projectID ids.ProjectID) error {
 	return AllowProjectScope(ctx, endpoint, operation, organizationID.String(), projectID.String())
+}
+
+// AllowProjectScopeReader is the variant of AllowProjectScope for callers that hold a resource
+// implementing ids.ProjectScopeReader (e.g. a region CRD). It recovers the organization and
+// project IDs from the resource. API handlers holding path-parameter IDs should use
+// AllowProjectScopeID instead.
+func AllowProjectScopeReader(ctx context.Context, endpoint string, operation openapi.AclOperation, scope ids.ProjectScopeReader) error {
+	organizationID, projectID, err := scope.OrganizationAndProjectID()
+	if err != nil {
+		return err
+	}
+
+	return AllowProjectScopeID(ctx, endpoint, operation, organizationID, projectID)
 }
 
 // AllowProjectScope tries to allow the requested operation at the global scope, then
@@ -177,6 +203,18 @@ func isAllowedByProjectACL(ctx context.Context, endpoint string, operation opena
 // AllowProjectScopeCreateID is the typed variant of AllowProjectScopeCreate.
 func AllowProjectScopeCreateID(ctx context.Context, client openapi.ClientWithResponsesInterface, endpoint string, operation openapi.AclOperation, organizationID ids.OrganizationID, projectID ids.ProjectID) error {
 	return AllowProjectScopeCreate(ctx, client, endpoint, operation, organizationID.String(), projectID.String())
+}
+
+// AllowProjectScopeCreateReader is the variant of AllowProjectScopeCreate for callers that hold
+// a resource implementing ids.ProjectScopeReader. It recovers the organization and project IDs
+// from the resource.
+func AllowProjectScopeCreateReader(ctx context.Context, client openapi.ClientWithResponsesInterface, endpoint string, operation openapi.AclOperation, scope ids.ProjectScopeReader) error {
+	organizationID, projectID, err := scope.OrganizationAndProjectID()
+	if err != nil {
+		return err
+	}
+
+	return AllowProjectScopeCreateID(ctx, client, endpoint, operation, organizationID, projectID)
 }
 
 // AllowProjectScopeCreate is like AllowProjectScope but intended for v2 create operations

--- a/pkg/rbac/handler.go
+++ b/pkg/rbac/handler.go
@@ -87,6 +87,12 @@ func AllowOrganizationScopeReader(ctx context.Context, endpoint string, operatio
 
 // AllowOrganizationScope tries to allow the requested operation at the global scope, then
 // the organization scope.
+//
+// Deprecated: prefer the typed AllowOrganizationScopeID (for path-parameter IDs) or
+// AllowOrganizationScopeReader (for a resource implementing ids.OrganizationScopeReader).
+// This string overload is retained for backwards compatibility with callers that still
+// deal in plain strings (e.g. IDs from API response bodies or pre-typed-ID repositories)
+// and is not slated for removal.
 func AllowOrganizationScope(ctx context.Context, endpoint string, operation openapi.AclOperation, organizationID string) error {
 	if AllowGlobalScope(ctx, endpoint, operation) == nil {
 		return nil
@@ -133,6 +139,12 @@ func AllowProjectScopeReader(ctx context.Context, endpoint string, operation ope
 
 // AllowProjectScope tries to allow the requested operation at the global scope, then
 // the organization scope, and finally at the project scope.
+//
+// Deprecated: prefer the typed AllowProjectScopeID (for path-parameter IDs) or
+// AllowProjectScopeReader (for a resource implementing ids.ProjectScopeReader). This
+// string overload is retained for backwards compatibility with callers that still deal
+// in plain strings (e.g. IDs from API response bodies or pre-typed-ID repositories) and
+// is not slated for removal.
 func AllowProjectScope(ctx context.Context, endpoint string, operation openapi.AclOperation, organizationID, projectID string) error {
 	if AllowOrganizationScope(ctx, endpoint, operation, organizationID) == nil {
 		return nil
@@ -224,10 +236,11 @@ func AllowProjectScopeCreateReader(ctx context.Context, client openapi.ClientWit
 // returning nil.  Global-scope callers (platform administrators) are exempt from this
 // check and their supplied project ID is trusted directly.
 //
-// The string-typed organizationID and projectID parameters are intentional: this function
-// is called by other repositories that pre-date the typed ID types and must remain
-// backward-compatible with those callers.  Callers that hold typed IDs should prefer
-// AllowProjectScopeCreateID, which delegates here after converting to strings.
+// Deprecated: prefer the typed AllowProjectScopeCreateID (for path-parameter IDs) or
+// AllowProjectScopeCreateReader (for a resource implementing ids.ProjectScopeReader). This
+// string overload is retained for backwards compatibility with callers that pre-date the
+// typed ID types and is not slated for removal; the typed variants delegate here after
+// converting to strings.
 func AllowProjectScopeCreate(ctx context.Context, client openapi.ClientWithResponsesInterface, endpoint string, operation openapi.AclOperation, organizationID, projectID string) error {
 	// If the project is explicitly present in the ACL it was fetched from storage
 	// when the ACL was built, so it must exist.

--- a/pkg/rbac/handler_test.go
+++ b/pkg/rbac/handler_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package rbac_test
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -201,6 +202,67 @@ func TestUnscopedACL(t *testing.T) {
 			}
 		})
 	}
+}
+
+var errScope = errors.New("scope accessor failed")
+
+// scopeStub stands in for a CRD that reports its scope via the ids scope-reader
+// interfaces, returning fixed IDs (or an error) for the reader-variant tests.
+type scopeStub struct {
+	orgID  ids.OrganizationID
+	projID ids.ProjectID
+	err    error
+}
+
+func (s scopeStub) OrganizationID() (ids.OrganizationID, error) {
+	return s.orgID, s.err
+}
+
+func (s scopeStub) OrganizationAndProjectID() (ids.OrganizationID, ids.ProjectID, error) {
+	return s.orgID, s.projID, s.err
+}
+
+func TestScopeReaderVariants(t *testing.T) {
+	t.Parallel()
+
+	acl := aclFixture()
+	orgID := ids.MustParseOrganizationID(organizationID)
+	projID := ids.MustParseProjectID(projectID)
+
+	t.Run("AllowOrganizationScopeReader allows via organization privilege", func(t *testing.T) {
+		t.Parallel()
+
+		err := rbac.AllowOrganizationScopeReader(rbac.NewContext(t.Context(), acl), resourceType1, openapi.Read, scopeStub{orgID: orgID})
+		require.NoError(t, err)
+	})
+
+	t.Run("AllowOrganizationScopeReader denies wrong privilege", func(t *testing.T) {
+		t.Parallel()
+
+		err := rbac.AllowOrganizationScopeReader(rbac.NewContext(t.Context(), acl), resourceType1, openapi.Create, scopeStub{orgID: orgID})
+		require.Error(t, err)
+	})
+
+	t.Run("AllowProjectScopeReader allows via project privilege", func(t *testing.T) {
+		t.Parallel()
+
+		err := rbac.AllowProjectScopeReader(rbac.NewContext(t.Context(), acl), resourceType2, openapi.Read, scopeStub{orgID: orgID, projID: projID})
+		require.NoError(t, err)
+	})
+
+	t.Run("AllowProjectScopeReader denies wrong privilege", func(t *testing.T) {
+		t.Parallel()
+
+		err := rbac.AllowProjectScopeReader(rbac.NewContext(t.Context(), acl), resourceType2, openapi.Create, scopeStub{orgID: orgID, projID: projID})
+		require.Error(t, err)
+	})
+
+	t.Run("accessor error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		err := rbac.AllowProjectScopeReader(rbac.NewContext(t.Context(), acl), resourceType2, openapi.Read, scopeStub{err: errScope})
+		require.ErrorIs(t, err, errScope)
+	})
 }
 
 const (


### PR DESCRIPTION
## Why

Services that own project-scoped CRDs (region, …) repeatedly do the same dance before calling identity's RBAC, principal-enrichment, and reference APIs: read the org/project off the resource's labels, parse them to typed IDs, then pass the IDs across. That boilerplate is duplicated at every callsite and is easy to get subtly wrong. The same pattern shows up *inside* identity's own handlers, where placement labels are set with stringified IDs.

This change defines the interfaces those resources already satisfy and lets the consumer **pass the resource itself** (or its typed IDs), so the "read labels → parse to typed ID → stringify" steps happen **once, in the right layer**, instead of at every call. The headline goal is cleaner consumer code with type safety preserved as far up the stack as possible.

## What

- **`pkg/ids`** — new `OrganizationScopeReader` and `ProjectScopeReader` interfaces (the latter embeds the former: a project always belongs to an organization), plus tenancy comparison helpers over them: `SameProject(a, b)` (do two resources share an org+project?) and `OwnedByProject` / `OwnedByOrganization` (does a resource live in this org/project?). The latter pair are typed equivalents of core's `Assert*Ownership` — referential-integrity equality checks, deliberately **not** RBAC (RBAC would let a multi-project caller relate resources across tenancy boundaries).
- **`pkg/rbac`** — additive `…Reader` variants (`AllowOrganizationScopeReader`, `AllowProjectScopeReader`, `AllowProjectScopeCreateReader`) that recover IDs from the resource and delegate to the existing typed `…ID` variants.
- **`pkg/principal`** — `EnrichUserPrincipal{Organization,Project}Scope{ID,Reader}`, the typed home for principal enrichment that previously lived as a bespoke helper downstream. Like the RBAC helpers, the `…ID` variants take typed IDs (path params) and the `…Reader` variants take a CRD.
- **`pkg/client/references.go`** — recovers IDs via `ProjectScopeReader` when the resource implements it, falling back to label parsing.
- **`pkg/handler/common`** — `SetIdentityMetadataOrganizationScope` / `SetIdentityMetadataProjectScope` stamp the placement organization/project labels from typed IDs and set the attribution metadata in one call. Identity's create paths (project, group, quota, service account, oauth2 provider, organization user, allocation) are migrated onto them.

## Type safety, preserved as long as possible

The scope checks come in three argument flavours so callers pass whatever they already hold and IDs stay typed end-to-end, with string conversion deferred to the lowest layer:

- `…` (string) — **deprecated**, retained for backwards compatibility while callers migrate.
- `…ID` (typed `ids.*`) — for handlers holding decoded path parameters.
- `…Reader` (resource) — for callers holding a CRD.

The string variants are marked `// Deprecated:`; staticcheck SA1019 only flags cross-module use, so this nudges external consumers to migrate without nagging identity's own code.

## Moving client hacks back where they belonged

- `pkg/client/references.go` carried a local label-read-and-parse helper — exactly the logic that should live behind a shared contract. It now goes through `ProjectScopeReader`, with the resource's own accessor doing the work, and `SameProject` lives in `pkg/ids` rather than being re-implemented per consumer.
- Identity's handlers set placement labels with `conversion.NewObjectMetadata(...).WithOrganization(id.String())`. Core's builder is necessarily string-based — core cannot import `identity/pkg/ids` without a circular dependency — so the typed equivalent can only live in identity. `SetIdentityMetadata{Organization,Project}Scope` provide it, keeping the typed ID to the lowest layer and stamping placement + attribution together so they can't drift apart.

## Backwards compatibility

Everything here is backwards compatible:

- The string and `…ID` variants are unchanged; the `…Reader` and `SetIdentityMetadata*Scope` variants are purely additive (bare `SetIdentityMetadata` stays for org-less resources).
- `references.go` falls back to label parsing for resources that have not yet adopted the accessors — both paths read the same labels and agree by construction.
- Migrated handlers write identical label keys and values; no API/OpenAPI surface changes.

## Follow-up (region, separate PR)

- Add `OrganizationID()` to region's project-scoped CRDs so they satisfy the embedded `ProjectScopeReader`.
- Migrate region's local `InjectUserPrincipal` to `principal.EnrichUserPrincipalProjectScopeReader` and adopt the `…Reader` RBAC variants where a CRD is in hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


