### PR TITLE
feat: propagate OTLP resource attributes

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -12,5 +12,5 @@ icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/d
 
 dependencies:
 - name: unikorn-common
-  version: 0.1.17
+  version: 0.1.18
   repository: https://nscaledev.github.io/uni-helm-common

--- a/charts/identity/templates/identity/deployment.yaml
+++ b/charts/identity/templates/identity/deployment.yaml
@@ -46,6 +46,10 @@ spec:
         {{- range $i, $arg := .Values.server.extraFlags }}
         - {{ $arg }}
         {{- end }}
+        {{- with include "unikorn.otlp.env" . }}
+        env:
+{{ . | indent 8 }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 6080

--- a/charts/identity/templates/oauth2client-controller/deployment.yaml
+++ b/charts/identity/templates/oauth2client-controller/deployment.yaml
@@ -20,6 +20,10 @@ spec:
         args:
         {{- include "unikorn.core.flags" . | nindent 8 }}
         {{- include "unikorn.otlp.flags" . | nindent 8 }}
+        {{- with include "unikorn.otlp.env" . }}
+        env:
+{{ . | indent 8 }}
+        {{- end }}
         resources:
           {{- .Values.oauth2clientController.resources | toYaml | nindent 10 }}
         securityContext:

--- a/charts/identity/templates/organization-controller/deployment.yaml
+++ b/charts/identity/templates/organization-controller/deployment.yaml
@@ -20,6 +20,10 @@ spec:
         args:
         {{- include "unikorn.core.flags" . | nindent 8 }}
         {{- include "unikorn.otlp.flags" . | nindent 8 }}
+        {{- with include "unikorn.otlp.env" . }}
+        env:
+{{ . | indent 8 }}
+        {{- end }}
         resources:
           {{- .Values.organizationController.resources | toYaml | nindent 10 }}
         securityContext:

--- a/charts/identity/templates/project-controller/deployment.yaml
+++ b/charts/identity/templates/project-controller/deployment.yaml
@@ -20,6 +20,10 @@ spec:
         args:
         {{- include "unikorn.core.flags" . | nindent 8 }}
         {{- include "unikorn.otlp.flags" . | nindent 8 }}
+        {{- with include "unikorn.otlp.env" . }}
+        env:
+{{ . | indent 8 }}
+        {{- end }}
         resources:
           {{- .Values.projectController.resources | toYaml | nindent 10 }}
         securityContext:

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -441,4 +441,7 @@ ingress:
 #   maxAge: 86400
 
 # Sets the OTLP endpoint for shipping spans.
-# otlpEndpoint: jaeger-collector.default:4318
+# otlp:
+#   endpoint: jaeger-collector.default:4318
+#   resourceAttributes:
+#     deployment.environment: dev

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -441,7 +441,8 @@ ingress:
 #   maxAge: 86400
 
 # Sets the OTLP endpoint for shipping spans.
-# otlp:
-#   endpoint: jaeger-collector.default:4318
-#   resourceAttributes:
-#     deployment.environment: dev
+# global:
+#   otlp:
+#     endpoint: jaeger-collector.default:4318
+#     resourceAttributes:
+#       deployment.environment: <environment>


### PR DESCRIPTION
## Summary

Bumps `unikorn-common` to `0.1.18` and wires the new OTLP resource attributes helper into the Identity deployments that already emit OTLP traces.

This renders `OTEL_RESOURCE_ATTRIBUTES` when `global.otlp.resourceAttributes` is configured, allowing spans to carry `deployment.environment` for Tempo spanmetrics promotion.

## Why

The Service Health & Error Rate dashboard is expected to support environment filtering for UNI, but the environment dropdown only shows `All` because UNI spanmetrics do not currently carry the `deployment_environment` label.

Tempo can promote `deployment.environment` into `deployment_environment`, but Identity pods first need that OTEL resource attribute on emitted spans.

Dashboard: https://observability-grafana.nscale.teleport.sh/d/uni-api-health/uni-api-health

## Dependency

Depends on `unikorn-common` `0.1.18` being released from:

- https://github.com/nscaledev/uni-helm-common/pull/17

## Validation

- Local render/lint against the local `unikorn-common` chart
- Verified default render does not include `OTEL_RESOURCE_ATTRIBUTES`
- Verified configured render includes 4 `OTEL_RESOURCE_ATTRIBUTES` entries
- `git diff --check`
- GitHub commit verification: signed and verified