### PR TITLE
feat(handler/groups): gate member additions on the group's roles (ID-368)

### DIFF
--- a/pkg/apis/unikorn/v1alpha1/group_helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/group_helpers.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"slices"
+)
+
+// IdentityKey returns a comparable key for the principal a subject names.  A
+// principal is identified by the issuer that authenticated it and its ID at
+// that issuer.  Email is display data only — the handlers that write subjects
+// populate it from different sources and it can differ between two records
+// for the same principal — so it takes no part in identity.
+func (s *GroupSubject) IdentityKey() string {
+	return s.Issuer + "\x00" + s.ID
+}
+
+// Matches reports whether two subjects name the same principal.
+func (s *GroupSubject) Matches(other GroupSubject) bool {
+	return s.IdentityKey() == other.IdentityKey()
+}
+
+// HasSubject reports whether the group already lists a subject for the same
+// principal.
+func (s *GroupSpec) HasSubject(subject GroupSubject) bool {
+	return slices.ContainsFunc(s.Subjects, subject.Matches)
+}
+
+// HasMember reports whether the group already confers its roles on the
+// principal.  Either membership representation counts: RBAC resolves a
+// principal's groups through the subject list and through the deprecated
+// organization user ID list alike, so presence in one is enough for the
+// principal to hold the roles already, and writing the other half confers
+// nothing.
+//
+// An empty organization user ID matches nothing.  Membership lists are not
+// validated against real records, so a junk empty entry must not stand in for
+// a principal that has no organization user record yet.
+func (s *GroupSpec) HasMember(organizationUserID string, subject GroupSubject) bool {
+	if organizationUserID != "" && slices.Contains(s.UserIDs, organizationUserID) {
+		return true
+	}
+
+	return s.HasSubject(subject)
+}

--- a/pkg/handler/common/membership.go
+++ b/pkg/handler/common/membership.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+
+	servererrors "github.com/unikorn-cloud/core/pkg/server/errors"
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/identity/pkg/ids"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AllowGroupMembershipAddition returns nil if the calling principal may add
+// a member to the given group.  Adding a member confers the group's roles,
+// so the caller must be able to grant every role the group carries.
+//
+// A role reference that does not resolve refuses the addition rather than
+// being skipped.  Role IDs are derived from the role name, so a role that is
+// deleted and later re-applied comes back with the same ID and immediately
+// re-binds to every group still referencing it; a member added during the gap
+// would then hold a role nobody was ever asked to grant, and for a service
+// account that authority rides a long-lived token.  Refusing also keeps this
+// consistent with ACL construction, which treats the same dangling reference
+// as a consistency failure rather than an empty permission set.
+//
+// Only additions go through here.  Removing a member, and deleting a
+// principal (which strips its memberships as cleanup), take authority away
+// rather than handing it out, so neither is gated.  Dropping a dangling role
+// from a group is likewise allowed — see validateRoleRemovals in
+// pkg/handler/groups.  The asymmetry is deliberate: skipping an unresolvable
+// role errs towards less authority on a removal and towards more on an
+// addition, so only the removal side is safe to skip.
+func AllowGroupMembershipAddition(ctx context.Context, cli client.Client, namespace string, organizationID ids.OrganizationID, group *unikornv1.Group) error {
+	for _, roleID := range group.Spec.RoleIDs {
+		var resource unikornv1.Role
+
+		if err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: roleID}, &resource); err != nil {
+			if kerrors.IsNotFound(err) {
+				return servererrors.HTTPForbidden(fmt.Sprintf("members cannot be added to the group: role %s does not resolve, so the authority it confers cannot be checked", roleID)).WithError(err)
+			}
+
+			return fmt.Errorf("%w: failed to validate group membership addition", err)
+		}
+
+		if err := rbac.AllowRole(ctx, &resource, organizationID); err != nil {
+			return servererrors.HTTPForbidden(fmt.Sprintf("members cannot be added to the group: role %q (%s) is not grantable by the caller", RoleDisplayName(&resource), roleID)).WithError(err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/handler/common/membership_test.go
+++ b/pkg/handler/common/membership_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/core/pkg/constants"
+	servererrors "github.com/unikorn-cloud/core/pkg/server/errors"
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/identity/pkg/handler/common"
+	"github.com/unikorn-cloud/identity/pkg/ids"
+	"github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	membershipNamespace      = "identity"
+	membershipOrganizationID = "acbaf1e5-6414-4066-b74e-2d95dc766299"
+	membershipRoleID         = "radar-id"
+	membershipRoleName       = "radar"
+)
+
+// membershipRole builds a role scoped to an endpoint no built-in role holds, so only a
+// caller whose ACL is extended to cover it can grant the role.
+func membershipRole() *unikornv1.Role {
+	return &unikornv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      membershipRoleID,
+			Namespace: membershipNamespace,
+			Labels:    map[string]string{constants.NameLabel: membershipRoleName},
+		},
+		Spec: unikornv1.RoleSpec{
+			Scopes: unikornv1.RoleScopes{
+				Organization: []unikornv1.RoleScope{
+					{Name: "radar:things", Operations: []unikornv1.Operation{unikornv1.Read}},
+				},
+			},
+		},
+	}
+}
+
+func membershipClient(t *testing.T, roles ...*unikornv1.Role) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, unikornv1.AddToScheme(scheme))
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, role := range roles {
+		builder = builder.WithObjects(role)
+	}
+
+	return builder.Build()
+}
+
+// membershipACL builds a context carrying an ACL that grants only the given
+// organization-scoped endpoints in the test organization.
+func membershipACL(endpoints openapi.AclEndpoints) context.Context {
+	organizations := openapi.AclOrganizationList{{Id: membershipOrganizationID, Endpoints: &endpoints}}
+
+	return rbac.NewContext(context.Background(), &openapi.Acl{Organizations: &organizations})
+}
+
+func membershipGroup(roleIDs ...string) *unikornv1.Group {
+	return &unikornv1.Group{Spec: unikornv1.GroupSpec{RoleIDs: roleIDs}}
+}
+
+func TestAllowGroupMembershipAdditionRefusesUngrantableRole(t *testing.T) {
+	t.Parallel()
+
+	cli := membershipClient(t, membershipRole())
+
+	organizationID, err := ids.ParseOrganizationID(membershipOrganizationID)
+	require.NoError(t, err)
+
+	// The caller may edit users and groups, but holds nothing on radar:things,
+	// so it cannot hand the group's role to a new member.
+	ctx := membershipACL(openapi.AclEndpoints{
+		{Name: "identity:users", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	err = common.AllowGroupMembershipAddition(ctx, cli, membershipNamespace, organizationID, membershipGroup(membershipRoleID))
+	require.Error(t, err)
+	require.True(t, servererrors.IsForbidden(err))
+	require.Contains(t, err.Error(), membershipRoleName)
+	require.Contains(t, err.Error(), membershipRoleID)
+}
+
+func TestAllowGroupMembershipAdditionAllowsRoleHolder(t *testing.T) {
+	t.Parallel()
+
+	cli := membershipClient(t, membershipRole())
+
+	organizationID, err := ids.ParseOrganizationID(membershipOrganizationID)
+	require.NoError(t, err)
+
+	// The grant traces to a holder: this caller has every permission the role
+	// carries, so it may confer it.
+	ctx := membershipACL(openapi.AclEndpoints{
+		{Name: "radar:things", Operations: openapi.AclOperations{openapi.Read}},
+	})
+
+	require.NoError(t, common.AllowGroupMembershipAddition(ctx, cli, membershipNamespace, organizationID, membershipGroup(membershipRoleID)))
+}
+
+func TestAllowGroupMembershipAdditionRefusesDanglingRole(t *testing.T) {
+	t.Parallel()
+
+	cli := membershipClient(t)
+
+	organizationID, err := ids.ParseOrganizationID(membershipOrganizationID)
+	require.NoError(t, err)
+
+	ctx := membershipACL(openapi.AclEndpoints{
+		{Name: "identity:users", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	// A role reference that does not resolve cannot be grant-checked, and role
+	// IDs are a hash of the role name, so the same ID comes back if the role is
+	// ever re-applied and re-binds to every group still referencing it.  A
+	// member parked in the group meanwhile would gain the role without anyone
+	// having authorised it, so the addition is refused rather than waved
+	// through.
+	err = common.AllowGroupMembershipAddition(ctx, cli, membershipNamespace, organizationID, membershipGroup("no-such-role"))
+	require.Error(t, err)
+	require.True(t, servererrors.IsForbidden(err))
+	require.Contains(t, err.Error(), "no-such-role", "the error must name the role that cannot be resolved")
+}
+
+func TestAllowGroupMembershipAdditionAllowsRolelessGroup(t *testing.T) {
+	t.Parallel()
+
+	cli := membershipClient(t, membershipRole())
+
+	organizationID, err := ids.ParseOrganizationID(membershipOrganizationID)
+	require.NoError(t, err)
+
+	ctx := membershipACL(openapi.AclEndpoints{
+		{Name: "identity:users", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	// A group with no roles confers nothing, so membership in it is not a grant.
+	require.NoError(t, common.AllowGroupMembershipAddition(ctx, cli, membershipNamespace, organizationID, membershipGroup()))
+}

--- a/pkg/handler/groups/README.md
+++ b/pkg/handler/groups/README.md
@@ -79,9 +79,41 @@ revocation:
 
 So group writes are also authority-delegation checks, for both grants and revocations.
 
-Group DELETE is an unguarded revocation path. Deleting a group is an explicit, whole-group action
+### Membership Guard Rails
+
+Adding a member to a group hands that member every role the group carries, so it is a grant like
+any other and has to trace to a holder. A `PUT /groups/{id}` that puts a user, subject, or service
+account on a group is refused unless the caller could grant each of the group's roles themselves.
+The roles checked are the ones the group carries after the write, since that is what the new member
+inherits. A refusal names the role.
+
+Membership is compared by principal identity, not by stored record. A subject identifies a
+principal by `(issuer, id)`; its `email` is display data that different writers populate from
+different sources, so it takes no part in the comparison. Both membership representations count as
+already-a-member: `pkg/rbac` resolves a principal's groups through `UserIDs` and through `Subjects`
+alike, so a member listed in one representation and named through the other gains nothing, and the
+write is not an addition. That matters for groups written before `Subjects` existed — re-sending
+their membership fills in the missing half and must not be read as a grant, or such a group has no
+legal update at all.
+
+A group with no roles confers nothing, so membership in it is not a grant and nothing blocks the
+addition. A role reference that no longer resolves is the opposite case and does block it — see
+Decommissioning A Service's Roles below for why that direction is not symmetric with removal.
+
+Create needs no separate membership check. Every role on a new group counts as an addition and is
+already grant-checked, so the creator holds everything the new group confers.
+
+This gate sits on the groups path. [`pkg/handler/users`](../users/README.md) and
+[`pkg/handler/serviceaccounts`](../serviceaccounts/README.md) also write group membership, by
+reconciling a requested `groupIDs` list into the groups that name the principal, and those paths do
+not run this check.
+
+Removals are ungated. Taking a member out of a group takes authority away rather than handing it
+out, so a caller who could not add a member to a group may still remove one. Group DELETE is an
+unguarded revocation path for the same reason: deleting a group is an explicit, whole-group action
 by the caller, not a silent side effect of an update, so the role-removal guard — which exists to
-catch omission — does not apply to it.
+catch omission — does not apply to it. Deleting a user or service account strips its memberships as
+cleanup, and is likewise unguarded.
 
 ### Decommissioning A Service's Roles
 
@@ -100,6 +132,20 @@ member of the affected group cannot perform the repair through the API at all �
 fails closed on the dangling reference — so if an organization's only admins sit in that group,
 repair falls back to direct CR access.)
 
+Adding a member to a group carrying a dangling reference is refused, and the refusal names the
+unresolvable role ID. The two directions are deliberately asymmetric, and the reason is that role
+IDs are not random: a role ID is derived from the role name, so deleting a `Role` CR and re-applying
+it later brings back the *same* ID, which immediately re-binds to every group that still references
+it. Anyone added to the group during that window silently acquires the role when it returns, without
+a grant check ever having run — and for a service account, that authority rides a long-lived token.
+Skipping an unresolvable role therefore errs towards less authority on a removal and towards more on
+an addition, so only the removal side is safe to skip. Refusing additions also matches what
+`pkg/rbac` already does with the same reference: it fails closed.
+
+A side effect worth naming: because ACL construction fails closed, adding someone to a
+dangling-reference group breaks their whole organization ACL, not just their access to that group.
+Refusing the addition closes that off as well, at least on the groups path.
+
 The trap is the window before that. While the `Role` CR still exists, removing it from a group is a
 guarded revocation like any other — the caller must hold its permissions. That is unremarkable for a
 live service, but once a service is being decommissioned, nobody may hold those permissions any
@@ -110,9 +156,13 @@ access would). Strip the references while permission holders still exist instead
 Protected roles are the one case exempt from that trap entirely: they are always droppable from a
 group regardless of who holds what, as invariant repair (see Role Assignment Guard Rails above).
 
-Deleting the group outright is the other way out, since group DELETE is unguarded. That takes the
-group's members with it, so it is only the right move when the group exists to carry the retiring
-service's roles and nothing else.
+Membership is the easier half of the job. Emptying a group of its members needs no authority over
+the roles it carries, so members can be pulled out of a group carrying a live ungrantable role at
+any point in the sequence, and the group can then be deleted outright — group DELETE is unguarded.
+Deleting the group takes the members with it, so it is only the right move when the group exists to
+carry the retiring service's roles and nothing else. What does not work while the `Role` CR is still
+installed is putting anyone *into* such a group through `PUT /groups/{id}`: a decommissioning
+service's group cannot take on new members that way once nobody holds its permissions.
 
 ### Project Reference Cleanup
 
@@ -131,6 +181,11 @@ would drift.
   group are not re-checked on subsequent writes
 - callers may only drop a role from a group on update if they are allowed to grant that role,
   unless the role no longer resolves or is protected
+- adding a member to a group through this client is a grant of that group's roles, so it is allowed
+  only where the caller could grant every role the group carries
+- a principal is the same member in either representation, identified by `(issuer, id)`; a subject's
+  `email` is display data and takes no part in that comparison
+- removing a member from a group confers nothing and is not gated
 - group DELETE revokes without a role check, by design
 - internal compatibility between `UserIDs` and `Subjects` should be maintained where possible
 - group membership and role/service-account ID lists are normalized to first-occurrence unique values
@@ -138,11 +193,16 @@ would drift.
 
 ## Caveats
 
-- A group seeded with a role from a broader-authority admin is role-frozen for everyone who cannot
-  grant that role: they can still rename it, resend its role list, change its members and delete it
-  outright, but they cannot drop the role. That is the intended trade — dropping a role is a
-  revocation the caller has to be entitled to make — and the way out is to give the editor the
-  role's permissions, not to relax the check.
+- A group seeded with a role from a broader-authority admin is frozen for everyone who cannot grant
+  that role: they can still rename it, resend its role list, remove members and delete it outright,
+  but they cannot drop the role and cannot add a member through this client. That is the intended
+  trade — dropping a role is a revocation, and adding a member is a grant, and the caller has to be
+  entitled to make either — and the way out is to give the editor the role's permissions, not to
+  relax the check.
+- The membership gate covers `PUT /groups/{id}` only. The same membership can be written through
+  `pkg/handler/users` and `pkg/handler/serviceaccounts`, which reconcile a requested `groupIDs` list
+  without this check, so a caller holding `identity:users` or `identity:serviceaccounts` write can
+  still put a principal into a group whose roles it cannot grant.
 - The package is partly a migration bridge because it must support both deprecated `UserIDs` and
   forward-looking `Subjects`.
 - Groups may include external subjects that do not resolve to local `User` objects, so not every

--- a/pkg/handler/groups/client.go
+++ b/pkg/handler/groups/client.go
@@ -197,7 +197,7 @@ func deduplicateGroupSubjects(in []unikornv1.GroupSubject) []unikornv1.GroupSubj
 	seen := make(map[string]struct{}, len(in))
 
 	for _, subject := range in {
-		key := subject.Issuer + "\x00" + subject.ID
+		key := subject.IdentityKey()
 		if _, ok := seen[key]; ok {
 			continue
 		}
@@ -208,6 +208,44 @@ func deduplicateGroupSubjects(in []unikornv1.GroupSubject) []unikornv1.GroupSubj
 	}
 
 	return out
+}
+
+// groupPrincipal is one member named by a membership write, carrying both the
+// representations a group stores members in.  UserID is empty for a principal
+// at an external issuer: it has no organization user record.  Keeping the two
+// together is what lets the addition guard ask whether the group already
+// confers its roles on this principal, rather than whether one particular
+// representation of it is present.
+type groupPrincipal struct {
+	userID  string
+	subject unikornv1.GroupSubject
+}
+
+// principalUserIDs projects the organization user IDs out of a principal list,
+// dropping principals that have no organization user record.
+func principalUserIDs(in []groupPrincipal) []string {
+	var userIDs []string //nolint:prealloc
+
+	for _, principal := range in {
+		if principal.userID == "" {
+			continue
+		}
+
+		userIDs = append(userIDs, principal.userID)
+	}
+
+	return deduplicateStrings(userIDs)
+}
+
+// principalSubjects projects the subjects out of a principal list.
+func principalSubjects(in []groupPrincipal) []unikornv1.GroupSubject {
+	var subjects []unikornv1.GroupSubject //nolint:prealloc
+
+	for _, principal := range in {
+		subjects = append(subjects, principal.subject)
+	}
+
+	return deduplicateGroupSubjects(subjects)
 }
 
 // findUserBySubject finds a User resource by subject field.
@@ -245,34 +283,40 @@ func (c *Client) findOrgUserByUserID(ctx context.Context, orgNamespace, userID s
 	}
 }
 
-// subjectsToUserIDs converts internal subjects to UserIDs.
-func (c *Client) subjectsToUserIDs(ctx context.Context, subjects []unikornv1.GroupSubject, organization *organizations.Meta) ([]string, error) {
-	var userIDs []string //nolint:prealloc
+// subjectsToPrincipals resolves each subject to the principal it names,
+// filling in the organization user ID for subjects at this deployment's own
+// issuer.  Subjects at an external issuer have no organization user record and
+// keep an empty ID.
+func (c *Client) subjectsToPrincipals(ctx context.Context, subjects []unikornv1.GroupSubject, organization *organizations.Meta) ([]groupPrincipal, error) {
+	principals := make([]groupPrincipal, 0, len(subjects))
 
 	for _, subject := range subjects {
-		if subject.Issuer != c.issuer.URL {
-			continue // Skip external subjects
+		principal := groupPrincipal{subject: subject}
+
+		if subject.Issuer == c.issuer.URL {
+			user, err := c.findUserBySubject(ctx, subject.ID)
+			if err != nil {
+				return nil, err
+			}
+
+			orgUser, err := c.findOrgUserByUserID(ctx, organization.Namespace, user.Name)
+			if err != nil {
+				return nil, err
+			}
+
+			principal.userID = orgUser.Name
 		}
 
-		user, err := c.findUserBySubject(ctx, subject.ID)
-		if err != nil {
-			return nil, err
-		}
-
-		orgUser, err := c.findOrgUserByUserID(ctx, organization.Namespace, user.Name)
-		if err != nil {
-			return nil, err
-		}
-
-		userIDs = append(userIDs, orgUser.Name)
+		principals = append(principals, principal)
 	}
 
-	return userIDs, nil
+	return principals, nil
 }
 
-// userIDsToSubjects converts UserIDs to subjects.
-func (c *Client) userIDsToSubjects(ctx context.Context, userIDs []string, organization *organizations.Meta) ([]unikornv1.GroupSubject, error) {
-	subjects := make([]unikornv1.GroupSubject, 0, len(userIDs))
+// userIDsToPrincipals resolves each organization user ID to the principal it
+// names, deriving the subject that identifies it at this deployment's issuer.
+func (c *Client) userIDsToPrincipals(ctx context.Context, userIDs []string, organization *organizations.Meta) ([]groupPrincipal, error) {
+	principals := make([]groupPrincipal, 0, len(userIDs))
 
 	for _, orgUserID := range userIDs {
 		var orguser unikornv1.OrganizationUser
@@ -287,20 +331,24 @@ func (c *Client) userIDsToSubjects(ctx context.Context, userIDs []string, organi
 			return nil, fmt.Errorf("%w: failed to get user record", err)
 		}
 
-		subjects = append(subjects, unikornv1.GroupSubject{
-			ID:     user.Spec.Subject,
-			Email:  user.Spec.Subject,
-			Issuer: c.issuer.URL,
+		principals = append(principals, groupPrincipal{
+			userID: orgUserID,
+			subject: unikornv1.GroupSubject{
+				ID:     user.Spec.Subject,
+				Email:  user.Spec.Subject,
+				Issuer: c.issuer.URL,
+			},
 		})
 	}
 
-	return subjects, nil
+	return principals, nil
 }
 
-// populateSubjectsAndUserIDs normalizes the dual UserIDs/Subjects representations.
-// Providing both non-empty fields is invalid. A non-empty Subjects input derives UserIDs,
-// and a non-empty UserIDs input derives Subjects.
-func (c *Client) populateSubjectsAndUserIDs(ctx context.Context, organization *organizations.Meta, in *openapi.GroupWrite) ([]string, []unikornv1.GroupSubject, error) {
+// populateGroupPrincipals normalizes the dual UserIDs/Subjects representations
+// into one principal list holding both.  Providing both non-empty fields is
+// invalid. A non-empty Subjects input derives UserIDs, and a non-empty UserIDs
+// input derives Subjects.
+func (c *Client) populateGroupPrincipals(ctx context.Context, organization *organizations.Meta, in *openapi.GroupWrite) ([]groupPrincipal, error) {
 	var normalizedUserIDs []string
 	if in.Spec.UserIDs != nil {
 		normalizedUserIDs = deduplicateStrings(*in.Spec.UserIDs)
@@ -315,28 +363,18 @@ func (c *Client) populateSubjectsAndUserIDs(ctx context.Context, organization *o
 	hasUserIDs := len(normalizedUserIDs) > 0
 
 	if hasSubjects && hasUserIDs {
-		return nil, nil, errors.OAuth2InvalidRequest("cannot provide both subjects and userIDs")
+		return nil, errors.OAuth2InvalidRequest("cannot provide both subjects and userIDs")
 	}
 
 	if hasSubjects {
-		resolvedUserIDs, err := c.subjectsToUserIDs(ctx, normalizedSubjects, organization)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		return deduplicateStrings(resolvedUserIDs), normalizedSubjects, nil
+		return c.subjectsToPrincipals(ctx, normalizedSubjects, organization)
 	}
 
 	if hasUserIDs {
-		resolvedSubjects, err := c.userIDsToSubjects(ctx, normalizedUserIDs, organization)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		return normalizedUserIDs, deduplicateGroupSubjects(resolvedSubjects), nil
+		return c.userIDsToPrincipals(ctx, normalizedUserIDs, organization)
 	}
 
-	return nil, nil, nil
+	return nil, nil
 }
 
 func (c *Client) validateRoleIDs(ctx context.Context, organizationID ids.OrganizationID, roleIDs, currentRoleIDs []string) ([]string, error) {
@@ -361,7 +399,8 @@ func (c *Client) validateRoleIDs(ctx context.Context, organizationID ids.Organiz
 		// Only roles being ADDED are grant-checked.  Re-sending a group's
 		// existing role list (e.g. a rename, or dropping a member) must not
 		// fail on roles the caller could not grant; the escalation guard
-		// applies to the delta.  Removals are guarded separately.
+		// applies to the delta.  Removals are guarded separately, and so are
+		// the member additions that would confer these roles on someone new.
 		if slices.Contains(currentRoleIDs, roleID) {
 			continue
 		}
@@ -382,10 +421,13 @@ func (c *Client) validateRoleIDs(ctx context.Context, organizationID ids.Organiz
 // grant, so a client that cannot see an ungrantable role cannot silently
 // revoke it by round-tripping the group.  Roles that no longer exist may
 // always be dropped: a dangling reference conveys no permissions, and
-// dropping it is how a group carrying one gets repaired.  Protected roles may
-// also always be dropped: they should never be on a group at all, so removing
-// one is invariant repair rather than a revocation the caller needs permission
-// for.
+// dropping it is how a group carrying one gets repaired.  The membership
+// addition guard refuses that same dangling reference instead of skipping it,
+// because a role ID is derived from the role name and rebinds if the role
+// returns: skipping errs towards less authority on a removal and towards more
+// on an addition.  Protected roles may also always be dropped: they should
+// never be on a group at all, so removing one is invariant repair rather than
+// a revocation the caller needs permission for.
 func (c *Client) validateRoleRemovals(ctx context.Context, organizationID ids.OrganizationID, current *unikornv1.Group, requestedRoleIDs []string) error {
 	for _, roleID := range current.Spec.RoleIDs {
 		if slices.Contains(requestedRoleIDs, roleID) {
@@ -420,13 +462,53 @@ func (c *Client) validateRoleRemovals(ctx context.Context, organizationID ids.Or
 	return nil
 }
 
-// generate builds the group the request asks for.  current is the stored group
-// on an update, and nil on a create, where every role in the request counts as
-// an addition.
-func (c *Client) generate(ctx context.Context, organization *organizations.Meta, in *openapi.GroupWrite, current *unikornv1.Group) (*unikornv1.Group, error) {
-	userIDs, subjects, err := c.populateSubjectsAndUserIDs(ctx, organization, in)
+// hasMemberAdditions reports whether the update puts a principal or service
+// account on the group that the group does not already confer its roles on.
+// A principal is matched on the identity its subject carries, not on the whole
+// stored record, and in either membership representation: an existing member
+// re-stated in a write, or named through the representation it is not stored
+// in, gains nothing it does not already hold.
+func hasMemberAdditions(current *unikornv1.Group, principals []groupPrincipal, serviceAccountIDs []string) bool {
+	for _, principal := range principals {
+		if !current.Spec.HasMember(principal.userID, principal.subject) {
+			return true
+		}
+	}
+
+	for _, serviceAccountID := range serviceAccountIDs {
+		if !slices.Contains(current.Spec.ServiceAccountIDs, serviceAccountID) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// validateMemberAdditions refuses updates that add members to a group whose
+// roles the caller could not grant themselves.  Adding a member confers the
+// group's roles on them, so it is a grant and must trace to a holder.
+// Member removal confers nothing and is not gated.
+func (c *Client) validateMemberAdditions(ctx context.Context, organizationID ids.OrganizationID, current, required *unikornv1.Group, principals []groupPrincipal) error {
+	if !hasMemberAdditions(current, principals, required.Spec.ServiceAccountIDs) {
+		return nil
+	}
+
+	// The roles checked are the ones the group will carry after the write:
+	// that is what the new member inherits.  Any role being added is already
+	// grant-checked by validateRoleIDs, so this only widens the check to the
+	// roles that were there before.
+	return common.AllowGroupMembershipAddition(ctx, c.client, c.namespace, organizationID, required)
+}
+
+// generate builds the group the write asks for.  current is the stored group on
+// an update, and nil on a create, where every role in the request counts as an
+// addition.  It also returns the principals the membership names, so the
+// addition guard can compare them against the stored group without having to
+// re-derive the pairing between the two membership representations.
+func (c *Client) generate(ctx context.Context, organization *organizations.Meta, in *openapi.GroupWrite, current *unikornv1.Group) (*unikornv1.Group, []groupPrincipal, error) {
+	principals, err := c.populateGroupPrincipals(ctx, organization, in)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var currentRoleIDs []string
@@ -437,7 +519,7 @@ func (c *Client) generate(ctx context.Context, organization *organizations.Meta,
 
 	roleIDs, err := c.validateRoleIDs(ctx, organization.ID, in.Spec.RoleIDs, currentRoleIDs)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// TODO: validate user and service account existence.
@@ -445,18 +527,18 @@ func (c *Client) generate(ctx context.Context, organization *organizations.Meta,
 		ObjectMeta: conversion.NewObjectMetadata(&in.Metadata, organization.Namespace).Get(),
 		Spec: unikornv1.GroupSpec{
 			Tags:              conversion.GenerateTagList(in.Metadata.Tags),
-			UserIDs:           userIDs,
-			Subjects:          subjects,
+			UserIDs:           principalUserIDs(principals),
+			Subjects:          principalSubjects(principals),
 			ServiceAccountIDs: deduplicateStrings(in.Spec.ServiceAccountIDs),
 			RoleIDs:           roleIDs,
 		},
 	}
 
 	if err := common.SetIdentityMetadataOrganizationScope(ctx, &out.ObjectMeta, organization.ID); err != nil {
-		return nil, fmt.Errorf("%w: failed to set identity metadata", err)
+		return nil, nil, fmt.Errorf("%w: failed to set identity metadata", err)
 	}
 
-	return out, nil
+	return out, principals, nil
 }
 
 func (c *Client) Create(ctx context.Context, organizationID ids.OrganizationID, request *openapi.GroupWrite) (*openapi.GroupRead, error) {
@@ -465,7 +547,7 @@ func (c *Client) Create(ctx context.Context, organizationID ids.OrganizationID, 
 		return nil, err
 	}
 
-	resource, err := c.generate(ctx, organization, request, nil)
+	resource, _, err := c.generate(ctx, organization, request, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -492,8 +574,12 @@ func (c *Client) Update(ctx context.Context, organizationID ids.OrganizationID, 
 		return err
 	}
 
-	required, err := c.generate(ctx, organization, request, current)
+	required, principals, err := c.generate(ctx, organization, request, current)
 	if err != nil {
+		return err
+	}
+
+	if err := c.validateMemberAdditions(ctx, organizationID, current, required, principals); err != nil {
 		return err
 	}
 

--- a/pkg/handler/groups/client_test.go
+++ b/pkg/handler/groups/client_test.go
@@ -651,9 +651,11 @@ func TestUpdateGroupRejectsRemovalOfUngrantableRole(t *testing.T) {
 
 // TestUpdateGroupKeepsUngrantableRoleWhenResent is the companion happy path: a caller who
 // cannot grant radar:things may still resend a group's existing radar-id role untouched
-// alongside an unrelated change (here, dropping one of two user members). Neither guard
-// may fire — the role is not being added, so the grant check skips it, and it is not being
-// dropped, so the removal check skips it too.
+// alongside an unrelated change (here, dropping one of two user members). The removal
+// guard must not fire when the role isn't actually being dropped, and member removal is
+// not a grant, so nothing else blocks the write either.  The retained member is the point:
+// it comes back in the request, and re-stating an existing member must not read as an
+// addition.
 func TestUpdateGroupKeepsUngrantableRoleWhenResent(t *testing.T) {
 	t.Parallel()
 
@@ -700,4 +702,279 @@ func (f *groupTestFixture) createGroupWithSpec(t *testing.T, spec unikornv1.Grou
 		Spec: spec,
 	}
 	require.NoError(t, f.client.Create(newContext(t), group))
+}
+
+// TestUpdateGroupAllowsNoOpResendOnLegacyUserIDsGroup covers a group written before
+// Subjects existed: it lists its members in UserIDs only.  Re-sending that membership
+// unchanged derives the Subjects half for the first time, but the members already hold the
+// group's roles through UserIDs, so nothing is conferred and the addition gate must not
+// fire — otherwise a legacy group carrying an ungrantable role has no legal update at all.
+func TestUpdateGroupAllowsNoOpResendOnLegacyUserIDsGroup(t *testing.T) {
+	t.Parallel()
+
+	f := setupGroupTestFixture(t)
+	f.createUserWithOrgMembership(t, userAliceID, userAliceSubject, orguserAliceID)
+	f.createRadarRole(t)
+	f.createGroupWithSpec(t, unikornv1.GroupSpec{
+		RoleIDs: []string{"radar-id"},
+		UserIDs: []string{orguserAliceID},
+	})
+
+	ctx := aclContext(t, openapi.AclEndpoints{
+		{Name: "identity:groups", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	userIDs := openapi.StringList{orguserAliceID}
+	request := makeGroupUpdateRequest(nil, &userIDs)
+	request.Spec.RoleIDs = openapi.StringList{"radar-id"}
+
+	err := f.groupsClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), groupTestID, request)
+	require.NoError(t, err)
+
+	// The write also migrates the group onto the Subjects representation.
+	stored := f.getGroup(t)
+	assert.Equal(t, []string{orguserAliceID}, stored.Spec.UserIDs)
+	require.Len(t, stored.Spec.Subjects, 1)
+	assert.Equal(t, userAliceSubject, stored.Spec.Subjects[0].ID)
+	assert.Equal(t, []string{"radar-id"}, stored.Spec.RoleIDs)
+}
+
+// TestUpdateGroupRejectsGenuineAdditionToLegacyUserIDsGroup is the other half: relaxing the
+// gate for members already present in either representation must not relax it for a member
+// that is in neither.
+func TestUpdateGroupRejectsGenuineAdditionToLegacyUserIDsGroup(t *testing.T) {
+	t.Parallel()
+
+	f := setupGroupTestFixture(t)
+	f.createUserWithOrgMembership(t, userAliceID, userAliceSubject, orguserAliceID)
+	f.createUserWithOrgMembership(t, userBobID, userBobSubject, orguserBobID)
+	f.createRadarRole(t)
+	f.createGroupWithSpec(t, unikornv1.GroupSpec{
+		RoleIDs: []string{"radar-id"},
+		UserIDs: []string{orguserAliceID},
+	})
+
+	ctx := aclContext(t, openapi.AclEndpoints{
+		{Name: "identity:groups", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	userIDs := openapi.StringList{orguserAliceID, orguserBobID}
+	request := makeGroupUpdateRequest(nil, &userIDs)
+	request.Spec.RoleIDs = openapi.StringList{"radar-id"}
+
+	err := f.groupsClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), groupTestID, request)
+	require.Error(t, err)
+	require.True(t, errors.IsForbidden(err))
+	require.Contains(t, err.Error(), "radar")
+
+	stored := f.getGroup(t)
+	assert.Equal(t, []string{orguserAliceID}, stored.Spec.UserIDs)
+}
+
+// TestUpdateGroupAllowsResendWhenStoredSubjectEmailDiffers pins the identity key: three
+// different writers populate a subject's Email with three different values, so a member
+// whose stored Email differs from the derived one is still the same principal and still
+// not an addition.
+func TestUpdateGroupAllowsResendWhenStoredSubjectEmailDiffers(t *testing.T) {
+	t.Parallel()
+
+	f := setupGroupTestFixture(t)
+	f.createUserWithOrgMembership(t, userAliceID, userAliceSubject, orguserAliceID)
+	f.createRadarRole(t)
+	f.createGroupWithSpec(t, unikornv1.GroupSpec{
+		RoleIDs:  []string{"radar-id"},
+		UserIDs:  []string{orguserAliceID},
+		Subjects: []unikornv1.GroupSubject{{ID: userAliceSubject, Issuer: testIssuerURL, Email: "stale-display@example.com"}},
+	})
+
+	ctx := aclContext(t, openapi.AclEndpoints{
+		{Name: "identity:groups", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	subjects := []openapi.Subject{
+		{Id: userAliceSubject, Issuer: testIssuerURL, Email: ptr.To("fresh-display@example.com")},
+	}
+	request := makeGroupUpdateRequest(&subjects, nil)
+	request.Spec.RoleIDs = openapi.StringList{"radar-id"}
+
+	err := f.groupsClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), groupTestID, request)
+	require.NoError(t, err)
+
+	stored := f.getGroup(t)
+	require.Len(t, stored.Spec.Subjects, 1, "the same principal must not be stored twice")
+	assert.Equal(t, userAliceSubject, stored.Spec.Subjects[0].ID)
+	assert.Equal(t, []string{orguserAliceID}, stored.Spec.UserIDs)
+}
+
+// TestUpdateGroupAllowsResendWhenOnlySubjectsStored is the mirror of the legacy case: the
+// group stores the member as a subject only, and a UserIDs-style write names the same
+// principal.  RBAC honours either representation, so completing the missing half confers
+// nothing.
+func TestUpdateGroupAllowsResendWhenOnlySubjectsStored(t *testing.T) {
+	t.Parallel()
+
+	f := setupGroupTestFixture(t)
+	f.createUserWithOrgMembership(t, userAliceID, userAliceSubject, orguserAliceID)
+	f.createRadarRole(t)
+	f.createGroupWithSpec(t, unikornv1.GroupSpec{
+		RoleIDs:  []string{"radar-id"},
+		Subjects: []unikornv1.GroupSubject{{ID: userAliceSubject, Issuer: testIssuerURL, Email: userAliceSubject}},
+	})
+
+	ctx := aclContext(t, openapi.AclEndpoints{
+		{Name: "identity:groups", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	userIDs := openapi.StringList{orguserAliceID}
+	request := makeGroupUpdateRequest(nil, &userIDs)
+	request.Spec.RoleIDs = openapi.StringList{"radar-id"}
+
+	err := f.groupsClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), groupTestID, request)
+	require.NoError(t, err)
+
+	stored := f.getGroup(t)
+	assert.Equal(t, []string{orguserAliceID}, stored.Spec.UserIDs)
+	require.Len(t, stored.Spec.Subjects, 1)
+}
+
+// TestUpdateGroupRejectsExternalSubjectAdditionAlongsideExistingMember guards the relaxation
+// itself: an external subject has no organization user record, so it can only ever be
+// matched in the Subjects list.  Naming it alongside a member who is already present must
+// not let it in unchecked.
+func TestUpdateGroupRejectsExternalSubjectAdditionAlongsideExistingMember(t *testing.T) {
+	t.Parallel()
+
+	f := setupGroupTestFixture(t)
+	f.createUserWithOrgMembership(t, userAliceID, userAliceSubject, orguserAliceID)
+	f.createRadarRole(t)
+	f.createGroupWithSpec(t, unikornv1.GroupSpec{
+		RoleIDs: []string{"radar-id"},
+		UserIDs: []string{orguserAliceID},
+	})
+
+	ctx := aclContext(t, openapi.AclEndpoints{
+		{Name: "identity:groups", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	subjects := []openapi.Subject{
+		{Id: userAliceSubject, Issuer: testIssuerURL, Email: ptr.To(userAliceSubject)},
+		{Id: "mallory@evil.example.com", Issuer: "https://external.example.com"},
+	}
+	request := makeGroupUpdateRequest(&subjects, nil)
+	request.Spec.RoleIDs = openapi.StringList{"radar-id"}
+
+	err := f.groupsClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), groupTestID, request)
+	require.Error(t, err)
+	require.True(t, errors.IsForbidden(err))
+	require.Contains(t, err.Error(), "radar")
+
+	stored := f.getGroup(t)
+	assert.Empty(t, stored.Spec.Subjects)
+}
+
+// TestUpdateGroupRejectsMemberAdditionToUngrantableRoleGroup covers the grant that hides
+// inside a membership edit: the new member inherits every role the group carries, so
+// adding one to a group holding radar-id grants radar:things to them. A caller who cannot
+// grant that role must be refused, and the group left untouched.
+func TestUpdateGroupRejectsMemberAdditionToUngrantableRoleGroup(t *testing.T) {
+	t.Parallel()
+
+	f := setupGroupTestFixture(t)
+	f.createRadarRole(t)
+	f.createGroupWithRoles(t, []string{"radar-id"})
+
+	ctx := aclContext(t, openapi.AclEndpoints{
+		{Name: "identity:groups", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	request := makeGroupUpdateRequest(nil, nil)
+	request.Spec.RoleIDs = openapi.StringList{"radar-id"}
+	request.Spec.ServiceAccountIDs = openapi.StringList{"sa-a"}
+
+	err := f.groupsClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), groupTestID, request)
+	require.Error(t, err)
+	require.True(t, errors.IsForbidden(err))
+	require.Contains(t, err.Error(), "radar")
+
+	stored := f.getGroup(t)
+	assert.Empty(t, stored.Spec.ServiceAccountIDs)
+	assert.Equal(t, []string{"radar-id"}, stored.Spec.RoleIDs)
+}
+
+// TestUpdateGroupRejectsUserAdditionToUngrantableRoleGroup is the human-member counterpart:
+// the gate has to cover the UserIDs and Subjects representations, not just service accounts.
+func TestUpdateGroupRejectsUserAdditionToUngrantableRoleGroup(t *testing.T) {
+	t.Parallel()
+
+	f := setupGroupTestFixture(t)
+	f.createUserWithOrgMembership(t, userAliceID, userAliceSubject, orguserAliceID)
+	f.createRadarRole(t)
+	f.createGroupWithRoles(t, []string{"radar-id"})
+
+	ctx := aclContext(t, openapi.AclEndpoints{
+		{Name: "identity:groups", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	userIDs := openapi.StringList{orguserAliceID}
+	request := makeGroupUpdateRequest(nil, &userIDs)
+	request.Spec.RoleIDs = openapi.StringList{"radar-id"}
+
+	err := f.groupsClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), groupTestID, request)
+	require.Error(t, err)
+	require.True(t, errors.IsForbidden(err))
+	require.Contains(t, err.Error(), "radar")
+
+	stored := f.getGroup(t)
+	assert.Empty(t, stored.Spec.UserIDs)
+	assert.Empty(t, stored.Spec.Subjects)
+}
+
+// TestUpdateGroupAllowsMemberAdditionToRolelessGroup shows the gate is scoped to what the
+// group actually confers: a group with no roles grants nothing, so anyone who may edit the
+// group may add members to it.
+func TestUpdateGroupAllowsMemberAdditionToRolelessGroup(t *testing.T) {
+	t.Parallel()
+
+	f := setupGroupTestFixture(t)
+	f.createGroupWithRoles(t, nil)
+
+	ctx := aclContext(t, openapi.AclEndpoints{
+		{Name: "identity:groups", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	request := makeGroupUpdateRequest(nil, nil)
+	request.Spec.ServiceAccountIDs = openapi.StringList{"sa-a"}
+
+	err := f.groupsClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), groupTestID, request)
+	require.NoError(t, err)
+
+	stored := f.getGroup(t)
+	assert.Equal(t, []string{"sa-a"}, stored.Spec.ServiceAccountIDs)
+}
+
+// TestUpdateGroupAllowsMemberAdditionByRoleHolder is the other half of the gate: the grant
+// traces to a holder, so a caller who does hold radar:things may add members to the group
+// that confers it.
+func TestUpdateGroupAllowsMemberAdditionByRoleHolder(t *testing.T) {
+	t.Parallel()
+
+	f := setupGroupTestFixture(t)
+	f.createRadarRole(t)
+	f.createGroupWithRoles(t, []string{"radar-id"})
+
+	ctx := aclContext(t, openapi.AclEndpoints{
+		{Name: "identity:groups", Operations: openapi.AclOperations{openapi.Update}},
+		{Name: "radar:things", Operations: openapi.AclOperations{openapi.Read}},
+	})
+
+	request := makeGroupUpdateRequest(nil, nil)
+	request.Spec.RoleIDs = openapi.StringList{"radar-id"}
+	request.Spec.ServiceAccountIDs = openapi.StringList{"sa-a"}
+
+	err := f.groupsClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), groupTestID, request)
+	require.NoError(t, err)
+
+	stored := f.getGroup(t)
+	assert.Equal(t, []string{"radar-id"}, stored.Spec.RoleIDs)
+	assert.Equal(t, []string{"sa-a"}, stored.Spec.ServiceAccountIDs)
 }

--- a/test/api/k8s.go
+++ b/test/api/k8s.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
 
@@ -74,6 +75,31 @@ func OrganizationNamespace(ctx context.Context, cli client.Client, identityNames
 	}
 
 	return org.Status.Namespace, nil
+}
+
+// AddGroupMember writes a user onto a Group custom resource directly.  The
+// groups API refuses to add a member to a group carrying a role the caller
+// cannot grant, because joining the group would confer that role, so a spec
+// that needs to start from "the member is already there" has to seed it out of
+// band.
+func AddGroupMember(ctx context.Context, cli client.Client, namespace, groupID, userID string) error {
+	group := &unikornv1.Group{}
+
+	if err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: groupID}, group); err != nil {
+		return fmt.Errorf("getting group %s: %w", groupID, err)
+	}
+
+	if slices.Contains(group.Spec.UserIDs, userID) {
+		return nil
+	}
+
+	group.Spec.UserIDs = append(group.Spec.UserIDs, userID)
+
+	if err := cli.Update(ctx, group); err != nil {
+		return fmt.Errorf("adding member %s to group %s: %w", userID, groupID, err)
+	}
+
+	return nil
 }
 
 // InstallFixture creates any custom resource and returns a cleanup function

--- a/test/api/suites/group_membership_test.go
+++ b/test/api/suites/group_membership_test.go
@@ -31,6 +31,7 @@ import (
 	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
 	coreopenapi "github.com/unikorn-cloud/core/pkg/openapi"
 	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
 	"github.com/unikorn-cloud/identity/test/api"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,38 +40,82 @@ import (
 )
 
 // waitForFixtureVisibility blocks until the API server has observed both
-// fixtures.  The server reads roles and groups through informer caches, so a
-// spec that calls the API straight after creating the custom resources can see
-// a 404 on the group, or have its write rejected as naming a role that does
-// not exist, until those caches catch up.  Every spec here must pass through
-// this before its first API call.
+// fixtures.  The server reads roles and groups through one informer cache, so
+// a spec that calls the API straight after creating the custom resources can
+// see a 404 on the group, or have its write rejected as naming a role that
+// does not exist, until that cache catches up.  Every spec here must pass
+// through this before its first API call.
 //
-// Group visibility is checked with a read.  Role visibility needs a write:
-// the role is deliberately one nobody can grant, so it is filtered out of the
-// role list and there is nothing to read it back from.  Re-sending the group's
-// own role list is the probe, because it is refused while the role is missing
-// from the cache and accepted once it lands, and it changes nothing either
-// way.
-func waitForFixtureVisibility(roleID, groupID, groupName string) {
+// Waiting on the role matters beyond the "does not exist" rejection: the guards
+// that resolve a role ID treat a NotFound as a dangling reference, which the
+// removal guard waves through and the membership guard refuses with a different
+// message.  Both would make a spec assert the wrong thing.  An ungrantable role
+// is still listed (flagged not grantable), so the list is a sound probe for it.
+func waitForFixtureVisibility(roleID, groupID string) {
 	GinkgoHelper()
 
 	Eventually(func(g Gomega) {
+		roles, err := client.ListRoles(ctx, config.OrgID)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		roleIDs := make([]string, 0, len(roles))
+		for _, role := range roles {
+			roleIDs = append(roleIDs, role.Metadata.Id)
+		}
+
+		g.Expect(roleIDs).To(ContainElement(roleID),
+			"the role fixture is not visible to the API yet")
+
 		group, err := client.GetGroup(ctx, config.OrgID, groupID)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(group.Spec.RoleIDs).To(ContainElement(roleID),
 			"the group fixture is not visible to the API yet")
 	}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
+}
 
-	payload := api.NewGroupPayload().
-		WithName(groupName).
-		WithRoleIDs([]string{roleID}).
-		Build()
+// groupUserIDs flattens the optional user ID list on a group read so specs can
+// assert membership without unwrapping the pointer every time.
+func groupUserIDs(group *identityopenapi.GroupRead) []string {
+	GinkgoHelper()
+
+	if group.Spec.UserIDs == nil {
+		return nil
+	}
+
+	return *group.Spec.UserIDs
+}
+
+// seedGroupMember puts a user into the group out of band and waits for the API
+// to observe it.  Adding a member through the API is a grant of the group's
+// roles and is refused here by design, so removal specs have to start from
+// state the API would not create.
+func seedGroupMember(kube kubeclient.Client, orgNamespace, groupID, userID string) {
+	GinkgoHelper()
+
+	Expect(api.AddGroupMember(ctx, kube, orgNamespace, groupID, userID)).To(Succeed())
 
 	Eventually(func(g Gomega) {
-		response, err := client.UpdateGroupWithResponse(ctx, config.OrgID, groupID, payload)
+		group, err := client.GetGroup(ctx, config.OrgID, groupID)
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(response.StatusCode()).To(Equal(http.StatusOK),
-			"the role fixture is not visible to the API yet: %s", string(response.Body))
+		g.Expect(groupUserIDs(group)).To(ContainElement(userID),
+			"the seeded membership is not visible to the API yet")
+	}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
+}
+
+// expectGroupEmptiedOfMembers waits for the API to report the group with no
+// members and its role intact.  Reads go through the server's informer cache,
+// which can still be serving the pre-write state for a moment after a write
+// the API server has already accepted.
+func expectGroupEmptiedOfMembers(groupID, roleID string) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		group, err := client.GetGroup(ctx, config.OrgID, groupID)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(groupUserIDs(group)).To(BeEmpty(),
+			"the member the admin removed must be gone")
+		g.Expect(group.Spec.RoleIDs).To(ContainElement(roleID),
+			"the ungrantable role must survive the round-trip")
 	}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 }
 
@@ -88,7 +133,7 @@ func readGroupResource(kube kubeclient.Client, orgNamespace, groupID string) *un
 	return group
 }
 
-var _ = Describe("Group role changes with ungrantable roles", func() {
+var _ = Describe("Group role and membership changes with ungrantable roles", func() {
 	Context("When a group carries a role the admin cannot grant", func() {
 		// The role is installed as a custom resource because roles have no
 		// write API, and the group has to be installed the same way because
@@ -108,6 +153,8 @@ var _ = Describe("Group role changes with ungrantable roles", func() {
 			BeforeEach(func() {
 				Expect(config.Namespace).NotTo(BeEmpty(),
 					"IDENTITY_NAMESPACE must be set by integration fixtures")
+				Expect(config.UserID).NotTo(BeEmpty(),
+					"TEST_USER_ID must be set by integration fixtures")
 
 				var err error
 
@@ -173,7 +220,7 @@ var _ = Describe("Group role changes with ungrantable roles", func() {
 				GinkgoWriter.Printf("Installed role %s (%s) and group %s (%s)\n",
 					roleName, roleID, groupName, groupID)
 
-				waitForFixtureVisibility(roleID, groupID, groupName)
+				waitForFixtureVisibility(roleID, groupID)
 			})
 
 			It("should accept an edit that resends the existing role list unchanged", func() {
@@ -211,13 +258,159 @@ var _ = Describe("Group role changes with ungrantable roles", func() {
 				Expect(response.JSON403.ErrorDescription).To(ContainSubstring(roleName),
 					"the error must give the role's display name, not only its ID")
 				Expect(response.JSON403.ErrorDescription).To(ContainSubstring("cannot be removed from the group"),
-					"the removal guard must be the one that refused, not the role grant guard")
+					"the removal guard must be the one that refused, not the membership or role grant guard")
 
 				stored := readGroupResource(kube, orgNamespace, groupID)
 				Expect(stored.Spec.RoleIDs).To(ContainElement(roleID),
 					"a refused update must leave the group untouched")
 
 				GinkgoWriter.Printf("Refused role removal: %s\n", response.JSON403.ErrorDescription)
+			})
+
+			It("should refuse a member addition, naming the role", func() {
+				payload := api.NewGroupPayload().
+					WithName(groupName).
+					WithRoleIDs([]string{roleID}).
+					WithUserIDs([]string{config.UserID}).
+					Build()
+
+				response, err := client.UpdateGroupWithResponse(ctx, config.OrgID, groupID, payload)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response.StatusCode()).To(Equal(http.StatusForbidden))
+				Expect(response.JSON403).NotTo(BeNil(),
+					"a refusal must come back as a typed forbidden response")
+				Expect(response.JSON403.Error).To(Equal(coreopenapi.Forbidden))
+				Expect(response.JSON403.ErrorDescription).To(ContainSubstring(roleID),
+					"the error must name the role that blocked the addition")
+				Expect(response.JSON403.ErrorDescription).To(ContainSubstring(roleName),
+					"the error must give the role's display name, not only its ID")
+				Expect(response.JSON403.ErrorDescription).To(ContainSubstring("members cannot be added to the group"),
+					"the membership guard must be the one that refused, not the role grant or removal guard")
+
+				stored := readGroupResource(kube, orgNamespace, groupID)
+				Expect(stored.Spec.UserIDs).To(BeEmpty(),
+					"a refused update must leave the group untouched")
+				Expect(stored.Spec.Subjects).To(BeEmpty())
+				Expect(stored.Spec.RoleIDs).To(ContainElement(roleID))
+
+				GinkgoWriter.Printf("Refused member addition: %s\n", response.JSON403.ErrorDescription)
+			})
+
+			It("should allow a member removal, and the role survives", func() {
+				seedGroupMember(kube, orgNamespace, groupID, config.UserID)
+
+				payload := api.NewGroupPayload().
+					WithName(groupName).
+					WithRoleIDs([]string{roleID}).
+					WithUserIDs([]string{}).
+					Build()
+
+				Expect(client.UpdateGroup(ctx, config.OrgID, groupID, payload)).To(Succeed(),
+					"removing a member confers nothing, so it is not gated on the group's roles")
+
+				expectGroupEmptiedOfMembers(groupID, roleID)
+
+				updated, err := client.GetGroup(ctx, config.OrgID, groupID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updated.Metadata.Id).To(Equal(groupID))
+				Expect(updated.Metadata.Name).To(Equal(groupName))
+			})
+		})
+	})
+
+	// Without this the whole suite passes with the membership guard replaced by an
+	// unconditional refusal: every other group in it carries either no role or an
+	// ungrantable one, so no other spec can tell "refused because the role is
+	// ungrantable" apart from "refused always".
+	Context("When a group carries a role the admin can grant", func() {
+		Describe("Given a role scoped to an endpoint the administrator holds", func() {
+			var (
+				roleID       string
+				groupID      string
+				groupName    string
+				kube         kubeclient.Client
+				orgNamespace string
+			)
+
+			BeforeEach(func() {
+				Expect(config.Namespace).NotTo(BeEmpty(),
+					"IDENTITY_NAMESPACE must be set by integration fixtures")
+				Expect(config.UserID).NotTo(BeEmpty(),
+					"TEST_USER_ID must be set by integration fixtures")
+
+				var err error
+
+				kube, err = api.NewKubernetesClient()
+				Expect(err).NotTo(HaveOccurred())
+
+				roleID = uuid.NewString()
+
+				// identity:groups read is part of the organization
+				// administrator's own permission set, so the admin holds
+				// everything this role confers and may grant it.
+				role := &unikornv1.Role{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      roleID,
+						Namespace: config.Namespace,
+						Labels: map[string]string{
+							coreconstants.NameLabel: "grantable-fixture-" + roleID[:8],
+						},
+					},
+					Spec: unikornv1.RoleSpec{
+						Scopes: unikornv1.RoleScopes{
+							Organization: []unikornv1.RoleScope{{
+								Name:       "identity:groups",
+								Operations: []unikornv1.Operation{unikornv1.Read},
+							}},
+						},
+					},
+				}
+
+				cleanupRole, err := api.InstallFixture(ctx, kube, role)
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(cleanupRole)
+
+				orgNamespace, err = api.OrganizationNamespace(ctx, kube, config.Namespace, config.OrgID)
+				Expect(err).NotTo(HaveOccurred())
+
+				groupID = uuid.NewString()
+				groupName = "grantable-group-" + groupID[:8]
+
+				group := &unikornv1.Group{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      groupID,
+						Namespace: orgNamespace,
+						Labels: map[string]string{
+							coreconstants.NameLabel:         groupName,
+							coreconstants.OrganizationLabel: config.OrgID,
+						},
+					},
+					Spec: unikornv1.GroupSpec{
+						RoleIDs: []string{roleID},
+					},
+				}
+
+				cleanupGroup, err := api.InstallFixture(ctx, kube, group)
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(cleanupGroup)
+
+				waitForFixtureVisibility(roleID, groupID)
+			})
+
+			It("should allow a member addition, because the grant traces to a holder", func() {
+				payload := api.NewGroupPayload().
+					WithName(groupName).
+					WithRoleIDs([]string{roleID}).
+					WithUserIDs([]string{config.UserID}).
+					Build()
+
+				Expect(client.UpdateGroup(ctx, config.OrgID, groupID, payload)).To(Succeed(),
+					"the caller holds every permission the group's role confers, so adding a member is a grant it may make")
+
+				stored := readGroupResource(kube, orgNamespace, groupID)
+				Expect(stored.Spec.UserIDs).To(ContainElement(config.UserID),
+					"the member the admin added must be on the group")
+				Expect(stored.Spec.RoleIDs).To(ContainElement(roleID))
 			})
 		})
 	})


### PR DESCRIPTION
Third of four PRs splitting the group-permission work ([ID-368](https://linear.app/nscale-workspace/issue/ID-368/clarify-permission-management-for-group-membership)). **Stacked on #528** — review #527 and #528 first; the base retargets as each merges.

## The rule this implements

A group carries roles, and every member of the group inherits them. Adding a member therefore *confers* those roles, so it is a grant like any other and must trace to a holder: the caller has to be able to grant every role the group carries. Removals, principal deletion and group DELETE take authority away rather than handing it out, and stay ungated.

This is the maintainer ruling from review — no actor confers authority on itself, and every grant traces to a prior holder.

## Change

- **`PUT /groups/{id}` gates member additions** on the group's role list. A refusal names the blocking role.
- **Members are compared by principal identity, not by struct equality.** A subject is `(Issuer, ID)`; `Email` is display data that the writers of these records populate from different sources, so it takes no part in identity. Presence in *either* the legacy `UserIDs` list or `Subjects` counts as already-a-member, because RBAC resolves membership through both — completing the other half confers nothing and is not a grant. Without this, a group still using the legacy representation reads every write as adding its existing members, and a no-op re-send or a member *removal* would be refused by the addition gate.
- **Two exemptions that confer nothing:** a group with no roles, and a role reference that no longer resolves — the latter refuses the addition rather than skipping it, because role IDs are derived from the role name and a role that is deleted and re-applied re-binds to every group still referencing it.
- **Create needs no membership check.** Every role on a new group is an addition and is already grant-checked, so the creator holds everything the group confers.

Scope: this PR gates the groups path only. `PUT /users/{id}` and service-account create/update remain ungated here, exactly as on `main`; PR 4 closes those and is where the "same rule everywhere" claim is earned.

## Compatibility

No CRD schema changes and no migration — `group_helpers.go` adds methods to existing types, so the generated CRDs and deepcopy are untouched.

One behaviour change worth a release note: **on deploy, a group carrying a role its editors cannot grant becomes frozen for member additions.** Removals, renames and role-list re-sends continue to work. The 403 names the blocking role. The unblock for an affected team is a holder of that role granting it to whoever administers the group.

There is also an interpretation change on unchanged data: a principal recorded only in the deprecated `UserIDs` list now counts as already a member of that group. Nothing stored is rewritten.

## Testing

- Unit: the gate proved non-vacuous in both directions — forcing the guard off fails the four rejection tests, forcing it on fails the four allow tests. Cases cover legacy `UserIDs`-only groups (no-op re-send allowed, genuine addition refused), a stored subject whose email differs from the derived one, subjects-only storage, an external subject riding in alongside an existing member, a roleless group, and an addition by a caller who does hold the role.
- Integration, against a live deployment: addition refused naming the role; removal allowed with the role surviving; and a positive control where the role IS grantable and the addition succeeds — without that control, a guard that refused everything would still look green.
- Full suite measured against a `main` baseline on the same cluster. The delta is entirely the `USER_AUTH_TOKEN` fixture, which is broken on that cluster independently of any branch; all five new specs pass inside the full run.
