### PR TITLE
Adopt the metav1 condition model

### DIFF
--- a/charts/identity/crds/identity.unikorn-cloud.org_oauth2clients.yaml
+++ b/charts/identity/crds/identity.unikorn-cloud.org_oauth2clients.yaml
@@ -92,44 +92,51 @@ spec:
               conditions:
                 description: Current service state of the resource.
                 items:
-                  description: |-
-                    Condition is a generic condition type for use across all resource types.
-                    It's generic so that the underlying controller-manager functionality can
-                    be shared across all resources.
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details about
-                        last transition.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
                       type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's
-                        last transition.
-                      enum:
-                      - Provisioning
-                      - Provisioned
-                      - Cancelled
-                      - Errored
-                      - Deprovisioning
-                      - Deprovisioned
-                      - Unknown
-                      - Healthy
-                      - Degraded
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: |-
-                        Status is the status of the condition.
-                        Can be True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
-                      description: Type is the type of the condition.
-                      enum:
-                      - Available
-                      - Healthy
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
                   - lastTransitionTime

--- a/charts/identity/crds/identity.unikorn-cloud.org_organizations.yaml
+++ b/charts/identity/crds/identity.unikorn-cloud.org_organizations.yaml
@@ -118,44 +118,51 @@ spec:
               conditions:
                 description: Current service state of the resource.
                 items:
-                  description: |-
-                    Condition is a generic condition type for use across all resource types.
-                    It's generic so that the underlying controller-manager functionality can
-                    be shared across all resources.
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details about
-                        last transition.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
                       type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's
-                        last transition.
-                      enum:
-                      - Provisioning
-                      - Provisioned
-                      - Cancelled
-                      - Errored
-                      - Deprovisioning
-                      - Deprovisioned
-                      - Unknown
-                      - Healthy
-                      - Degraded
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: |-
-                        Status is the status of the condition.
-                        Can be True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
-                      description: Type is the type of the condition.
-                      enum:
-                      - Available
-                      - Healthy
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
                   - lastTransitionTime

--- a/charts/identity/crds/identity.unikorn-cloud.org_projects.yaml
+++ b/charts/identity/crds/identity.unikorn-cloud.org_projects.yaml
@@ -87,44 +87,51 @@ spec:
               conditions:
                 description: Current service state of a project.
                 items:
-                  description: |-
-                    Condition is a generic condition type for use across all resource types.
-                    It's generic so that the underlying controller-manager functionality can
-                    be shared across all resources.
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details about
-                        last transition.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
                       type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's
-                        last transition.
-                      enum:
-                      - Provisioning
-                      - Provisioned
-                      - Cancelled
-                      - Errored
-                      - Deprovisioning
-                      - Deprovisioned
-                      - Unknown
-                      - Healthy
-                      - Degraded
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: |-
-                        Status is the status of the condition.
-                        Can be True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
-                      description: Type is the type of the condition.
-                      enum:
-                      - Available
-                      - Healthy
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
                   - lastTransitionTime

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spjmurray/go-util v0.1.3
 	github.com/stretchr/testify v1.11.1
-	github.com/unikorn-cloud/core v1.17.1
+	github.com/unikorn-cloud/core v1.19.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v1.17.1 h1:HTdh055cAyqROqFUTGRQE4zJW9J5Xzm/6Naa/YGYY3M=
-github.com/unikorn-cloud/core v1.17.1/go.mod h1:t91+Hw7YbNt5nOtp93Ij826iQfYDcz6Og0KAi2xq+B8=
+github.com/unikorn-cloud/core v1.19.0 h1:xfw1sa3x7w5acZh/cmjNg2z19D0AyDzWjE5c2J0Qli4=
+github.com/unikorn-cloud/core v1.19.0/go.mod h1:VOEnnmpUPEFC5LsYJGXEWxyS8VuLUcvFSH5LtzT64rA=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -24,6 +24,7 @@ import (
 	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -38,15 +39,14 @@ func (c *OAuth2Client) Paused() bool {
 
 // StatusConditionRead scans the status conditions for an existing condition whose type
 // matches.
-func (c *OAuth2Client) StatusConditionRead(t unikornv1core.ConditionType) (*unikornv1core.Condition, error) {
+func (c *OAuth2Client) StatusConditionRead(t unikornv1core.ConditionType) (*metav1.Condition, error) {
 	return unikornv1core.GetCondition(c.Status.Conditions, t)
 }
 
-// StatusConditionWrite either adds or updates a condition in the cluster manager status.
-// If the condition, status and message match an existing condition the update is
-// ignored.
-func (c *OAuth2Client) StatusConditionWrite(t unikornv1core.ConditionType, status corev1.ConditionStatus, reason unikornv1core.ConditionReason, message string) {
-	unikornv1core.UpdateCondition(&c.Status.Conditions, t, status, reason, message)
+// SetProvisioningCondition sets the Available condition with a reason drawn from
+// the provisioning vocabulary.
+func (c *OAuth2Client) SetProvisioningCondition(status corev1.ConditionStatus, reason unikornv1core.ProvisioningConditionReason, message string) {
+	unikornv1core.UpdateCondition(&c.Status.Conditions, unikornv1core.ConditionAvailable, status, string(reason), message)
 }
 
 // ResourceLabels generates a set of labels to uniquely identify the resource

--- a/pkg/apis/unikorn/v1alpha1/organization_helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/organization_helpers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/unikorn-cloud/core/pkg/constants"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -33,15 +34,20 @@ func (c *Organization) Paused() bool {
 
 // StatusConditionRead scans the status conditions for an existing condition whose type
 // matches.
-func (c *Organization) StatusConditionRead(t unikornv1core.ConditionType) (*unikornv1core.Condition, error) {
+func (c *Organization) StatusConditionRead(t unikornv1core.ConditionType) (*metav1.Condition, error) {
 	return unikornv1core.GetCondition(c.Status.Conditions, t)
 }
 
-// StatusConditionWrite either adds or updates a condition in the cluster manager status.
-// If the condition, status and message match an existing condition the update is
-// ignored.
-func (c *Organization) StatusConditionWrite(t unikornv1core.ConditionType, status corev1.ConditionStatus, reason unikornv1core.ConditionReason, message string) {
-	unikornv1core.UpdateCondition(&c.Status.Conditions, t, status, reason, message)
+// SetProvisioningCondition sets the Available condition with a reason drawn from
+// the provisioning vocabulary.
+func (c *Organization) SetProvisioningCondition(status corev1.ConditionStatus, reason unikornv1core.ProvisioningConditionReason, message string) {
+	unikornv1core.UpdateCondition(&c.Status.Conditions, unikornv1core.ConditionAvailable, status, string(reason), message)
+}
+
+// SetHealthCondition sets the Healthy condition with a reason drawn from the
+// health vocabulary.
+func (c *Organization) SetHealthCondition(status corev1.ConditionStatus, reason unikornv1core.HealthConditionReason, message string) {
+	unikornv1core.UpdateCondition(&c.Status.Conditions, unikornv1core.ConditionHealthy, status, string(reason), message)
 }
 
 // ResourceLabels generates a set of labels to uniquely identify the resource

--- a/pkg/apis/unikorn/v1alpha1/organization_types.go
+++ b/pkg/apis/unikorn/v1alpha1/organization_types.go
@@ -99,5 +99,5 @@ type OrganizationStatus struct {
 	Namespace string `json:"namespace,omitempty"`
 
 	// Current service state of the resource.
-	Conditions []unikornv1core.Condition `json:"conditions,omitempty"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/pkg/apis/unikorn/v1alpha1/project_helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/project_helpers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/unikorn-cloud/core/pkg/constants"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -41,15 +42,20 @@ func (c *Project) Paused() bool {
 
 // StatusConditionRead scans the status conditions for an existing condition whose type
 // matches.
-func (c *Project) StatusConditionRead(t unikornv1core.ConditionType) (*unikornv1core.Condition, error) {
+func (c *Project) StatusConditionRead(t unikornv1core.ConditionType) (*metav1.Condition, error) {
 	return unikornv1core.GetCondition(c.Status.Conditions, t)
 }
 
-// StatusConditionWrite either adds or updates a condition in the cluster manager status.
-// If the condition, status and message match an existing condition the update is
-// ignored.
-func (c *Project) StatusConditionWrite(t unikornv1core.ConditionType, status corev1.ConditionStatus, reason unikornv1core.ConditionReason, message string) {
-	unikornv1core.UpdateCondition(&c.Status.Conditions, t, status, reason, message)
+// SetProvisioningCondition sets the Available condition with a reason drawn from
+// the provisioning vocabulary.
+func (c *Project) SetProvisioningCondition(status corev1.ConditionStatus, reason unikornv1core.ProvisioningConditionReason, message string) {
+	unikornv1core.UpdateCondition(&c.Status.Conditions, unikornv1core.ConditionAvailable, status, string(reason), message)
+}
+
+// SetHealthCondition sets the Healthy condition with a reason drawn from the
+// health vocabulary.
+func (c *Project) SetHealthCondition(status corev1.ConditionStatus, reason unikornv1core.HealthConditionReason, message string) {
+	unikornv1core.UpdateCondition(&c.Status.Conditions, unikornv1core.ConditionHealthy, status, string(reason), message)
 }
 
 // ResourceLabels generates a set of labels to uniquely identify the resource

--- a/pkg/apis/unikorn/v1alpha1/project_types.go
+++ b/pkg/apis/unikorn/v1alpha1/project_types.go
@@ -64,5 +64,5 @@ type ProjectStatus struct {
 	Namespace string `json:"namespace,omitempty"`
 
 	// Current service state of a project.
-	Conditions []unikornv1core.Condition `json:"conditions,omitempty"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -79,7 +79,7 @@ type OAuth2ClientStatus struct {
 	// Secret is the generated client secret.
 	Secret string `json:"secret,omitempty"`
 	// Current service state of the resource.
-	Conditions []unikornv1core.Condition `json:"conditions,omitempty"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 // OAuth2ProviderList is a typed list of backend servers.

--- a/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha1
 
 import (
 	unikornv1alpha1 "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -388,7 +389,7 @@ func (in *OAuth2ClientStatus) DeepCopyInto(out *OAuth2ClientStatus) {
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]unikornv1alpha1.Condition, len(*in))
+		*out = make([]v1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -673,7 +674,7 @@ func (in *OrganizationStatus) DeepCopyInto(out *OrganizationStatus) {
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]unikornv1alpha1.Condition, len(*in))
+		*out = make([]v1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -902,7 +903,7 @@ func (in *ProjectStatus) DeepCopyInto(out *ProjectStatus) {
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]unikornv1alpha1.Condition, len(*in))
+		*out = make([]v1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/pkg/provisioners/organization/provisioner.go
+++ b/pkg/provisioners/organization/provisioner.go
@@ -91,7 +91,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 	// TODO: we may want to consider rolling up the conditions of subordinates,
 	// but then again it may be overkill and cause undue stress!
-	p.organization.StatusConditionWrite(unikornv1core.ConditionHealthy, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "Healthy")
+	p.organization.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "Healthy")
 
 	return nil
 }

--- a/pkg/provisioners/project/provisioner.go
+++ b/pkg/provisioners/project/provisioner.go
@@ -99,7 +99,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 	// TODO: we may want to consider rolling up the conditions of subordinates,
 	// but then again it may be overkill and cause undue stress!
-	p.project.StatusConditionWrite(unikornv1core.ConditionHealthy, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "Healthy")
+	p.project.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "Healthy")
 
 	return nil
 }


### PR DESCRIPTION
Move identity's status conditions onto the shared metav1.Condition model
reworked in core (typed reasons, metav1 shape, generic Active) so the same
generic condition algorithms apply uniformly across Available/Healthy/Active.
Pins core to the released v1.19.0 that carries the model; the local replace
is gone.

Part of INST-1023.