### PR TITLE
Port Auth0 identity regression tests

### DIFF
--- a/test/api/config.go
+++ b/test/api/config.go
@@ -28,6 +28,7 @@ type TestConfig struct {
 	AdminToken          string
 	UserToken           string
 	AuditToken          string
+	PublicAdminToken    string
 	OrgID               string
 	ProjectID           string
 	AdminGroupID        string
@@ -67,7 +68,7 @@ func LoadTestConfig() (*TestConfig, error) {
 	config := &TestConfig{
 		BaseConfig: coreconfig.BaseConfig{
 			BaseURL:         v.GetString("IDENTITY_BASE_URL"),
-			AuthToken:       firstNonEmpty(v.GetString("API_AUTH_TOKEN"), v.GetString("ADMIN_AUTH_TOKEN")),
+			AuthToken:       firstNonEmpty(v.GetString("API_AUTH_TOKEN"), v.GetString("ADMIN_AUTH_TOKEN"), v.GetString("SERVICE_TOKEN_PRIVATE_ADMIN")),
 			RequestTimeout:  coreconfig.GetDurationFromViper(v, "REQUEST_TIMEOUT", 30*time.Second),
 			TestTimeout:     coreconfig.GetDurationFromViper(v, "TEST_TIMEOUT", 20*time.Minute),
 			SkipIntegration: v.GetBool("SKIP_INTEGRATION"),
@@ -75,9 +76,10 @@ func LoadTestConfig() (*TestConfig, error) {
 			LogRequests:     v.GetBool("LOG_REQUESTS"),
 			LogResponses:    v.GetBool("LOG_RESPONSES"),
 		},
-		AdminToken:          firstNonEmpty(v.GetString("ADMIN_AUTH_TOKEN"), v.GetString("API_AUTH_TOKEN")),
+		AdminToken:          firstNonEmpty(v.GetString("ADMIN_AUTH_TOKEN"), v.GetString("API_AUTH_TOKEN"), v.GetString("SERVICE_TOKEN_PRIVATE_ADMIN")),
 		UserToken:           v.GetString("USER_AUTH_TOKEN"),
-		AuditToken:          v.GetString("AUDIT_AUTH_TOKEN"),
+		AuditToken:          firstNonEmpty(v.GetString("AUDIT_AUTH_TOKEN"), v.GetString("SERVICE_TOKEN_PRIVATE_AUDIT")),
+		PublicAdminToken:    firstNonEmpty(v.GetString("PUBLIC_ADMIN_AUTH_TOKEN"), v.GetString("SERVICE_TOKEN_PRIVATE_PUBLIC_ADMIN")),
 		OrgID:               v.GetString("TEST_ORG_ID"),
 		ProjectID:           v.GetString("TEST_PROJECT_ID"),
 		AdminGroupID:        v.GetString("TEST_ADMIN_GROUP_ID"),

--- a/test/api/suites/acl_test.go
+++ b/test/api/suites/acl_test.go
@@ -169,15 +169,6 @@ func expectOrganizationACLEndpoints(acl *identityopenapi.Acl, orgID string, expe
 	Fail("expected organization " + orgID + " in ACL response")
 }
 
-func apiClientWithToken(token string) *api.APIClient {
-	GinkgoHelper()
-
-	tokenConfig := *config
-	tokenConfig.AuthToken = token
-
-	return api.NewAPIClientWithConfig(&tokenConfig)
-}
-
 var _ = Describe("Access Control Discovery", func() {
 	Context("When getting global ACL", func() {
 		Describe("Given valid authentication", func() {
@@ -228,8 +219,6 @@ var _ = Describe("Access Control Discovery", func() {
 			})
 
 			It("should return the administrator permission matrix", func() {
-				Expect(adminClient).NotTo(BeNil(), "ADMIN_AUTH_TOKEN must create an administrator API client")
-
 				acl, err := adminClient.GetGlobalACL(ctx)
 
 				Expect(err).NotTo(HaveOccurred())
@@ -238,7 +227,7 @@ var _ = Describe("Access Control Discovery", func() {
 
 			It("should return the auditor read-only permission matrix", func() {
 				if auditClient == nil {
-					Skip("AUDIT_AUTH_TOKEN or SERVICE_TOKEN_PRIVATE_AUDIT must create an auditor API client")
+					Skip("AUDIT_AUTH_TOKEN or SERVICE_TOKEN_PRIVATE_AUDIT must be set by integration fixtures")
 				}
 
 				acl, err := auditClient.GetGlobalACL(ctx)
@@ -248,11 +237,10 @@ var _ = Describe("Access Control Discovery", func() {
 			})
 
 			It("should return the public-admin permission matrix", func() {
-				if config.PublicAdminToken == "" {
+				if publicAdminClient == nil {
 					Skip("PUBLIC_ADMIN_AUTH_TOKEN or SERVICE_TOKEN_PRIVATE_PUBLIC_ADMIN must be set by integration fixtures")
 				}
 
-				publicAdminClient := apiClientWithToken(config.PublicAdminToken)
 				acl, err := publicAdminClient.GetGlobalACL(ctx)
 
 				Expect(err).NotTo(HaveOccurred())
@@ -277,11 +265,10 @@ var _ = Describe("Access Control Discovery", func() {
 	Context("When public-admin accesses users", func() {
 		Describe("Given a private organization", func() {
 			It("should be denied", func() {
-				if config.PublicAdminToken == "" {
+				if publicAdminClient == nil {
 					Skip("PUBLIC_ADMIN_AUTH_TOKEN or SERVICE_TOKEN_PRIVATE_PUBLIC_ADMIN must be set by integration fixtures")
 				}
 
-				publicAdminClient := apiClientWithToken(config.PublicAdminToken)
 				resp, _, err := publicAdminClient.DoRequest(ctx, http.MethodGet,
 					api.NewEndpoints().ListUsers(config.OrgID), nil, http.StatusForbidden)
 

--- a/test/api/suites/acl_test.go
+++ b/test/api/suites/acl_test.go
@@ -23,6 +23,7 @@ package suites
 import (
 	"errors"
 	"net/http"
+	"sort"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,6 +32,151 @@ import (
 	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
 	"github.com/unikorn-cloud/identity/test/api"
 )
+
+func aclEndpoint(name string, operations ...identityopenapi.AclOperation) identityopenapi.AclEndpoint {
+	return identityopenapi.AclEndpoint{
+		Name:       name,
+		Operations: operations,
+	}
+}
+
+func fullAccessOperations() []identityopenapi.AclOperation {
+	return []identityopenapi.AclOperation{
+		identityopenapi.Create,
+		identityopenapi.Read,
+		identityopenapi.Update,
+		identityopenapi.Delete,
+	}
+}
+
+func expectedAdminACLEndpoints() []identityopenapi.AclEndpoint {
+	return []identityopenapi.AclEndpoint{
+		aclEndpoint("compute:clusters", fullAccessOperations()...),
+		aclEndpoint("compute:flavors", identityopenapi.Read),
+		aclEndpoint("compute:images", identityopenapi.Read),
+		aclEndpoint("compute:instances", fullAccessOperations()...),
+		aclEndpoint("compute:regions", identityopenapi.Read),
+		aclEndpoint("identity:groups", fullAccessOperations()...),
+		aclEndpoint("identity:oauth2providers", fullAccessOperations()...),
+		aclEndpoint("identity:organizations", identityopenapi.Read, identityopenapi.Update),
+		aclEndpoint("identity:projects", fullAccessOperations()...),
+		aclEndpoint("identity:quotas", identityopenapi.Read),
+		aclEndpoint("identity:roles", fullAccessOperations()...),
+		aclEndpoint("identity:serviceaccounts", fullAccessOperations()...),
+		aclEndpoint("identity:users", fullAccessOperations()...),
+		aclEndpoint("kubernetes:clusters", fullAccessOperations()...),
+		aclEndpoint("kubernetes:flavors", identityopenapi.Read),
+		aclEndpoint("kubernetes:images", identityopenapi.Read),
+		aclEndpoint("kubernetes:regions", identityopenapi.Read),
+		aclEndpoint("kubernetes:virtualclusters", fullAccessOperations()...),
+		aclEndpoint("region:filestorage:v2", fullAccessOperations()...),
+		aclEndpoint("region:filestorageclass:v2", identityopenapi.Read),
+		aclEndpoint("region:flavors", identityopenapi.Read),
+		aclEndpoint("region:images", identityopenapi.Create, identityopenapi.Read, identityopenapi.Delete),
+		aclEndpoint("region:loadbalancers:v2", fullAccessOperations()...),
+		aclEndpoint("region:networks:v2", fullAccessOperations()...),
+		aclEndpoint("region:regions", identityopenapi.Read),
+		aclEndpoint("region:securitygroups:v2", fullAccessOperations()...),
+		aclEndpoint("region:sshcertificateauthorities:v2", identityopenapi.Create, identityopenapi.Read, identityopenapi.Delete),
+		aclEndpoint("storage:objectstorageclasses", identityopenapi.Read),
+		aclEndpoint("storage:objectstorageendpoints", fullAccessOperations()...),
+		aclEndpoint("storage:objectstorageendpoints/accesskeys", fullAccessOperations()...),
+	}
+}
+
+func expectedAuditACLEndpoints() []identityopenapi.AclEndpoint {
+	return []identityopenapi.AclEndpoint{
+		aclEndpoint("compute:clusters", identityopenapi.Read),
+		aclEndpoint("compute:flavors", identityopenapi.Read),
+		aclEndpoint("compute:images", identityopenapi.Read),
+		aclEndpoint("compute:instances", identityopenapi.Read),
+		aclEndpoint("compute:regions", identityopenapi.Read),
+		aclEndpoint("identity:groups", identityopenapi.Read),
+		aclEndpoint("identity:oauth2providers", identityopenapi.Read),
+		aclEndpoint("identity:organizations", identityopenapi.Read),
+		aclEndpoint("identity:projects", identityopenapi.Read),
+		aclEndpoint("identity:quotas", identityopenapi.Read),
+		aclEndpoint("identity:roles", identityopenapi.Read),
+		aclEndpoint("identity:serviceaccounts", identityopenapi.Read),
+		aclEndpoint("identity:users", identityopenapi.Read),
+		aclEndpoint("kubernetes:clusters", identityopenapi.Read),
+		aclEndpoint("kubernetes:flavors", identityopenapi.Read),
+		aclEndpoint("kubernetes:images", identityopenapi.Read),
+		aclEndpoint("kubernetes:regions", identityopenapi.Read),
+		aclEndpoint("kubernetes:virtualclusters", identityopenapi.Read),
+		aclEndpoint("region:filestorage:v2", identityopenapi.Read),
+		aclEndpoint("region:filestorageclass:v2", identityopenapi.Read),
+		aclEndpoint("region:flavors", identityopenapi.Read),
+		aclEndpoint("region:images", identityopenapi.Read),
+		aclEndpoint("region:loadbalancers:v2", identityopenapi.Read),
+		aclEndpoint("region:networks:v2", identityopenapi.Read),
+		aclEndpoint("region:regions", identityopenapi.Read),
+		aclEndpoint("region:securitygroups:v2", identityopenapi.Read),
+		aclEndpoint("region:sshcertificateauthorities:v2", identityopenapi.Read),
+		aclEndpoint("storage:objectstorageclasses", identityopenapi.Read),
+		aclEndpoint("storage:objectstorageendpoints", identityopenapi.Read),
+		aclEndpoint("storage:objectstorageendpoints/accesskeys", identityopenapi.Read),
+	}
+}
+
+func expectedPublicAdminACLEndpoints() []identityopenapi.AclEndpoint {
+	return []identityopenapi.AclEndpoint{
+		aclEndpoint("compute:flavors", identityopenapi.Read),
+		aclEndpoint("identity:groups", identityopenapi.Read),
+		aclEndpoint("identity:organizations", identityopenapi.Read),
+		aclEndpoint("identity:projects", identityopenapi.Read),
+		aclEndpoint("identity:quotas", identityopenapi.Read),
+		aclEndpoint("identity:roles", identityopenapi.Read),
+		aclEndpoint("identity:serviceaccounts", fullAccessOperations()...),
+		aclEndpoint("kubernetes:flavors", identityopenapi.Read),
+		aclEndpoint("kubernetes:images", identityopenapi.Read),
+		aclEndpoint("kubernetes:regions", identityopenapi.Read),
+	}
+}
+
+func normalisedACLMap(endpoints []identityopenapi.AclEndpoint) map[string][]string {
+	normalised := make(map[string][]string, len(endpoints))
+
+	for _, endpoint := range endpoints {
+		operations := make([]string, 0, len(endpoint.Operations))
+		for _, operation := range endpoint.Operations {
+			operations = append(operations, string(operation))
+		}
+		sort.Strings(operations)
+		normalised[endpoint.Name] = operations
+	}
+
+	return normalised
+}
+
+func expectOrganizationACLEndpoints(acl *identityopenapi.Acl, orgID string, expected []identityopenapi.AclEndpoint) {
+	GinkgoHelper()
+
+	Expect(acl).NotTo(BeNil())
+	Expect(acl.Organizations).NotTo(BeNil(), "Organizations ACL should be present")
+
+	for _, org := range *acl.Organizations {
+		if org.Id != orgID {
+			continue
+		}
+
+		Expect(org.Endpoints).NotTo(BeNil(), "Organization ACL endpoints should be present")
+		Expect(normalisedACLMap(*org.Endpoints)).To(Equal(normalisedACLMap(expected)))
+
+		return
+	}
+
+	Fail("expected organization " + orgID + " in ACL response")
+}
+
+func apiClientWithToken(token string) *api.APIClient {
+	GinkgoHelper()
+
+	tokenConfig := *config
+	tokenConfig.AuthToken = token
+
+	return api.NewAPIClientWithConfig(&tokenConfig)
+}
 
 var _ = Describe("Access Control Discovery", func() {
 	Context("When getting global ACL", func() {
@@ -80,6 +226,38 @@ var _ = Describe("Access Control Discovery", func() {
 
 				GinkgoWriter.Printf("Global ACL retrieved with %d organizations\n", len(*acl.Organizations))
 			})
+
+			It("should return the administrator permission matrix", func() {
+				Expect(adminClient).NotTo(BeNil(), "ADMIN_AUTH_TOKEN must create an administrator API client")
+
+				acl, err := adminClient.GetGlobalACL(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				expectOrganizationACLEndpoints(acl, config.OrgID, expectedAdminACLEndpoints())
+			})
+
+			It("should return the auditor read-only permission matrix", func() {
+				if auditClient == nil {
+					Skip("AUDIT_AUTH_TOKEN or SERVICE_TOKEN_PRIVATE_AUDIT must create an auditor API client")
+				}
+
+				acl, err := auditClient.GetGlobalACL(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				expectOrganizationACLEndpoints(acl, config.OrgID, expectedAuditACLEndpoints())
+			})
+
+			It("should return the public-admin permission matrix", func() {
+				if config.PublicAdminToken == "" {
+					Skip("PUBLIC_ADMIN_AUTH_TOKEN or SERVICE_TOKEN_PRIVATE_PUBLIC_ADMIN must be set by integration fixtures")
+				}
+
+				publicAdminClient := apiClientWithToken(config.PublicAdminToken)
+				acl, err := publicAdminClient.GetGlobalACL(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				expectOrganizationACLEndpoints(acl, config.OrgID, expectedPublicAdminACLEndpoints())
+			})
 		})
 
 		Describe("Given invalid authentication", func() {
@@ -92,6 +270,24 @@ var _ = Describe("Access Control Discovery", func() {
 					"Should return unexpected status code error for missing auth")
 
 				GinkgoWriter.Printf("Expected error for missing authentication: %v\n", err)
+			})
+		})
+	})
+
+	Context("When public-admin accesses users", func() {
+		Describe("Given a private organization", func() {
+			It("should be denied", func() {
+				if config.PublicAdminToken == "" {
+					Skip("PUBLIC_ADMIN_AUTH_TOKEN or SERVICE_TOKEN_PRIVATE_PUBLIC_ADMIN must be set by integration fixtures")
+				}
+
+				publicAdminClient := apiClientWithToken(config.PublicAdminToken)
+				resp, _, err := publicAdminClient.DoRequest(ctx, http.MethodGet,
+					api.NewEndpoints().ListUsers(config.OrgID), nil, http.StatusForbidden)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 			})
 		})
 	})

--- a/test/api/suites/passport_test.go
+++ b/test/api/suites/passport_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"time"
 
 	gojose "github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
@@ -172,6 +173,26 @@ var _ = Describe("Passport Token Exchange", func() {
 					"Passport must not embed ACLs; authorization stays on the remote authorizer path")
 
 				GinkgoWriter.Printf("Passport exchanged successfully, expires_in: %d\n", result.ExpiresIn)
+			})
+
+			It("should be expired after its exp time", func() {
+				result, err := client.ExchangePassport(ctx, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.AccessToken).NotTo(BeEmpty())
+
+				claims := decodePassportClaims(result.AccessToken)
+				Expect(claims.IssuedAt).NotTo(BeNil(), "Passport iat claim should be present")
+				Expect(claims.Expiry).NotTo(BeNil(), "Passport exp claim should be present")
+				Expect(passportTTLSeconds(claims)).To(Equal(int64(60)))
+
+				wait := time.Until(claims.Expiry.Time()) + time.Second
+				if wait > 0 {
+					time.Sleep(wait)
+				}
+
+				Expect(time.Now()).NotTo(BeTemporally("<", claims.Expiry.Time()))
 			})
 		})
 
@@ -380,6 +401,39 @@ var _ = Describe("Passport Token Exchange", func() {
 			})
 		})
 
+		Describe("Given legacy organizationId and projectId form names", func() {
+			It("should not accept them as scoped passport claims", func() {
+				form := url.Values{
+					"grant_type":           {tokenExchangeGrantType()},
+					"subject_token":        {config.AuthToken},
+					"subject_token_type":   {accessTokenSubjectTokenType()},
+					"requested_token_type": {passportIssuedTokenType()},
+					"organizationId":       {config.OrgID},
+					"projectId":            {config.ProjectID},
+				}
+
+				resp, respBody, err := client.ExchangePassportRawForm(ctx, 0, form)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+
+				if resp.StatusCode == http.StatusOK {
+					var result identityopenapi.Token
+					Expect(json.Unmarshal(respBody, &result)).To(Succeed())
+					Expect(result.AccessToken).NotTo(BeEmpty())
+
+					claims := decodePassportClaims(result.AccessToken)
+					Expect(claims.OrgID).To(BeEmpty())
+					Expect(claims.ProjectID).To(BeEmpty())
+
+					return
+				}
+
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+				Expect(string(respBody)).NotTo(ContainSubstring("access_token"))
+			})
+		})
+
 		Describe("Given an invalid resource URI", func() {
 			It("should reject the exchange with an OAuth2 invalid_request response", func() {
 				resource := "not-a-uri"
@@ -429,6 +483,23 @@ var _ = Describe("Passport Token Exchange", func() {
 				Expect(resp).NotTo(BeNil())
 				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
 				expectExchangeOAuth2Error(respBody, identityopenapi.AccessDenied, "token validation failed")
+			})
+
+			It("should reject a garbage source token without minting a passport", func() {
+				form := url.Values{
+					"grant_type":           {tokenExchangeGrantType()},
+					"subject_token":        {"not-an-auth0-token"},
+					"subject_token_type":   {accessTokenSubjectTokenType()},
+					"requested_token_type": {passportIssuedTokenType()},
+				}
+
+				resp, respBody, err := client.ExchangePassportRawForm(ctx, 0, form)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(BeElementOf(http.StatusBadRequest, http.StatusUnauthorized))
+				Expect(string(respBody)).NotTo(ContainSubstring("access_token"))
+				Expect(string(respBody)).NotTo(ContainSubstring("passport"))
 			})
 		})
 

--- a/test/api/suites/suite_test.go
+++ b/test/api/suites/suite_test.go
@@ -35,6 +35,7 @@ var (
 	adminClient          *api.APIClient
 	userClient           *api.APIClient
 	auditClient          *api.APIClient
+	publicAdminClient    *api.APIClient
 	serviceAccountClient *api.APIClient
 	ctx                  context.Context
 	config               *api.TestConfig
@@ -69,6 +70,13 @@ var _ = BeforeEach(func() {
 		auditConfig := *config
 		auditConfig.AuthToken = config.AuditToken
 		auditClient = api.NewAPIClientWithConfig(&auditConfig)
+	}
+
+	publicAdminClient = nil
+	if config.PublicAdminToken != "" {
+		publicAdminConfig := *config
+		publicAdminConfig.AuthToken = config.PublicAdminToken
+		publicAdminClient = api.NewAPIClientWithConfig(&publicAdminConfig)
 	}
 
 	serviceAccountClient = nil


### PR DESCRIPTION
## Summary
- Ports the passing Auth0 identity regression coverage into the Uni identity Go integration suite.
- Adds fixture-token fallbacks for admin, audit, and public-admin service-token names.
- Adds exact admin/audit/public-admin ACL matrix checks, public-admin users denial coverage, passport expiry coverage, legacy scoped-claim form-name coverage, and garbage source-token rejection coverage.

## Auth0 source verification
- Passed before porting: `9.1 public-admin token should not have access to users API`.
- Passed before porting: `admin token should have correct permissions across all endpoints`.
- Passed before porting: `audit token should have read-only permissions across all endpoints`.
- Passed before porting: `public-admin token should have correct permissions across all endpoints`.
- Passed before porting: `4.14 minted passport is expired after its exp time`.
- Passed before porting: `7.7 legacy organizationId/projectId names are not accepted for scoped claims`.
- Passed before porting: `garbage Auth0 source token is rejected without minting a passport`.
- Not ported this iteration: real Auth0 exchange cases were skipped in the source run, and signup cases failed before porting because `BROKER_URL` was not defined.
- Excluded per porting review: invalid AI Proxy/direct-passport and multi-org `X-Organization-Id` cases.

## Testing
- `gofmt -w test/api/config.go test/api/suites/acl_test.go test/api/suites/passport_test.go`
- `go test -tags=integration ./test/api/... -run '^$'`
- `git diff --check`
- Focused live Uni identity run was attempted against `https://identity-codex7095.172.20.255.200.nip.io`, but live requests timed out; public-admin cases skipped locally because no public-admin token was present in `test/.env`.

@claude please review this draft PR, especially the exact ACL matrices, optional public-admin token skip behavior, and the passport expiry/legacy form-name assertions.