### PR TITLE
ci: publish OpenAPI spec to nscaledev/openapi

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -97,3 +97,16 @@ jobs:
           --broker-base-url="${{ vars.PACT_BROKER_URL_DEV }}" \
           --broker-username="${{ vars.PACT_BROKER_USERNAME }}" \
           --broker-password="${{ secrets.PACT_BROKER_PASSWORD }}"
+  PublishOpenAPISpec:
+    needs: Coverage
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Publish OpenAPI spec
+      uses: nscaledev/openapi/.github/actions/publish-spec@main
+      with:
+        service: identity
+        spec-path: pkg/openapi/server.spec.yaml
+        version: main
+        token: ${{ secrets.OPENAPI_PUBLISH_TOKEN }}

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -104,7 +104,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Publish OpenAPI spec
-      uses: nscaledev/openapi/.github/actions/publish-spec@main
+      uses: nscaledev/openapi/.github/actions/publish-spec@3c79a8b4cd3863a152456c1c2c729b245a79a1af # main
       with:
         service: identity
         spec-path: pkg/openapi/server.spec.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,7 +96,7 @@ jobs:
         name: Release ${{ github.ref_name }}
         tag_name: ${{ github.ref_name }}
     - name: Publish OpenAPI spec
-      uses: nscaledev/openapi/.github/actions/publish-spec@main
+      uses: nscaledev/openapi/.github/actions/publish-spec@3c79a8b4cd3863a152456c1c2c729b245a79a1af # main
       with:
         service: identity
         spec-path: pkg/openapi/server.spec.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,3 +95,10 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         name: Release ${{ github.ref_name }}
         tag_name: ${{ github.ref_name }}
+    - name: Publish OpenAPI spec
+      uses: nscaledev/openapi/.github/actions/publish-spec@main
+      with:
+        service: identity
+        spec-path: pkg/openapi/server.spec.yaml
+        version: ${{ github.ref_name }}
+        token: ${{ secrets.OPENAPI_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a `PublishOpenAPISpec` job to `merge.yaml` that calls the shared [`nscaledev/openapi/.github/actions/publish-spec`](https://github.com/nscaledev/openapi/blob/main/.github/actions/publish-spec/action.yml) action with `version: main` on every push to `main`.
- Adds a final step to `release.yaml`'s `release` job calling the same action with `version: ${{ github.ref_name }}` on every tagged release.
- The action bundles, sanitizes (strips internal-only operations/servers/vendor extensions), lints, and commits `pkg/openapi/server.spec.yaml` into `identity/main/` or `identity/vX.Y.Z/` in `nscaledev/openapi`. It's a no-op if the spec hasn't changed since the last publish.

## Before this can actually work
This repo needs an `OPENAPI_PUBLISH_TOKEN` secret — a token with `contents: write` on `nscaledev/openapi` — added under **Settings → Secrets and variables → Actions**. Until then, the new step will fail with an auth error; everything else in `merge.yaml`/`release.yaml` is unaffected.

## Test plan
- [ ] Add the `OPENAPI_PUBLISH_TOKEN` secret
- [ ] Merge this PR, confirm `PublishOpenAPISpec` succeeds on the resulting main-push run and `identity/main/openapi.{yaml,json}` updates in `nscaledev/openapi`
- [ ] Cut a release tag, confirm the new step in `release.yaml` succeeds and `identity/vX.Y.Z/` appears in `nscaledev/openapi`