### PR TITLE
fix(rbac): check role grantability at project scope, not flattened to org

### DIFF
--- a/pkg/handler/roles/README.md
+++ b/pkg/handler/roles/README.md
@@ -69,7 +69,9 @@ API behaviour: if the caller cannot legally delegate a role, the role is omitted
   caller. This makes the list silently sensitive to gaps in the role definitions: if a service's
   endpoints are added to `user`/`reader` but omitted from the organization `administrator`, those
   roles vanish from an administrator's view. See the `pkg/rbac` caveats on consistent permission
-  distribution across the hierarchy.
+  distribution across the hierarchy, the built-in role catalogue and grant lattice documented
+  there, and the `TestBuiltinRoleGrantability` guard that pins those relationships to
+  `charts/identity/values.yaml`.
 
 ## Related Documentation
 

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -69,6 +69,67 @@ without re-deriving it:
 
 Rule of thumb: path-parameter handler → `…ID`; you have a CRD object in hand → `…Reader`.
 
+## Built-in Roles
+
+The role catalogue is defined in `charts/identity/values.yaml` and rendered into `Role`
+resources by `charts/identity/templates/roles.yaml`. That values file is the single
+source of truth; `pkg/rbac` resolves those roles but never invents them. There are two
+families.
+
+### Protected (platform) roles
+
+Roles marked `protected: true` are internal-only: never returned by the user-facing role
+list and never grantable through the API. They are bound solely via Helm values at
+deployment time.
+
+- `platform-administrator` — global CRUD over every resource; can act in any organization
+  or project.
+- `region-service`, `kubernetes-service`, `compute-service`, `storage-service` — system
+  accounts mapped from an mTLS certificate common name (see the Actor Model). Each holds
+  only the global permissions the corresponding service actually exercises;
+  over-permissioning here is a security defect.
+
+### User-facing roles
+
+These carry `organization` and/or `project` scope blocks and are the roles an
+administrator grants to groups.
+
+| Role | organization block | project block |
+| --- | --- | --- |
+| `administrator` | full CRUD across identity, region, storage, Kubernetes and compute | — |
+| `auditor` | read-only across all of the above | — |
+| `user` | org-wide reads, plus `region:images` create/delete | CRUD on workloads: networks, load balancers, security groups, file storage, object storage, SSH CAs, clusters, instances |
+| `reader` | org-wide reads (`region:images` read only) | read-only on those same workloads |
+
+`administrator` and `auditor` hold all their authority at organization scope. `user` and
+`reader` keep a thin organization-wide read baseline but place their real workload
+authority in the project block, so it applies only to the projects their group is linked
+to.
+
+### Grant relationships
+
+A caller may grant a role only if they already hold every permission it contains, at the
+grant's scope or broader (`AllowRole`, with the downward scope flow described above).
+Because a grant hands out a subset of what the caller already holds, the built-in roles
+form a superset lattice:
+
+```
+administrator ─┬─ auditor ─── reader
+               └─ user ────── reader
+```
+
+- `administrator` can grant every user-facing role.
+- `auditor` (read-only) can grant `reader` (also read-only) but not `user`, which needs
+  write verbs `auditor` lacks.
+- `user` can grant `reader` — the same project scope with fewer verbs (downscoping) — but
+  not `auditor`, which needs `identity:*` reads `user` lacks.
+- `reader` can grant only `reader`.
+
+`user` and `auditor` are incomparable, and neither can grant `administrator`. This lattice
+is locked down by `TestBuiltinRoleGrantability`, which drives `AllowRole` from the parsed
+chart values for every ordered role pair, asserting each allowed edge and rejecting every
+non-edge.
+
 ## Actor Model
 
 The package distinguishes three important actor classes:
@@ -111,13 +172,17 @@ cannot exercise permissions that either side lacks.
 - Some pragmatic compatibility behaviour exists around scoped lookups and transition paths, so
   security-sensitive changes here should be reviewed in terms of end-to-end actor behaviour rather
   than local code shape alone.
-- Role permission sets must be distributed *consistently across the role hierarchy*. Because
-  grantability requires the caller to hold every permission a role contains (with project-scoped
-  endpoints promoted to an organization-scope check), granting a service's endpoints to a lower
-  role such as `user` or `reader` *without also granting them to the organization `administrator`*
-  silently makes that lower role non-grantable and invisible to administrators. Any new service
-  endpoint added to the roles in `charts/identity/values.yaml` must be added to every role that
-  should be able to grant it — not just the leaf roles that consume it.
+- Role permission sets must be distributed *consistently across the role hierarchy*.
+  Grantability requires the caller to hold every permission a role contains at the same
+  scope or broader (`AllowRole`; project-scoped endpoints are satisfied by project, then
+  organization, then global authority — not flattened to an organization-only check).
+  Granting a service's endpoints to a lower role such as `user` or `reader` *without also
+  granting them to every role above it in the grant lattice* — `administrator` for any
+  operation, and `auditor` for reads — silently makes that lower role non-grantable and
+  invisible to those roles. Any new endpoint added to a role in
+  `charts/identity/values.yaml` must be added to every role that should be able to grant
+  it, not just the leaf roles that consume it. `TestBuiltinRoleGrantability` enforces this
+  over the parsed chart values.
 - The `application:*` endpoints (`application:applications`, `application:applicationsets`) were
   removed because the application service was never implemented and never will be — they were dead
   configuration. The removal also fixed a live bug: they were present on `platform-administrator`,
@@ -129,9 +194,6 @@ cannot exercise permissions that either side lacks.
 - Re-check places where globally scoped callers are allowed to skip existence verification for
   user-supplied scoped resource identifiers, especially create paths that accept project IDs in the
   request body.
-- Add test coverage for role grantability/visibility across the role hierarchy. The `application:*`
-  regression went unnoticed because nothing asserts that every non-protected role remains grantable
-  by the organization `administrator`; a guard test over the role definitions would have caught it.
 
 ## Relationship To Other Packages
 

--- a/pkg/rbac/grant_guard_test.go
+++ b/pkg/rbac/grant_guard_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/identity/pkg/ids"
+	"github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
+
+	"sigs.k8s.io/yaml"
+)
+
+// chartValuesPath locates the Helm values file that is the single source of truth for
+// the built-in role catalogue rendered by charts/identity/templates/roles.yaml. The
+// guard test parses it directly so that any change to the role definitions is validated
+// against the intended grant relationships.
+const chartValuesPath = "../../charts/identity/values.yaml"
+
+// endpointOperations mirrors the map-of-lists shape used under each scope block in
+// values.yaml: endpoint name -> granted CRUD operations.
+type endpointOperations map[string][]string
+
+type chartRole struct {
+	Description string `json:"description"`
+	Protected   bool   `json:"protected"`
+	Scopes      struct {
+		Global       endpointOperations `json:"global"`
+		Organization endpointOperations `json:"organization"`
+		Project      endpointOperations `json:"project"`
+	} `json:"scopes"`
+}
+
+type chartValues struct {
+	Roles map[string]chartRole `json:"roles"`
+}
+
+func loadChartRoles(t *testing.T) map[string]chartRole {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Clean(chartValuesPath))
+	require.NoError(t, err)
+
+	var values chartValues
+
+	require.NoError(t, yaml.Unmarshal(raw, &values))
+	require.NotEmpty(t, values.Roles)
+
+	return values.Roles
+}
+
+func toRoleScopes(in endpointOperations) []unikornv1.RoleScope {
+	if len(in) == 0 {
+		return nil
+	}
+
+	scopes := make([]unikornv1.RoleScope, 0, len(in))
+
+	for name, operations := range in {
+		ops := make([]unikornv1.Operation, len(operations))
+		for i, operation := range operations {
+			ops[i] = unikornv1.Operation(operation)
+		}
+
+		scopes = append(scopes, unikornv1.RoleScope{Name: name, Operations: ops})
+	}
+
+	return scopes
+}
+
+// asRole projects a chart role into the stored Role resource AllowRole consumes as the
+// grant target.
+func asRole(in chartRole) *unikornv1.Role {
+	return &unikornv1.Role{
+		Spec: unikornv1.RoleSpec{
+			Protected: in.Protected,
+			Scopes: unikornv1.RoleScopes{
+				Global:       toRoleScopes(in.Scopes.Global),
+				Organization: toRoleScopes(in.Scopes.Organization),
+				Project:      toRoleScopes(in.Scopes.Project),
+			},
+		},
+	}
+}
+
+func toACLEndpoints(in endpointOperations) openapi.AclEndpoints {
+	endpoints := make(openapi.AclEndpoints, 0, len(in))
+
+	for name, operations := range in {
+		ops := make(openapi.AclOperations, len(operations))
+		for i, operation := range operations {
+			ops[i] = openapi.AclOperation(operation)
+		}
+
+		endpoints = append(endpoints, openapi.AclEndpoint{Name: name, Operations: ops})
+	}
+
+	return endpoints
+}
+
+// aclForHolder builds the effective ACL a principal holding exactly this role would have
+// when resolved for organizationID. The organization block lands at organization scope
+// and the project block in a single accessible project, exactly as pkg/rbac accumulates
+// real group membership. This placement is what makes downscoping observable: a holder's
+// project-scoped authority lives under a project, it is not promoted to organization
+// scope.
+func aclForHolder(in chartRole) *openapi.Acl {
+	acl := &openapi.Acl{}
+
+	if len(in.Scopes.Global) > 0 {
+		global := toACLEndpoints(in.Scopes.Global)
+		acl.Global = &global
+	}
+
+	organization := openapi.AclOrganization{Id: organizationID}
+
+	if len(in.Scopes.Organization) > 0 {
+		endpoints := toACLEndpoints(in.Scopes.Organization)
+		organization.Endpoints = &endpoints
+	}
+
+	if len(in.Scopes.Project) > 0 {
+		projects := openapi.AclProjectList{
+			{Id: projectID, Endpoints: toACLEndpoints(in.Scopes.Project)},
+		}
+		organization.Projects = &projects
+	}
+
+	organizations := openapi.AclOrganizationList{organization}
+	acl.Organizations = &organizations
+
+	return acl
+}
+
+// TestBuiltinRoleGrantability asserts that AllowRole permits exactly the grants declared
+// in the grant tree for every ordered pair of user-facing built-in roles, using the role
+// definitions parsed from charts/identity/values.yaml.
+func TestBuiltinRoleGrantability(t *testing.T) {
+	t.Parallel()
+
+	// grantTree encodes the intended delegation relationships between the user-facing
+	// (non-protected) built-in roles. Each granter maps to every role it must be able to
+	// grant, i.e. every role whose permission set it fully contains at the same or a
+	// narrower scope (a role can always grant itself):
+	//
+	//	administrator ─┬─ auditor ─── reader
+	//	               └─ user ────── reader
+	//
+	// This is the source of truth for the "X is a superset of Y" relationship. It guards
+	// against role-catalogue drift such as the removed application:* endpoints, which were
+	// present on user/reader but missing from administrator and thereby silently made
+	// user/reader non-grantable by an administrator. Any endpoint added to a leaf role must
+	// remain covered by every role above it here, or this test fails.
+	grantTree := map[string][]string{
+		"administrator": {"administrator", "auditor", "user", "reader"},
+		"auditor":       {"auditor", "reader"},
+		"user":          {"user", "reader"},
+		"reader":        {"reader"},
+	}
+
+	roles := loadChartRoles(t)
+
+	// Every user-facing role in the chart must appear in the grant tree so that a newly
+	// added role cannot silently escape the guard.
+	userFacing := make([]string, 0, len(roles))
+
+	for name, role := range roles {
+		if role.Protected {
+			continue
+		}
+
+		userFacing = append(userFacing, name)
+
+		require.Containsf(t, grantTree, name, "user-facing role %q is missing from grantTree; declare its grant relationships", name)
+	}
+
+	slices.Sort(userFacing)
+
+	// Conversely, every role named in the grant tree must be a real, user-facing role,
+	// so stale entries cannot mask a deleted or newly-protected role.
+	for granter, grantees := range grantTree {
+		require.Containsf(t, userFacing, granter, "grantTree references unknown or protected granter %q", granter)
+
+		for _, grantee := range grantees {
+			require.Containsf(t, userFacing, grantee, "grantTree references unknown or protected grantee %q", grantee)
+		}
+	}
+
+	org := ids.MustParseOrganizationID(organizationID)
+
+	for _, granter := range userFacing {
+		ctx := rbac.NewContext(t.Context(), aclForHolder(roles[granter]))
+
+		for _, grantee := range userFacing {
+			expectGrantable := slices.Contains(grantTree[granter], grantee)
+
+			t.Run(granter+" grants "+grantee, func(t *testing.T) {
+				t.Parallel()
+
+				err := rbac.AllowRole(ctx, asRole(roles[grantee]), org)
+
+				if expectGrantable {
+					require.NoErrorf(t, err, "%q holds a superset of %q and must be able to grant it, but AllowRole refused", granter, grantee)
+				} else {
+					require.Errorf(t, err, "%q does not hold a superset of %q and must not be able to grant it, but AllowRole allowed it", granter, grantee)
+				}
+			})
+		}
+	}
+}

--- a/pkg/rbac/handler.go
+++ b/pkg/rbac/handler.go
@@ -288,9 +288,76 @@ func AllowProjectScopeCreate(ctx context.Context, client openapi.ClientWithRespo
 	return nil
 }
 
+// allowGrantProjectScope decides whether the caller may grant a role's project-scoped
+// permission. Unlike a normal access check there is no specific target project — a role
+// grant is organization-scoped — so the permission is satisfied if the caller holds it
+// at global or organization scope, or at project scope in *any* project they can access
+// within the organization.
+//
+// This is deliberately laxer than promoting the permission to an organization-scope
+// check: granting a project-scoped role hands out a subset of what the caller already
+// holds at the same scope (downscoping, e.g. a project `user` granting a project
+// `reader`), which is least-privilege delegation, not privilege escalation. Requiring
+// the caller to hold every project permission organization-wide would wrongly reject
+// those legitimate grants.
+//
+// Trust assumption: accepting a permission held in *any* one of the caller's projects is
+// only safe because a granted role cannot take effect in a project the caller does not
+// already administer. Two surrounding invariants enforce that and must be preserved:
+//
+//   - group create/update (the only path to AllowRole via validateRoleIDs) requires
+//     organization-scope identity:groups write, which project-scoped authority cannot
+//     satisfy; and
+//   - linking a group to an existing project requires project-scope identity:projects
+//     update for that specific project.
+//
+// If a role ever grants identity:groups write at project scope, or project-group linking
+// is relaxed to organization scope, this "any project" acceptance would become a
+// cross-project escalation and must be tightened to a specific target project.
+func allowGrantProjectScope(ctx context.Context, endpoint string, operation openapi.AclOperation, organizationID ids.OrganizationID) error {
+	if AllowOrganizationScopeID(ctx, endpoint, operation, organizationID) == nil {
+		return nil
+	}
+
+	acl := FromContext(ctx)
+
+	if acl.Organizations != nil {
+		for _, organization := range *acl.Organizations {
+			if organization.Id != organizationID.String() {
+				continue
+			}
+
+			if organization.Projects == nil {
+				break
+			}
+
+			for _, project := range *organization.Projects {
+				if operationAllowedByEndpoints(project.Endpoints, endpoint, operation) == nil {
+					return nil
+				}
+			}
+		}
+	}
+
+	return errors.HTTPForbidden(fmt.Sprintf("operation is not allowed by rbac: operation '%s' on endpoint '%s' — the caller holds it at neither organization nor any project scope, so cannot grant it", operation, endpoint))
+}
+
 // AllowRole determines whether your ACL contains the same or higher privileges than
 // the role, which is then used to determine role visibility and limit privilege
 // escalation.
+//
+// Each scope block of the target role is checked against the caller's authority at the
+// matching scope, with the usual downward flow (global satisfies organization and
+// project, organization satisfies project):
+//
+//   - global endpoints must be held at global scope;
+//   - organization endpoints must be held at global or organization scope;
+//   - project endpoints must be held at global or organization scope, or at project
+//     scope in any project the caller can access (see allowGrantProjectScope).
+//
+// The project case is why granting is subset-preserving rather than escalation-prone: a
+// caller may only ever grant a role whose permissions they already hold at the grant's
+// scope or broader.
 func AllowRole(ctx context.Context, role *unikornv1.Role, organizationID ids.OrganizationID) error {
 	for _, endpoint := range role.Spec.Scopes.Global {
 		for _, operation := range endpoint.Operations {
@@ -310,7 +377,7 @@ func AllowRole(ctx context.Context, role *unikornv1.Role, organizationID ids.Org
 
 	for _, endpoint := range role.Spec.Scopes.Project {
 		for _, operation := range endpoint.Operations {
-			if err := AllowOrganizationScopeID(ctx, endpoint.Name, convertOperation(operation), organizationID); err != nil {
+			if err := allowGrantProjectScope(ctx, endpoint.Name, convertOperation(operation), organizationID); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
AllowRole flattened a target role's project-scoped endpoints into an
organization-scope check against the caller. That wrongly rejected
legitimate downscoping grants — a project `user` handing out a project
`reader` is a subset of what the caller already holds at the same scope,
not privilege escalation.

Replace the promotion with allowGrantProjectScope, which satisfies a
project endpoint from global, organization, or any project the caller can
access. Each scope block of the target role is now checked at its matching
scope with proper downward flow, so a caller may only grant a role whose
permissions they already hold at the grant's scope or broader.

Add TestBuiltinRoleGrantability, a table-driven guard that parses the
built-in roles from charts/identity/values.yaml (the source of truth) and
drives AllowRole over every ordered role pair against the intended grant
lattice:

    administrator ─┬─ auditor ─── reader
                   └─ user ────── reader

It asserts every allowed edge and rejects every non-edge, and requires the
chart's non-protected roles and the tree to stay in sync. This would have
caught the application:* regression, where endpoints on user/reader but
missing from administrator silently made those roles non-grantable.

Document the built-in role catalogue and grant lattice in pkg/rbac, correct
the now-stale "promoted to an organization-scope check" caveat, drop the
completed grantability-coverage TODO, and cross-reference the guard from
pkg/handler/roles.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
