### PR TITLE
fix(rbac): remove dead application:* role permissions

### DIFF
--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -182,8 +182,6 @@ roles:
         storage:objectstorageclasses: [create,read,update,delete]
         storage:objectstorageendpoints: [create,read,update,delete]
         storage:objectstorageendpoints/accesskeys: [create,read,update,delete]
-        application:applications: [create,read,update,delete]
-        application:applicationsets: [create,read,update,delete]
   region-service:
     decription: Region service
     protected: true
@@ -335,8 +333,6 @@ roles:
         kubernetes:virtualclusters: [create,read,update,delete]
         compute:instances: [create,read,update,delete]
         compute:clusters: [create,read,update,delete]
-        application:applications: [read]
-        application:applicationsets: [create,read,update,delete]
   # A reader can view projects they are a member of and view
   # kubernetes clusters.
   reader:
@@ -368,8 +364,6 @@ roles:
         kubernetes:virtualclusters: [read]
         compute:instances: [read]
         compute:clusters: [read]
-        application:applications: [read]
-        application:applicationsets: [read]
 
 # Optional additional roles that can be injected alongside the defaults.
 # Shape matches the roles map below. Same names will raise an error.

--- a/pkg/handler/roles/README.md
+++ b/pkg/handler/roles/README.md
@@ -65,6 +65,11 @@ API behaviour: if the caller cannot legally delegate a role, the role is omitted
   definitions.
 - The current role source is still centrally administered even though the longer-term model is
   expected to allow organization-local custom roles.
+- A role becomes invisible here the moment any single permission it contains is not held by the
+  caller. This makes the list silently sensitive to gaps in the role definitions: if a service's
+  endpoints are added to `user`/`reader` but omitted from the organization `administrator`, those
+  roles vanish from an administrator's view. See the `pkg/rbac` caveats on consistent permission
+  distribution across the hierarchy.
 
 ## Related Documentation
 

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -111,12 +111,27 @@ cannot exercise permissions that either side lacks.
 - Some pragmatic compatibility behaviour exists around scoped lookups and transition paths, so
   security-sensitive changes here should be reviewed in terms of end-to-end actor behaviour rather
   than local code shape alone.
+- Role permission sets must be distributed *consistently across the role hierarchy*. Because
+  grantability requires the caller to hold every permission a role contains (with project-scoped
+  endpoints promoted to an organization-scope check), granting a service's endpoints to a lower
+  role such as `user` or `reader` *without also granting them to the organization `administrator`*
+  silently makes that lower role non-grantable and invisible to administrators. Any new service
+  endpoint added to the roles in `charts/identity/values.yaml` must be added to every role that
+  should be able to grant it — not just the leaf roles that consume it.
+- The `application:*` endpoints (`application:applications`, `application:applicationsets`) were
+  removed because the application service was never implemented and never will be — they were dead
+  configuration. The removal also fixed a live bug: they were present on `platform-administrator`,
+  `user`, and `reader` but absent from the organization `administrator`, which broke administrator
+  grantability of `user`/`reader`. They are gone for good; there is no service to grant access to.
 
 ## TODO
 
 - Re-check places where globally scoped callers are allowed to skip existence verification for
   user-supplied scoped resource identifiers, especially create paths that accept project IDs in the
   request body.
+- Add test coverage for role grantability/visibility across the role hierarchy. The `application:*`
+  regression went unnoticed because nothing asserts that every non-protected role remains grantable
+  by the organization `administrator`; a guard test over the role definitions would have caught it.
 
 ## Relationship To Other Packages
 


### PR DESCRIPTION
The `application:applications` and `application:applicationsets` endpoints
were never implemented and never will be, so granting them in any role was
dead configuration. They were also distributed inconsistently: present on
`platform-administrator`, `user`, and `reader`, but absent from the
organization `administrator`.

That inconsistency was actively harmful, not merely dead weight. `AllowRole`
(pkg/rbac/handler.go) only lets a caller see or grant a role if the caller
holds every permission the role contains, with project-scoped endpoints
promoted to an organization-scope check. Because the organization
`administrator` held no `application:*` permissions, the superset check
failed on `application:applications` and `application:applicationsets`, so an
administrator could not see or grant the `user` or `reader` roles at all,
defeating the primary purpose of the administrator role.

Remove the endpoints entirely. There is nothing to reinstate: the service
does not exist and is not planned, so the permissions should simply not be
referenced anywhere.

This regression slipped through because there is a clear test gap: nothing
asserts that every non-protected role stays grantable/visible to the
organization administrator. Adding that guard test is left as a follow-up.


