### PR TITLE
Pin cloud-provider-kind to v0.10.0 in CI infra setup

### DIFF
--- a/hack/ci/setup-infra
+++ b/hack/ci/setup-infra
@@ -27,7 +27,10 @@ if [[ "${IS_KIND}" == true ]]; then
       GOBIN="$(go env GOPATH)/bin"
     fi
 
-    go install sigs.k8s.io/cloud-provider-kind@latest
+    # Pinned: cloud-provider-kind v0.11.0 requires Go >= 1.26, which CI does
+    # not provide (GOTOOLCHAIN=local). v0.10.0 builds against Go 1.24. Do not
+    # float to @latest without confirming the CI Go toolchain supports it.
+    go install sigs.k8s.io/cloud-provider-kind@v0.10.0
 
     echo "==> Starting cloud-provider-kind..."
     sudo "${GOBIN}/cloud-provider-kind" > /tmp/cloud-provider-kind.log 2>&1 &


### PR DESCRIPTION
cloud-provider-kind v0.11.0 raised its minimum Go version to 1.26, but CI
runs Go 1.25 with GOTOOLCHAIN=local, so `go install ...@latest` fails and
the integration infrastructure step errors out before any test runs. This
broke the Integration job across every consuming repo's open PRs.

Pin to v0.10.0, the newest release that builds against Go 1.24, and add a
note not to float back to @latest without confirming the CI toolchain.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
