### PR TITLE
feat(handler): gate membership additions on the user and service-account paths (ID-368, ID-367)

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -104,6 +104,7 @@ This is most visible in:
 
 - [handler](./handler/README.md)
 - [handler/users](./handler/users/README.md)
+- [handler/serviceaccounts](./handler/serviceaccounts/README.md)
 - [handler/groups](./handler/groups/README.md)
 - [handler/quotas](./handler/quotas/README.md)
 - [handler/allocations](./handler/allocations/README.md)

--- a/pkg/apis/unikorn/v1alpha1/group_helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/group_helpers.go
@@ -50,10 +50,42 @@ func (s *GroupSpec) HasSubject(subject GroupSubject) bool {
 // An empty organization user ID matches nothing.  Membership lists are not
 // validated against real records, so a junk empty entry must not stand in for
 // a principal that has no organization user record yet.
+//
+// Subjects are matched issuer-qualified, so this is the predicate for writes
+// that carry a client-authored subject record: a record at a new issuer is a
+// new stored fact and callers may treat it as an addition.  A gate asking
+// whether the group's roles are already conferred must use HasMemberByID
+// instead.
 func (s *GroupSpec) HasMember(organizationUserID string, subject GroupSubject) bool {
 	if organizationUserID != "" && slices.Contains(s.UserIDs, organizationUserID) {
 		return true
 	}
 
 	return s.HasSubject(subject)
+}
+
+// HasMemberByID reports whether the group already confers its roles on the
+// principal, matching subjects by ID alone.  This mirrors how RBAC actually
+// resolves membership: its subject matching deliberately ignores the recorded
+// issuer (see groupSubjectFilter in pkg/rbac), because subject records
+// written before issuers were recorded carry an empty one and must still
+// resolve.  A grant gate has to match the same way — a membership stored as a
+// legacy record already confers the roles, so a write that re-states it
+// confers nothing and must not read as an addition and be refused.  If RBAC
+// matching ever becomes issuer-qualified, this must move with it.
+//
+// An empty subject ID matches nothing, for the same reason as the empty
+// organization user ID above.
+func (s *GroupSpec) HasMemberByID(organizationUserID, subjectID string) bool {
+	if organizationUserID != "" && slices.Contains(s.UserIDs, organizationUserID) {
+		return true
+	}
+
+	if subjectID == "" {
+		return false
+	}
+
+	return slices.ContainsFunc(s.Subjects, func(subject GroupSubject) bool {
+		return subject.ID == subjectID
+	})
 }

--- a/pkg/handler/README.md
+++ b/pkg/handler/README.md
@@ -163,6 +163,12 @@ Across the package, the common limitations are:
 
 This is a systemic property of the storage model, not just an isolated flaw in one client.
 
+Authorization is deliberately kept out of that gap on the paths that write group membership.
+`users`, `serviceaccounts` and `groups` settle every grant a request makes before the request
+writes anything, so a refusal applies none of it. What can still leave a partial write is
+infrastructure failure partway through, which is the limitation above and not an authorization
+one. See [`users`](./users/README.md) and [`serviceaccounts`](./serviceaccounts/README.md).
+
 ## Package Map
 
 - [`organizations`](./organizations/README.md): tenancy-root visibility and current `v1`

--- a/pkg/handler/common/membership.go
+++ b/pkg/handler/common/membership.go
@@ -19,6 +19,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	servererrors "github.com/unikorn-cloud/core/pkg/server/errors"
 	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
@@ -29,6 +30,28 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// ValidateGroupsExist returns an error naming the first requested group that
+// is not in the organization's group list.
+//
+// Membership reconciliation walks the groups that exist and asks of each
+// whether the request names it, so a requested ID matching nothing matches no
+// branch: without this the principal is neither joined to it nor told, and the
+// response reports only the memberships that did apply.  Note the list is read
+// through an informer cache, so a group created moments earlier may not be in
+// it yet; refusing is still the better answer, because the alternative is a
+// success whose body silently contradicts the request.
+func ValidateGroupsExist(groupIDs []string, groups *unikornv1.GroupList) error {
+	for _, groupID := range groupIDs {
+		if !slices.ContainsFunc(groups.Items, func(group unikornv1.Group) bool {
+			return group.Name == groupID
+		}) {
+			return servererrors.OAuth2InvalidRequest(fmt.Sprintf("group %s does not exist in this organization", groupID))
+		}
+	}
+
+	return nil
+}
 
 // AllowGroupMembershipAddition returns nil if the calling principal may add
 // a member to the given group.  Adding a member confers the group's roles,

--- a/pkg/handler/common/membership_test.go
+++ b/pkg/handler/common/membership_test.go
@@ -89,6 +89,53 @@ func membershipGroup(roleIDs ...string) *unikornv1.Group {
 	return &unikornv1.Group{Spec: unikornv1.GroupSpec{RoleIDs: roleIDs}}
 }
 
+// membershipGroupList builds the organization's group list as a reconciler reads it.
+func membershipGroupList(names ...string) *unikornv1.GroupList {
+	list := &unikornv1.GroupList{}
+
+	for _, name := range names {
+		list.Items = append(list.Items, unikornv1.Group{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		})
+	}
+
+	return list
+}
+
+func TestValidateGroupsExistAcceptsKnownGroups(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, common.ValidateGroupsExist([]string{"group-a", "group-b"}, membershipGroupList("group-a", "group-b", "group-c")))
+}
+
+func TestValidateGroupsExistAcceptsAnEmptyRequest(t *testing.T) {
+	t.Parallel()
+
+	// Leaving every group is a legal write and names nothing to check.
+	require.NoError(t, common.ValidateGroupsExist(nil, membershipGroupList("group-a")))
+}
+
+func TestValidateGroupsExistRefusesUnknownGroup(t *testing.T) {
+	t.Parallel()
+
+	// Reconciliation matches the request against the groups that exist, so an
+	// ID matching none of them would otherwise be dropped from the write
+	// without the caller being told.
+	err := common.ValidateGroupsExist([]string{"group-a", "no-such-group"}, membershipGroupList("group-a"))
+	require.Error(t, err)
+	require.True(t, servererrors.IsBadRequest(err))
+	require.Contains(t, err.Error(), "no-such-group", "the error must name the group that does not exist")
+}
+
+func TestValidateGroupsExistRefusesAgainstAnEmptyOrganization(t *testing.T) {
+	t.Parallel()
+
+	err := common.ValidateGroupsExist([]string{"group-a"}, membershipGroupList())
+	require.Error(t, err)
+	require.True(t, servererrors.IsBadRequest(err))
+	require.Contains(t, err.Error(), "group-a")
+}
+
 func TestAllowGroupMembershipAdditionRefusesUngrantableRole(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/handler/groups/README.md
+++ b/pkg/handler/groups/README.md
@@ -96,6 +96,15 @@ write is not an addition. That matters for groups written before `Subjects` exis
 their membership fills in the missing half and must not be read as a grant, or such a group has no
 legal update at all.
 
+The issuer's part in that comparison differs by entry point, deliberately. This client compares
+the request's subjects issuer-qualified: they are client-authored records, and a record at a new
+issuer is a new stored fact the caller is asking to add. The users path derives its subject
+server-side instead, and its already-a-member test matches by ID alone
+(`GroupSpec.HasMemberByID`), mirroring how `pkg/rbac` resolves membership — records written before
+issuers existed carry an empty one and still confer the group's roles, so re-stating such a
+membership is not an addition. See the matching notes in
+[`pkg/handler/users`](../users/README.md).
+
 A group with no roles confers nothing, so membership in it is not a grant and nothing blocks the
 addition. A role reference that no longer resolves is the opposite case and does block it — see
 Decommissioning A Service's Roles below for why that direction is not symmetric with removal.

--- a/pkg/handler/groups/README.md
+++ b/pkg/handler/groups/README.md
@@ -82,10 +82,10 @@ So group writes are also authority-delegation checks, for both grants and revoca
 ### Membership Guard Rails
 
 Adding a member to a group hands that member every role the group carries, so it is a grant like
-any other and has to trace to a holder. A `PUT /groups/{id}` that puts a user, subject, or service
-account on a group is refused unless the caller could grant each of the group's roles themselves.
-The roles checked are the ones the group carries after the write, since that is what the new member
-inherits. A refusal names the role.
+any other and has to trace to a holder. A write that puts a user, subject, or service account on a
+group is refused unless the caller could grant each of the group's roles themselves. The roles
+checked are the ones the group carries after the write, since that is what the new member inherits.
+A refusal names the role.
 
 Membership is compared by principal identity, not by stored record. A subject identifies a
 principal by `(issuer, id)`; its `email` is display data that different writers populate from
@@ -103,10 +103,13 @@ Decommissioning A Service's Roles below for why that direction is not symmetric 
 Create needs no separate membership check. Every role on a new group counts as an addition and is
 already grant-checked, so the creator holds everything the new group confers.
 
-This gate sits on the groups path. [`pkg/handler/users`](../users/README.md) and
-[`pkg/handler/serviceaccounts`](../serviceaccounts/README.md) also write group membership, by
-reconciling a requested `groupIDs` list into the groups that name the principal, and those paths do
-not run this check.
+The gate applies wherever membership is written, not only through this client:
+[`pkg/handler/users`](../users/README.md) and
+[`pkg/handler/serviceaccounts`](../serviceaccounts/README.md) reconcile a requested `groupIDs` list
+into group membership and run the same check, from `pkg/handler/common`, on the branch that adds.
+Those two paths settle every grant in a request before it writes anything, so a refusal there
+applies none of the write; this client checks after building the required group but before the
+single patch that stores it, which comes to the same thing.
 
 Removals are ungated. Taking a member out of a group takes authority away rather than handing it
 out, so a caller who could not add a member to a group may still remove one. Group DELETE is an
@@ -144,7 +147,8 @@ an addition, so only the removal side is safe to skip. Refusing additions also m
 
 A side effect worth naming: because ACL construction fails closed, adding someone to a
 dangling-reference group breaks their whole organization ACL, not just their access to that group.
-Refusing the addition closes that off as well, at least on the groups path.
+Anyone holding `identity:users` update could do that to anyone. Refusing the addition closes that
+off as well, on every path that writes membership.
 
 The trap is the window before that. While the `Role` CR still exists, removing it from a group is a
 guarded revocation like any other — the caller must hold its permissions. That is unremarkable for a
@@ -161,8 +165,8 @@ the roles it carries, so members can be pulled out of a group carrying a live un
 any point in the sequence, and the group can then be deleted outright — group DELETE is unguarded.
 Deleting the group takes the members with it, so it is only the right move when the group exists to
 carry the retiring service's roles and nothing else. What does not work while the `Role` CR is still
-installed is putting anyone *into* such a group through `PUT /groups/{id}`: a decommissioning
-service's group cannot take on new members that way once nobody holds its permissions.
+installed is putting anyone *into* such a group, by any route: a decommissioning service's group
+cannot take on new members once nobody holds its permissions.
 
 ### Project Reference Cleanup
 
@@ -181,11 +185,11 @@ would drift.
   group are not re-checked on subsequent writes
 - callers may only drop a role from a group on update if they are allowed to grant that role,
   unless the role no longer resolves or is protected
-- adding a member to a group through this client is a grant of that group's roles, so it is allowed
-  only where the caller could grant every role the group carries
+- adding a member to a group is a grant of that group's roles, wherever the membership is written,
+  so it is allowed only where the caller could grant every role the group carries
 - a principal is the same member in either representation, identified by `(issuer, id)`; a subject's
   `email` is display data and takes no part in that comparison
-- removing a member from a group confers nothing and is not gated
+- removing a member from a group, and deleting a member principal, confer nothing and are not gated
 - group DELETE revokes without a role check, by design
 - internal compatibility between `UserIDs` and `Subjects` should be maintained where possible
 - group membership and role/service-account ID lists are normalized to first-occurrence unique values
@@ -195,14 +199,14 @@ would drift.
 
 - A group seeded with a role from a broader-authority admin is frozen for everyone who cannot grant
   that role: they can still rename it, resend its role list, remove members and delete it outright,
-  but they cannot drop the role and cannot add a member through this client. That is the intended
-  trade — dropping a role is a revocation, and adding a member is a grant, and the caller has to be
-  entitled to make either — and the way out is to give the editor the role's permissions, not to
-  relax the check.
-- The membership gate covers `PUT /groups/{id}` only. The same membership can be written through
-  `pkg/handler/users` and `pkg/handler/serviceaccounts`, which reconcile a requested `groupIDs` list
-  without this check, so a caller holding `identity:users` or `identity:serviceaccounts` write can
-  still put a principal into a group whose roles it cannot grant.
+  but they cannot drop the role and cannot add a member — through this client or any other. That is
+  the intended trade — dropping a role is a revocation, and adding a member is a grant, and the
+  caller has to be entitled to make either — and the way out is to give the editor the role's
+  permissions, not to relax the check.
+- The gate binds authorization, not write atomicity. A refusal applies nothing, on every path. An
+  infrastructure failure partway through a request that patches several groups can still leave some
+  of them applied; see the TODO in [`pkg/handler/users`](../users/README.md) and the create caveat
+  in [`pkg/handler/serviceaccounts`](../serviceaccounts/README.md).
 - The package is partly a migration bridge because it must support both deprecated `UserIDs` and
   forward-looking `Subjects`.
 - Groups may include external subjects that do not resolve to local `User` objects, so not every

--- a/pkg/handler/serviceaccounts/README.md
+++ b/pkg/handler/serviceaccounts/README.md
@@ -33,6 +33,37 @@ authority of the service account through their `RoleIDs`.
 So this client participates in the same local delegation model as users, but without the global
 identity split.
 
+### Membership Additions Are Grants
+
+Putting a service account into a group hands it every role that group carries, so it is a grant and
+is checked as one: the add branch of the reconciliation refuses unless the caller could grant each
+of the group's roles in that organization. The refusal names the role. This is the same rule
+[`pkg/handler/groups`](../groups/README.md) applies to membership written through the group itself
+— the check lives in `pkg/handler/common` so both entry points share it, and a service-account
+write cannot be used to sidestep the group write's guard.
+
+This is the path that matters most for authority a downgraded caller can keep hold of. A group
+membership on a user takes effect through a session; a group membership on a service account rides
+a token that lives for up to 90 days and that the account can keep renewing itself.
+
+Re-sending a group the account already belongs to confers nothing new and passes. Removing it from
+a group takes authority away rather than handing it out, so the remove branch is unguarded, and
+delete is exempt for the same reason: it reconciles against an empty group list, so it only ever
+unlinks, and an account must remain deletable even when it sits in a group nobody can grant the
+roles of.
+
+Reconciliation is validate-then-apply: every group the account would newly join is grant-checked
+before the first group is patched, so a write that joins one group the caller may grant and another
+they may not is refused whole rather than applying the permitted half.
+
+That ordering is a guarantee about *refusals*, not about failures. What it buys is that no
+authorization decision is ever discovered after a write has landed. It does not make the write
+atomic — see the caveat on partial application below.
+
+A group ID the organization does not have is refused rather than dropped. Reconciliation matches
+the request against the groups that exist, so an ID matching nothing would otherwise leave the
+caller with a success whose body does not mention the group it asked for.
+
 ### Token Issuance And Rotation
 
 This is the main behavioural difference from the users client.
@@ -52,6 +83,12 @@ That makes this package both an identity-binding client and a credential-lifecyc
 
 - service accounts are organization-bound actors
 - service-account authority is still mediated through groups and roles
+- adding a service account to a group is a grant of that group's roles, so it is allowed only where
+  the caller could grant every role the group carries; removals and account deletion are not gated
+- a requested group that does not exist in the organization is an error, not a silently dropped
+  part of the write
+- a refused membership addition applies none of the write's other additions, and on create issues
+  no token
 - create returns freshly issued credentials
 - ordinary update preserves the current token
 - rotate replaces the token and invalidates the old one
@@ -61,6 +98,27 @@ That makes this package both an identity-binding client and a credential-lifecyc
 
 - Like `pkg/handler/users`, this package performs best-effort multi-object consistency across
   service accounts and groups on top of Kubernetes storage rather than an ACID backing store.
+- **Create can strand a credentialled account.** The grants are settled first and the account is
+  written second, but the group patches come third, and nothing rolls the account back if one of
+  them fails. Two ways in: an infrastructure failure part-way through the loop, or a concurrent
+  privileged writer changing a group between the pre-pass reading it and the reconciler patching
+  it. The second is *detected* rather than silently allowed — the patch carries an optimistic lock
+  against the version the pre-pass read, so a group modified underneath the request conflicts
+  instead of quietly conferring a role nobody authorised — but detection still arrives after any
+  earlier group in the same request has been patched. Either way the caller sees an error while a
+  service account exists, holds a freshly issued token, and sits in some prefix of the groups it
+  asked for.
+
+  There is deliberately no rollback attempt: unpicking a partial write needs the same multi-object
+  atomicity the storage layer does not offer, and a failed rollback leaves a worse state than the
+  one it was trying to repair.
+
+  What makes this worth knowing rather than merely untidy is that a stranded account is not inert.
+  `Rotate` is gated on `identity:serviceaccounts` update or on the account rotating *itself*, and
+  neither path re-checks group membership, so the account can keep renewing its own credential
+  indefinitely and any update holder can re-token it. Callers that see create fail should treat the
+  account as possibly created and delete by name; operators auditing this should look for service
+  accounts whose group membership does not match anything a caller would have asked for.
 - The current access token is stored on the service-account resource and returned on create/rotate,
   so token-handling mistakes have more impact here than in most handler clients.
 - The package is intentionally similar to the users client; the main value in documenting it is the

--- a/pkg/handler/serviceaccounts/client.go
+++ b/pkg/handler/serviceaccounts/client.go
@@ -202,8 +202,51 @@ func (c *Client) listGroups(ctx context.Context, organization *organizations.Met
 	return result, nil
 }
 
+// validateGroupAdditions checks every group the service account would newly
+// join before any of them is written.  Joining a group confers its roles, so
+// each is a grant the caller has to be able to make; running the whole set up
+// front keeps a refusal from landing after an earlier group has already been
+// patched.  Groups the account is only leaving, or already belongs to, confer
+// nothing and are skipped.
+//
+// An account that does not exist yet belongs to no group: the create path
+// passes an empty ID, and every group it asked to join counts as an addition.
+func (c *Client) validateGroupAdditions(ctx context.Context, organizationID ids.OrganizationID, serviceAccountID string, groupIDs openapi.GroupIDs, groups *unikornv1.GroupList) error {
+	// Reconciliation below can only act on groups that exist, so an ID naming
+	// none of them would otherwise be dropped without the caller being told.
+	if err := common.ValidateGroupsExist(groupIDs, groups); err != nil {
+		return err
+	}
+
+	for i := range groups.Items {
+		group := &groups.Items[i]
+
+		if !slices.Contains(groupIDs, group.Name) {
+			continue
+		}
+
+		// Membership lists are not validated against real accounts, so an
+		// empty ID could match a junk entry.  Test the ID first rather than
+		// letting the sentinel skip a check.
+		if serviceAccountID != "" && slices.Contains(group.Spec.ServiceAccountIDs, serviceAccountID) {
+			continue
+		}
+
+		if err := common.AllowGroupMembershipAddition(ctx, c.client, c.namespace, organizationID, group); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // updateGroups takes a user name and a requested list of groups and adds to
 // the groups it should be a member of and removes itself from groups it shouldn't.
+//
+// This writes.  It does no grant checking of its own: callers must run
+// validateGroupAdditions over the same group list first, before they make any
+// other write, so a refusal cannot leave an earlier part of the request
+// applied.
 func (c *Client) updateGroups(ctx context.Context, serviceAccountID string, groupIDs openapi.GroupIDs, groups *unikornv1.GroupList) error {
 	for i := range groups.Items {
 		current := &groups.Items[i]
@@ -235,6 +278,10 @@ func (c *Client) updateGroups(ctx context.Context, serviceAccountID string, grou
 
 			return fmt.Errorf("%w: failed to patch group", err)
 		}
+
+		// Reflect the change in the caller's in-memory list so responses can be
+		// built from it without a cached reload that may lag the write.
+		groups.Items[i] = *updated
 	}
 
 	return nil
@@ -247,6 +294,19 @@ func (c *Client) Create(ctx context.Context, organizationID ids.OrganizationID, 
 		return nil, err
 	}
 
+	groups, err := c.listGroups(ctx, organization)
+	if err != nil {
+		return nil, err
+	}
+
+	// Settle the group grants before the account exists.  Creating it first
+	// and refusing afterwards would strand a service account, with a token
+	// already issued, that the caller was never told about.  The account is
+	// new, so it is in no group yet.
+	if err := c.validateGroupAdditions(ctx, organization.ID, "", request.Spec.GroupIDs, groups); err != nil {
+		return nil, err
+	}
+
 	resource, err := c.generate(ctx, organization, request)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to generate service account", err)
@@ -254,11 +314,6 @@ func (c *Client) Create(ctx context.Context, organizationID ids.OrganizationID, 
 
 	if err := c.client.Create(ctx, resource); err != nil {
 		return nil, fmt.Errorf("%w: failed to create service account", err)
-	}
-
-	groups, err := c.listGroups(ctx, organization)
-	if err != nil {
-		return nil, err
 	}
 
 	if err := c.updateGroups(ctx, resource.Name, request.Spec.GroupIDs, groups); err != nil {
@@ -322,6 +377,19 @@ func (c *Client) Update(ctx context.Context, organizationID ids.OrganizationID, 
 		return nil, err
 	}
 
+	groups, err := c.listGroups(ctx, organization)
+	if err != nil {
+		return nil, err
+	}
+
+	// Settle every grant in the request before the first write.  The metadata
+	// and tag changes below land on the service account record, so a
+	// membership refusal discovered after them would have already applied part
+	// of a request the caller was told it could not make.
+	if err := c.validateGroupAdditions(ctx, organization.ID, serviceAccountID, request.Spec.GroupIDs, groups); err != nil {
+		return nil, err
+	}
+
 	required, err := c.generate(ctx, organization, request)
 	if err != nil {
 		return nil, err
@@ -346,11 +414,6 @@ func (c *Client) Update(ctx context.Context, organizationID ids.OrganizationID, 
 		}
 
 		return nil, fmt.Errorf("%w: failed to patch group", err)
-	}
-
-	groups, err := c.listGroups(ctx, organization)
-	if err != nil {
-		return nil, err
 	}
 
 	if err := c.updateGroups(ctx, serviceAccountID, request.Spec.GroupIDs, groups); err != nil {
@@ -422,6 +485,8 @@ func (c *Client) Delete(ctx context.Context, organizationID ids.OrganizationID, 
 		return err
 	}
 
+	// Deletion only strips memberships, which confers nothing, so there is no
+	// grant pre-pass to run.
 	if err := c.updateGroups(ctx, serviceAccountID, nil, groups); err != nil {
 		return err
 	}

--- a/pkg/handler/serviceaccounts/update_groups_internal_test.go
+++ b/pkg/handler/serviceaccounts/update_groups_internal_test.go
@@ -1,0 +1,440 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccounts
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/core/pkg/constants"
+	coreopenapi "github.com/unikorn-cloud/core/pkg/openapi"
+	"github.com/unikorn-cloud/core/pkg/server/errors"
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/identity/pkg/ids"
+	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
+	"github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/principal"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testNamespace      = "identity"
+	testOrgNS          = "test-org-ns"
+	testOrganizationID = "acbaf1e5-6414-4066-b74e-2d95dc766299"
+
+	testGroupID          = "radar-group"
+	testCleanGroupID     = "clean-group"
+	testServiceAccountID = "sa-a"
+	testRoleID           = "radar-id"
+	testRoleName         = "radar"
+)
+
+// testRole builds a role scoped to an endpoint no built-in role holds, so only a caller
+// whose ACL is extended to cover it can grant the role.
+func testRole() *unikornv1.Role {
+	return &unikornv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testRoleID,
+			Namespace: testNamespace,
+			Labels:    map[string]string{constants.NameLabel: testRoleName},
+		},
+		Spec: unikornv1.RoleSpec{
+			Scopes: unikornv1.RoleScopes{
+				Organization: []unikornv1.RoleScope{
+					{Name: "radar:things", Operations: []unikornv1.Operation{unikornv1.Read}},
+				},
+			},
+		},
+	}
+}
+
+// testGroup builds a group already carrying the ungrantable role, standing in for one
+// seeded by a third-party service or a more privileged admin.
+func testGroup(serviceAccountIDs ...string) *unikornv1.Group {
+	return &unikornv1.Group{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testGroupID,
+			Namespace: testOrgNS,
+		},
+		Spec: unikornv1.GroupSpec{
+			RoleIDs:           []string{testRoleID},
+			ServiceAccountIDs: serviceAccountIDs,
+		},
+	}
+}
+
+// cleanGroup builds a group carrying no roles, so joining it is never a grant.  Its name
+// sorts before the radar group's, so a reconciliation reaches it first.
+func cleanGroup() *unikornv1.Group {
+	return &unikornv1.Group{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testCleanGroupID,
+			Namespace: testOrgNS,
+		},
+	}
+}
+
+func testFixture(t *testing.T, objects ...client.Object) (*Client, client.Client) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, unikornv1.AddToScheme(scheme))
+
+	organization := &unikornv1.Organization{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      testOrganizationID,
+		},
+		Status: unikornv1.OrganizationStatus{
+			Namespace: testOrgNS,
+		},
+	}
+
+	objects = append([]client.Object{organization}, objects...)
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+
+	// Membership reconciliation needs only the Kubernetes client and the
+	// identity namespace.  The token issuer is left nil deliberately: nothing
+	// on these paths may mint a token, and a refused create in particular must
+	// bail out before it would.
+	return &Client{client: cli, namespace: testNamespace}, cli
+}
+
+// testACL builds a context carrying an ACL granting only the given organization-scoped
+// endpoints in the test organization, over the authorization and principal info the
+// handlers stamp onto anything they create.
+func testACL(endpoints openapi.AclEndpoints) context.Context {
+	ctx := authorization.NewContext(context.Background(), &authorization.Info{
+		Userinfo: &openapi.Userinfo{
+			Sub: "test-subject",
+		},
+	})
+
+	ctx = principal.NewContext(ctx, &principal.Principal{
+		Actor: "test-principal",
+	})
+
+	organizations := openapi.AclOrganizationList{{Id: testOrganizationID, Endpoints: &endpoints}}
+
+	return rbac.NewContext(ctx, &openapi.Acl{Organizations: &organizations})
+}
+
+func listGroups(t *testing.T, cli client.Client) *unikornv1.GroupList {
+	t.Helper()
+
+	groups := &unikornv1.GroupList{}
+	require.NoError(t, cli.List(t.Context(), groups, &client.ListOptions{Namespace: testOrgNS}))
+
+	return groups
+}
+
+func getGroup(t *testing.T, cli client.Client) *unikornv1.Group {
+	t.Helper()
+
+	return getNamedGroup(t, cli, testGroupID)
+}
+
+func getNamedGroup(t *testing.T, cli client.Client, name string) *unikornv1.Group {
+	t.Helper()
+
+	group := &unikornv1.Group{}
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKey{Namespace: testOrgNS, Name: name}, group))
+
+	return group
+}
+
+// validateAndUpdateGroups runs the sequence every write path uses: settle the grants over
+// the group list first, then apply the membership changes.  updateGroups does no checking
+// of its own, so that a refusal can be raised before the request's other writes land.
+func validateAndUpdateGroups(ctx context.Context, c *Client, organizationID ids.OrganizationID, groupIDs openapi.GroupIDs, groups *unikornv1.GroupList) error {
+	if err := c.validateGroupAdditions(ctx, organizationID, testServiceAccountID, groupIDs, groups); err != nil {
+		return err
+	}
+
+	return c.updateGroups(ctx, testServiceAccountID, groupIDs, groups)
+}
+
+// TestUpdateGroupsRefusesAdditionToUngrantableRoleGroup covers the grant hidden inside a
+// service account write: joining a group hands the account every role the group carries,
+// so it is refused unless the caller could grant those roles.
+func TestUpdateGroupsRefusesAdditionToUngrantableRoleGroup(t *testing.T) {
+	t.Parallel()
+
+	c, cli := testFixture(t, testRole(), testGroup())
+
+	organizationID, err := ids.ParseOrganizationID(testOrganizationID)
+	require.NoError(t, err)
+
+	ctx := testACL(openapi.AclEndpoints{
+		{Name: "identity:serviceaccounts", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	err = validateAndUpdateGroups(ctx, c, organizationID, openapi.GroupIDs{testGroupID}, listGroups(t, cli))
+	require.Error(t, err)
+	require.True(t, errors.IsForbidden(err))
+	assert.Contains(t, err.Error(), testRoleName)
+
+	assert.Empty(t, getGroup(t, cli).Spec.ServiceAccountIDs)
+}
+
+// TestUpdateGroupsRefusesEveryAdditionWhenOneIsRefused pins the write down as one unit: a
+// request joining a harmless group and an ungrantable one must leave both alone, even
+// though the harmless one is reached first.
+func TestUpdateGroupsRefusesEveryAdditionWhenOneIsRefused(t *testing.T) {
+	t.Parallel()
+
+	c, cli := testFixture(t, testRole(), cleanGroup(), testGroup())
+
+	organizationID, err := ids.ParseOrganizationID(testOrganizationID)
+	require.NoError(t, err)
+
+	ctx := testACL(openapi.AclEndpoints{
+		{Name: "identity:serviceaccounts", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	err = validateAndUpdateGroups(ctx, c, organizationID, openapi.GroupIDs{testCleanGroupID, testGroupID}, listGroups(t, cli))
+	require.Error(t, err)
+	require.True(t, errors.IsForbidden(err))
+	assert.Contains(t, err.Error(), testRoleName)
+
+	assert.Empty(t, getNamedGroup(t, cli, testCleanGroupID).Spec.ServiceAccountIDs,
+		"the permitted addition must not land when another in the same write is refused")
+	assert.Empty(t, getGroup(t, cli).Spec.ServiceAccountIDs)
+}
+
+// TestUpdateGroupsAllowsAdditionByRoleHolder is the other half of the gate: the grant
+// traces to a holder, so a caller who holds radar:things may confer it.
+func TestUpdateGroupsAllowsAdditionByRoleHolder(t *testing.T) {
+	t.Parallel()
+
+	c, cli := testFixture(t, testRole(), testGroup())
+
+	organizationID, err := ids.ParseOrganizationID(testOrganizationID)
+	require.NoError(t, err)
+
+	ctx := testACL(openapi.AclEndpoints{
+		{Name: "radar:things", Operations: openapi.AclOperations{openapi.Read}},
+	})
+
+	require.NoError(t, validateAndUpdateGroups(ctx, c, organizationID, openapi.GroupIDs{testGroupID}, listGroups(t, cli)))
+	assert.Equal(t, []string{testServiceAccountID}, getGroup(t, cli).Spec.ServiceAccountIDs)
+}
+
+// TestCreateRefusesUngrantableGroupWithoutPersistingTheAccount pins the ordering on the
+// create path: the grant is settled before the account exists.  Creating it first and
+// discovering the refusal afterwards would strand a service account, with a token already
+// issued, that the caller never got told about.
+func TestCreateRefusesUngrantableGroupWithoutPersistingTheAccount(t *testing.T) {
+	t.Parallel()
+
+	c, cli := testFixture(t, testRole(), testGroup())
+
+	organizationID, err := ids.ParseOrganizationID(testOrganizationID)
+	require.NoError(t, err)
+
+	ctx := testACL(openapi.AclEndpoints{
+		{Name: "identity:serviceaccounts", Operations: openapi.AclOperations{openapi.Create}},
+	})
+
+	request := &openapi.ServiceAccountWrite{
+		Metadata: coreopenapi.ResourceWriteMetadata{Name: "refused-sa"},
+		Spec: openapi.ServiceAccountSpec{
+			GroupIDs: openapi.GroupIDs{testGroupID},
+		},
+	}
+
+	_, err = c.Create(ctx, organizationID, request)
+	require.Error(t, err)
+	require.True(t, errors.IsForbidden(err))
+	assert.Contains(t, err.Error(), testRoleName)
+
+	accounts := &unikornv1.ServiceAccountList{}
+	require.NoError(t, cli.List(t.Context(), accounts, &client.ListOptions{Namespace: testOrgNS}))
+	assert.Empty(t, accounts.Items,
+		"a refused create must not leave a service account behind")
+
+	assert.Empty(t, getGroup(t, cli).Spec.ServiceAccountIDs)
+}
+
+// TestUpdateRefusesUngrantableGroupWithoutPatchingTheAccount pins the ordering on the
+// update path: the grant is settled before the account record is rewritten.  Discovering
+// the refusal afterwards would leave the metadata change applied for a request the caller
+// was told it could not make.
+func TestUpdateRefusesUngrantableGroupWithoutPatchingTheAccount(t *testing.T) {
+	t.Parallel()
+
+	account := &unikornv1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testServiceAccountID,
+			Namespace: testOrgNS,
+			Labels:    map[string]string{constants.NameLabel: "original-name"},
+		},
+		Spec: unikornv1.ServiceAccountSpec{
+			Expiry:      &metav1.Time{Time: time.Now().Add(time.Hour)},
+			AccessToken: "original-token",
+		},
+	}
+
+	c, cli := testFixture(t, testRole(), testGroup(), account)
+
+	organizationID, err := ids.ParseOrganizationID(testOrganizationID)
+	require.NoError(t, err)
+
+	ctx := testACL(openapi.AclEndpoints{
+		{Name: "identity:serviceaccounts", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	request := &openapi.ServiceAccountWrite{
+		Metadata: coreopenapi.ResourceWriteMetadata{Name: "renamed-sa"},
+		Spec: openapi.ServiceAccountSpec{
+			GroupIDs: openapi.GroupIDs{testGroupID},
+		},
+	}
+
+	_, err = c.Update(ctx, organizationID, testServiceAccountID, request)
+	require.Error(t, err)
+	require.True(t, errors.IsForbidden(err))
+	assert.Contains(t, err.Error(), testRoleName)
+
+	stored := &unikornv1.ServiceAccount{}
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKey{Namespace: testOrgNS, Name: testServiceAccountID}, stored))
+	assert.Equal(t, "original-name", stored.Labels[constants.NameLabel],
+		"a refused update must not persist the metadata change")
+
+	assert.Empty(t, getGroup(t, cli).Spec.ServiceAccountIDs)
+}
+
+// TestUpdateGroupsReflectsMembershipInTheRenderedList pins the response body. Callers
+// render groupIDs from the group list they passed in, so a patch that is not also applied
+// to that list reports a successful join as no membership at all.
+func TestUpdateGroupsReflectsMembershipInTheRenderedList(t *testing.T) {
+	t.Parallel()
+
+	c, cli := testFixture(t, testRole(), cleanGroup())
+
+	organizationID, err := ids.ParseOrganizationID(testOrganizationID)
+	require.NoError(t, err)
+
+	ctx := testACL(openapi.AclEndpoints{
+		{Name: "identity:serviceaccounts", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	groups := listGroups(t, cli)
+	require.NoError(t, validateAndUpdateGroups(ctx, c, organizationID, openapi.GroupIDs{testCleanGroupID}, groups))
+
+	// The membership really landed on the stored resource.
+	assert.Equal(t, []string{testServiceAccountID}, getNamedGroup(t, cli, testCleanGroupID).Spec.ServiceAccountIDs)
+
+	// And the list the response is built from agrees with it.
+	account := &unikornv1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: testServiceAccountID, Namespace: testOrgNS},
+		Spec:       unikornv1.ServiceAccountSpec{Expiry: &metav1.Time{Time: time.Now()}},
+	}
+
+	assert.Equal(t, openapi.GroupIDs{testCleanGroupID}, convert(account, groups).Spec.GroupIDs,
+		"a successful join must be reported in the response")
+}
+
+// TestUpdateGroupsAllowsRemovalFromUngrantableRoleGroup shows removal confers nothing and
+// stays ungated, so a group can still be managed down by a caller who could not add to it.
+func TestUpdateGroupsAllowsRemovalFromUngrantableRoleGroup(t *testing.T) {
+	t.Parallel()
+
+	c, cli := testFixture(t, testRole(), testGroup(testServiceAccountID))
+
+	organizationID, err := ids.ParseOrganizationID(testOrganizationID)
+	require.NoError(t, err)
+
+	ctx := testACL(openapi.AclEndpoints{
+		{Name: "identity:serviceaccounts", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	require.NoError(t, validateAndUpdateGroups(ctx, c, organizationID, openapi.GroupIDs{}, listGroups(t, cli)))
+
+	group := getGroup(t, cli)
+	assert.Empty(t, group.Spec.ServiceAccountIDs)
+	assert.Equal(t, []string{testRoleID}, group.Spec.RoleIDs)
+}
+
+// TestUpdateGroupsAllowsDeletionUnlink covers the delete path, which passes no group IDs at
+// all: stripping memberships as cleanup confers nothing and must not be gated.
+func TestUpdateGroupsAllowsDeletionUnlink(t *testing.T) {
+	t.Parallel()
+
+	c, cli := testFixture(t, testRole(), testGroup(testServiceAccountID))
+
+	organizationID, err := ids.ParseOrganizationID(testOrganizationID)
+	require.NoError(t, err)
+
+	ctx := testACL(openapi.AclEndpoints{
+		{Name: "identity:serviceaccounts", Operations: openapi.AclOperations{openapi.Delete}},
+	})
+
+	require.NoError(t, validateAndUpdateGroups(ctx, c, organizationID, nil, listGroups(t, cli)))
+	assert.Empty(t, getGroup(t, cli).Spec.ServiceAccountIDs)
+}
+
+// TestUpdateGroupsAllowsReaffirmingExistingMembership shows the gate keys on the change,
+// not the request: re-sending a membership the account already has is not a new grant.
+func TestUpdateGroupsAllowsReaffirmingExistingMembership(t *testing.T) {
+	t.Parallel()
+
+	c, cli := testFixture(t, testRole(), testGroup(testServiceAccountID))
+
+	organizationID, err := ids.ParseOrganizationID(testOrganizationID)
+	require.NoError(t, err)
+
+	ctx := testACL(openapi.AclEndpoints{
+		{Name: "identity:serviceaccounts", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	require.NoError(t, validateAndUpdateGroups(ctx, c, organizationID, openapi.GroupIDs{testGroupID}, listGroups(t, cli)))
+	assert.Equal(t, []string{testServiceAccountID}, getGroup(t, cli).Spec.ServiceAccountIDs)
+}
+
+// TestValidateGroupAdditionsRefusesUnknownGroup covers a requested group the organization
+// does not have.  Reconciliation walks the groups that exist and matches the request
+// against them, so an ID matching nothing used to fall through every branch and the caller
+// got a 200 whose body did not mention the group it asked for.
+func TestValidateGroupAdditionsRefusesUnknownGroup(t *testing.T) {
+	t.Parallel()
+
+	c, cli := testFixture(t, testRole(), cleanGroup())
+
+	organizationID, err := ids.ParseOrganizationID(testOrganizationID)
+	require.NoError(t, err)
+
+	ctx := testACL(openapi.AclEndpoints{
+		{Name: "identity:serviceaccounts", Operations: openapi.AclOperations{openapi.Update}},
+	})
+
+	err = c.validateGroupAdditions(ctx, organizationID, testServiceAccountID, openapi.GroupIDs{testCleanGroupID, "group-that-does-not-exist"}, listGroups(t, cli))
+	require.Error(t, err)
+	require.True(t, errors.IsBadRequest(err))
+	assert.Contains(t, err.Error(), "group-that-does-not-exist")
+}

--- a/pkg/handler/users/README.md
+++ b/pkg/handler/users/README.md
@@ -46,6 +46,49 @@ and adds or removes both:
 So this package is not just a membership record manager. It is also one side of the compatibility
 bridge between old and new group-membership representations.
 
+### Membership Additions Are Grants
+
+Putting a user into a group hands them every role that group carries, so it is a grant and is
+checked as one: the add branch of the reconciliation refuses unless the caller could grant each of
+the group's roles in that organization. The refusal names the role. This is the same rule
+[`pkg/handler/groups`](../groups/README.md) applies to membership written through the group itself
+— the check lives in `pkg/handler/common` so both entry points share it, and a user write cannot be
+used to sidestep the group write's guard.
+
+The check keys on the change, not on the request: re-sending a group the user already belongs to
+confers nothing new and passes. Membership has two representations, the deprecated `UserIDs` list
+and the subject list, and `pkg/rbac` resolves a user into a group through either one. A user
+present in one is therefore already a member, so filling in the other half confers nothing and is
+not gated. That matters for groups written before subjects existed: re-sending their membership
+derives the missing half for the first time, and reading that as a grant would leave such a group
+with no legal user write at all.
+
+Removing a user from a group takes authority away rather than handing it out, so the remove branch
+is unguarded. Deletion is exempt for the same reason — it reconciles against an empty group list,
+so it only ever removes, and a user must remain deletable even when they sit in a group nobody can
+grant the roles of.
+
+Reconciliation is validate-then-apply: every group the user would newly join is grant-checked
+before the first group is patched. A write that joins one group the caller may grant and another
+they may not is refused whole, leaving both untouched, rather than applying the permitted half and
+then failing. Without that, whether a partial grant landed would depend on the order the groups
+came back in.
+
+Create runs the same check earlier still — before the global `User` and the `OrganizationUser` are
+written, not just before the group patches. A create refused on its group membership therefore
+leaves no records at all, rather than an account the caller was told it could not create. Because
+create is idempotent, the check resolves any records the subject already has first, so memberships
+they already hold are exempt just as they are on update.
+
+That ordering is a guarantee about *refusals*, not about failures. No authorization decision is
+ever discovered after a write has landed. It does not make the write atomic — see the TODO on
+partial-failure behaviour below.
+
+A group ID the organization does not have is refused rather than dropped. Reconciliation walks the
+groups that exist and asks of each whether the request names it, so an ID matching nothing matches
+no branch: without the check the caller would get a success whose body simply does not mention the
+group it asked for.
+
 ### Read Model Aggregation
 
 The user read model is assembled from multiple sources:
@@ -66,6 +109,14 @@ clients.
   must use update to intentionally change organization-local state
 - organization membership changes must keep group membership consistent with the requested
   `groupIDs`
+- a requested group that does not exist in the organization is an error, not a silently dropped
+  part of the write
+- adding a user to a group is a grant of that group's roles, so it is allowed only where the caller
+  could grant every role the group carries; removals and user deletion are not gated
+- a principal present in either membership representation is already a member, so completing the
+  other half is not an addition
+- a refused membership addition applies none of the write's other additions, and on create writes
+  no user records either
 - user read responses are assembled from global user state, organization membership state, and
   group membership state together
 - the API-managed path only allows email-address subjects for normal user creation
@@ -80,7 +131,12 @@ clients.
 ## TODO
 
 - Revisit partial-failure behaviour in create/update/delete flows that mutate organization users
-  and then reconcile groups, so membership state does not drift if later steps fail.
+  and then reconcile groups, so membership state does not drift if later steps fail. Authorization
+  no longer contributes: every grant in a request is settled before that request writes anything.
+  What remains is infrastructure failure partway through a multi-object write — a conflict or an
+  API-server error on the third of four group patches leaves the first two applied, and on update
+  the organization user is patched before group reconciliation starts. Closing that needs a
+  rollback or a single-object write.
 - Revisit list resilience so an orphaned `OrganizationUser` -> `User` reference does not
   necessarily fail the entire organization user listing.
 
@@ -88,6 +144,8 @@ clients.
 
 - [`pkg/handler/organizations`](../organizations/README.md), which provides the parent
   organization scope and namespace handoff used here
+- [`pkg/handler/groups`](../groups/README.md), which owns the group resources this package
+  reconciles membership into, and documents the guard rails on their roles
 - [`pkg/userdb`](../../userdb/README.md), which shields authn/authz consumers from the raw local
   `User` and `OrganizationUser` storage joins that this package mutates
 - [`pkg/apis/unikorn/v1alpha1`](../../apis/unikorn/v1alpha1/README.md), which defines the stored

--- a/pkg/handler/users/README.md
+++ b/pkg/handler/users/README.md
@@ -63,6 +63,13 @@ not gated. That matters for groups written before subjects existed: re-sending t
 derives the missing half for the first time, and reading that as a grant would leave such a group
 with no legal user write at all.
 
+For the same reason, the already-a-member test matches subjects by ID alone, mirroring how
+`pkg/rbac` actually resolves membership (see `GroupSpec.HasMemberByID`). Subject records written
+before issuers were recorded carry an empty issuer and still confer the group's roles, so an
+issuer-qualified comparison would read a no-op re-send of such a membership as an addition and
+refuse it — the frozen-group failure this gate exists to avoid. If RBAC matching ever becomes
+issuer-qualified, the gate must move with it.
+
 Removing a user from a group takes authority away rather than handing it out, so the remove branch
 is unguarded. Deletion is exempt for the same reason — it reconciles against an empty group list,
 so it only ever removes, and a user must remain deletable even when they sit in a group nobody can

--- a/pkg/handler/users/client.go
+++ b/pkg/handler/users/client.go
@@ -128,7 +128,7 @@ func addToGroup(subject unikornv1.GroupSubject, orgUserID string, updated *uniko
 // keeps a refusal from landing after an earlier group has already been
 // patched.  Groups the user is only leaving, or already belongs to, confer
 // nothing and are skipped.
-func (c *Client) validateGroupAdditions(ctx context.Context, organizationID ids.OrganizationID, subject unikornv1.GroupSubject, orgUserID string, groupIDs openapi.GroupIDs, groups *unikornv1.GroupList) error {
+func (c *Client) validateGroupAdditions(ctx context.Context, organizationID ids.OrganizationID, subjectID, orgUserID string, groupIDs openapi.GroupIDs, groups *unikornv1.GroupList) error {
 	// Reconciliation below can only act on groups that exist, so an ID naming
 	// none of them would otherwise be dropped without the caller being told.
 	if err := common.ValidateGroupsExist(groupIDs, groups); err != nil {
@@ -143,8 +143,12 @@ func (c *Client) validateGroupAdditions(ctx context.Context, organizationID ids.
 		}
 
 		// Presence in either membership representation already confers the
-		// group's roles, so writing the other half grants nothing.
-		if group.Spec.HasMember(orgUserID, subject) {
+		// group's roles, so writing the other half grants nothing.  Subjects
+		// are matched by ID alone, mirroring how RBAC resolves membership: a
+		// record written before subject issuers existed carries an empty one
+		// yet still confers the roles, so re-stating that membership must not
+		// read as an addition and be refused.
+		if group.Spec.HasMemberByID(orgUserID, subjectID) {
 			continue
 		}
 
@@ -462,8 +466,6 @@ func (c *Client) validateCreateGroupAdditions(ctx context.Context, organization 
 		return nil
 	}
 
-	subject := c.groupSubject(request.Spec.Subject)
-
 	// Resolve what already exists without creating it.  Either record may be
 	// absent on a first-time create, which just means there is no prior
 	// membership to exempt.
@@ -487,7 +489,7 @@ func (c *Client) validateCreateGroupAdditions(ctx context.Context, organization 
 		return err
 	}
 
-	return c.validateGroupAdditions(ctx, organization.ID, subject, orgUserID, request.Spec.GroupIDs, groups)
+	return c.validateGroupAdditions(ctx, organization.ID, request.Spec.Subject, orgUserID, request.Spec.GroupIDs, groups)
 }
 
 // Create makes a new user.  This creates a new user in an organization, but they
@@ -601,7 +603,7 @@ func (c *Client) Update(ctx context.Context, organizationID ids.OrganizationID, 
 	// tags and label changes below land on the organization user record, so a
 	// membership refusal discovered after them would have already applied
 	// part of a request the caller was told it could not make.
-	if err := c.validateGroupAdditions(ctx, organization.ID, c.groupSubject(user.Spec.Subject), userID, request.Spec.GroupIDs, groups); err != nil {
+	if err := c.validateGroupAdditions(ctx, organization.ID, user.Spec.Subject, userID, request.Spec.GroupIDs, groups); err != nil {
 		return nil, err
 	}
 

--- a/pkg/handler/users/client.go
+++ b/pkg/handler/users/client.go
@@ -89,9 +89,7 @@ func removeFromGroup(subject unikornv1.GroupSubject, orgUserID string, updated *
 		needsPatching = true
 	}
 
-	subjects := slices.DeleteFunc(updated.Spec.Subjects, func(sub unikornv1.GroupSubject) bool {
-		return sub.ID == subject.ID && sub.Issuer == subject.Issuer
-	})
+	subjects := slices.DeleteFunc(updated.Spec.Subjects, subject.Matches)
 	if len(subjects) != len(updated.Spec.Subjects) {
 		updated.Spec.Subjects = subjects
 		needsPatching = true
@@ -100,16 +98,23 @@ func removeFromGroup(subject unikornv1.GroupSubject, orgUserID string, updated *
 	return needsPatching
 }
 
-// addToGroup adds the Subject and userID if not present.
+// addToGroup writes the user into whichever membership representations do not
+// already hold it, and reports whether anything changed.  Completing the
+// missing half of a membership the group already has confers nothing — RBAC
+// already resolves the user into the group through the half that is present —
+// so this runs whether or not the grant guard saw an addition.  Subjects are
+// matched on identity, not on the whole record: the same principal written by
+// a different handler carries a different Email and must not be appended
+// again.
 func addToGroup(subject unikornv1.GroupSubject, orgUserID string, updated *unikornv1.Group) bool {
 	var needsPatching bool
-	// Add to a group where it should be a member but isn't.
-	if !slices.Contains(updated.Spec.UserIDs, orgUserID) {
+
+	if orgUserID != "" && !slices.Contains(updated.Spec.UserIDs, orgUserID) {
 		updated.Spec.UserIDs = append(updated.Spec.UserIDs, orgUserID)
 		needsPatching = true
 	}
 
-	if !slices.Contains(updated.Spec.Subjects, subject) {
+	if !updated.Spec.HasSubject(subject) {
 		updated.Spec.Subjects = append(updated.Spec.Subjects, subject)
 		needsPatching = true
 	}
@@ -117,18 +122,63 @@ func addToGroup(subject unikornv1.GroupSubject, orgUserID string, updated *uniko
 	return needsPatching
 }
 
+// validateGroupAdditions checks every group the user would newly join before
+// any of them is written.  Joining a group confers its roles, so each is a
+// grant the caller has to be able to make; running the whole set up front
+// keeps a refusal from landing after an earlier group has already been
+// patched.  Groups the user is only leaving, or already belongs to, confer
+// nothing and are skipped.
+func (c *Client) validateGroupAdditions(ctx context.Context, organizationID ids.OrganizationID, subject unikornv1.GroupSubject, orgUserID string, groupIDs openapi.GroupIDs, groups *unikornv1.GroupList) error {
+	// Reconciliation below can only act on groups that exist, so an ID naming
+	// none of them would otherwise be dropped without the caller being told.
+	if err := common.ValidateGroupsExist(groupIDs, groups); err != nil {
+		return err
+	}
+
+	for i := range groups.Items {
+		group := &groups.Items[i]
+
+		if !slices.Contains(groupIDs, group.Name) {
+			continue
+		}
+
+		// Presence in either membership representation already confers the
+		// group's roles, so writing the other half grants nothing.
+		if group.Spec.HasMember(orgUserID, subject) {
+			continue
+		}
+
+		if err := common.AllowGroupMembershipAddition(ctx, c.client, c.namespace, organizationID, group); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// groupSubject builds the membership subject for a user of this deployment's
+// own issuer.
+func (c *Client) groupSubject(userSubject string) unikornv1.GroupSubject {
+	return unikornv1.GroupSubject{
+		ID:     userSubject,
+		Email:  userSubject,
+		Issuer: c.issuer.URL,
+	}
+}
+
 // updateGroups takes a user's subject and a requested list of groups and adds to
 // the groups it should be a member of and removes itself from groups it shouldn't.
+//
+// This writes.  It does no grant checking of its own: callers must run
+// validateGroupAdditions over the same group list first, before they make any
+// other write, so a refusal cannot leave an earlier part of the request
+// applied.
 func (c *Client) updateGroups(ctx context.Context, userSubject, orgUserID string, groupIDs openapi.GroupIDs, groups *unikornv1.GroupList) error {
 	// The subject is supplied by the caller rather than re-read here: on the
 	// create path the global user was just written to the API server, and a
 	// read back through the cached client can miss it while the informer catches
 	// up, spuriously failing the request. Callers already hold the user.
-	subject := unikornv1.GroupSubject{
-		ID:     userSubject,
-		Email:  userSubject,
-		Issuer: c.issuer.URL,
-	}
+	subject := c.groupSubject(userSubject)
 
 	for i := range groups.Items {
 		current := &groups.Items[i]
@@ -400,6 +450,46 @@ func (c *Client) getOrCreateOrganizationUser(ctx context.Context, organization *
 	return resource, nil
 }
 
+// validateCreateGroupAdditions checks the groups a create request asks to join
+// before any record is written.  Create is idempotent, so the subject may
+// already have a user record and some of these memberships; those confer
+// nothing new and are skipped, exactly as on the update path.  A subject with
+// no records yet belongs to no group, so every requested group is an addition.
+func (c *Client) validateCreateGroupAdditions(ctx context.Context, organization *organizations.Meta, request *openapi.UserWrite, groups *unikornv1.GroupList) error {
+	// Nothing is being granted, so skip the lookups below: they cannot change
+	// the answer, and on this path they would only add ways to fail.
+	if len(request.Spec.GroupIDs) == 0 {
+		return nil
+	}
+
+	subject := c.groupSubject(request.Spec.Subject)
+
+	// Resolve what already exists without creating it.  Either record may be
+	// absent on a first-time create, which just means there is no prior
+	// membership to exempt.
+	var orgUserID string
+
+	user, err := c.getGlobalUser(ctx, request.Spec.Subject)
+
+	switch {
+	case err == nil:
+		orgUser, err := c.getOrganizationUserByGlobalUserID(ctx, organization, user.Name)
+
+		switch {
+		case err == nil:
+			orgUserID = orgUser.Name
+		case goerrors.Is(err, ErrReference):
+		default:
+			return err
+		}
+	case goerrors.Is(err, ErrReference):
+	default:
+		return err
+	}
+
+	return c.validateGroupAdditions(ctx, organization.ID, subject, orgUserID, request.Spec.GroupIDs, groups)
+}
+
 // Create makes a new user.  This creates a new user in an organization, but they
 // reference a unique user resource, so we need to get or create the underlying record
 // first, then add to the organization.
@@ -410,22 +500,30 @@ func (c *Client) Create(ctx context.Context, organizationID ids.OrganizationID, 
 		return nil, errors.OAuth2InvalidRequest("subject address invalid").WithError(err)
 	}
 
-	user, err := c.getOrCreateGlobalUser(ctx, request)
-	if err != nil {
-		return nil, err
-	}
-
 	organization, err := organizations.New(c.client, c.namespace).GetMetadata(ctx, organizationID)
 	if err != nil {
 		return nil, err
 	}
 
-	resource, err := c.getOrCreateOrganizationUser(ctx, organization, request, user.Name)
+	groups, err := c.listGroups(ctx, organization)
 	if err != nil {
 		return nil, err
 	}
 
-	groups, err := c.listGroups(ctx, organization)
+	// Settle the group grants before any record exists.  Writing the user
+	// first and refusing afterwards would leave a global user and an
+	// organization membership behind for an account the caller was told it
+	// could not create.
+	if err := c.validateCreateGroupAdditions(ctx, organization, request, groups); err != nil {
+		return nil, err
+	}
+
+	user, err := c.getOrCreateGlobalUser(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	resource, err := c.getOrCreateOrganizationUser(ctx, organization, request, user.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -494,6 +592,19 @@ func (c *Client) Update(ctx context.Context, organizationID ids.OrganizationID, 
 		return nil, err
 	}
 
+	groups, err := c.listGroups(ctx, organization)
+	if err != nil {
+		return nil, err
+	}
+
+	// Settle every grant in the request before the first write.  The state,
+	// tags and label changes below land on the organization user record, so a
+	// membership refusal discovered after them would have already applied
+	// part of a request the caller was told it could not make.
+	if err := c.validateGroupAdditions(ctx, organization.ID, c.groupSubject(user.Spec.Subject), userID, request.Spec.GroupIDs, groups); err != nil {
+		return nil, err
+	}
+
 	required, err := generateOrganizationUser(ctx, organization, request, current.Labels[constants.UserLabel])
 	if err != nil {
 		return nil, err
@@ -509,11 +620,6 @@ func (c *Client) Update(ctx context.Context, organizationID ids.OrganizationID, 
 	updated.Spec = required.Spec
 
 	if err := c.patchOrganizationUser(ctx, updated, current); err != nil {
-		return nil, err
-	}
-
-	groups, err := c.listGroups(ctx, organization)
-	if err != nil {
 		return nil, err
 	}
 
@@ -553,6 +659,8 @@ func (c *Client) Delete(ctx context.Context, organizationID ids.OrganizationID, 
 		return err
 	}
 
+	// Deletion only strips memberships, which confers nothing, so there is no
+	// grant pre-pass to run.
 	if err := c.updateGroups(ctx, user.Spec.Subject, userID, nil, groups); err != nil {
 		return err
 	}

--- a/pkg/handler/users/client_test.go
+++ b/pkg/handler/users/client_test.go
@@ -968,6 +968,86 @@ func TestClient_GroupMembershipRepresentations(t *testing.T) {
 		assert.Len(t, alphaGroup.Spec.Subjects, 1, "the same principal must not be stored twice")
 		assert.Equal(t, []string{orgUserAliceID}, alphaGroup.Spec.UserIDs)
 	})
+
+	t.Run("allows re-stating a membership stored as a legacy empty-issuer subject", func(t *testing.T) {
+		t.Parallel()
+
+		// Subject records written before issuers were recorded carry an empty
+		// one, and RBAC resolves them by ID alone, so the user already holds
+		// the group's roles.  The gate must match the way RBAC matches: an
+		// issuer-qualified comparison would read this no-op re-send as an
+		// addition and refuse it on the ungrantable role.
+		stored := unikornv1.GroupSubject{
+			ID:    userAliceSubject,
+			Email: userAliceSubject,
+		}
+
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			newGlobalUser(userAliceID, userAliceSubject),
+			newOrganizationUser(orgUserAliceID, userAliceID),
+			radarRole(),
+			newRadarGroup(groupAlphaID, nil, []unikornv1.GroupSubject{stored}),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Update}},
+		})
+
+		request := &openapi.UserWrite{
+			Spec: openapi.UserSpec{
+				Subject:  userAliceSubject,
+				State:    openapi.Active,
+				GroupIDs: openapi.GroupIDs{groupAlphaID},
+			},
+		}
+
+		_, err := fixture.usersClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), orgUserAliceID, request)
+		require.NoError(t, err)
+
+		// The write completes the canonical representation alongside the
+		// legacy record rather than being refused.
+		alphaGroup := getGroup(ctx, t, fixture.client, groupAlphaID)
+		assert.Equal(t, []string{orgUserAliceID}, alphaGroup.Spec.UserIDs)
+	})
+
+	t.Run("still refuses a genuine addition to a group holding only legacy records", func(t *testing.T) {
+		t.Parallel()
+
+		// The ID-only matching above must not blanket-allow: a legacy record
+		// for someone else confers nothing on this user, so joining the group
+		// is still a grant of the ungrantable role and is refused.
+		stored := unikornv1.GroupSubject{
+			ID:    userBobSubject,
+			Email: userBobSubject,
+		}
+
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			newGlobalUser(userAliceID, userAliceSubject),
+			newOrganizationUser(orgUserAliceID, userAliceID),
+			radarRole(),
+			newRadarGroup(groupAlphaID, nil, []unikornv1.GroupSubject{stored}),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Update}},
+		})
+
+		request := &openapi.UserWrite{
+			Spec: openapi.UserSpec{
+				Subject:  userAliceSubject,
+				State:    openapi.Active,
+				GroupIDs: openapi.GroupIDs{groupAlphaID},
+			},
+		}
+
+		_, err := fixture.usersClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), orgUserAliceID, request)
+		require.Error(t, err)
+		require.True(t, errors.IsForbidden(err))
+		require.Contains(t, err.Error(), "radar")
+
+		alphaGroup := getGroup(ctx, t, fixture.client, groupAlphaID)
+		assert.Empty(t, alphaGroup.Spec.UserIDs, "a refused addition must not be applied")
+	})
 }
 
 func TestClient_Delete(t *testing.T) {

--- a/pkg/handler/users/client_test.go
+++ b/pkg/handler/users/client_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/unikorn-cloud/core/pkg/constants"
 	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
+	"github.com/unikorn-cloud/core/pkg/server/errors"
 	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
 	handlercommon "github.com/unikorn-cloud/identity/pkg/handler/common"
 	"github.com/unikorn-cloud/identity/pkg/handler/users"
@@ -33,6 +34,7 @@ import (
 	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
 	"github.com/unikorn-cloud/identity/pkg/openapi"
 	"github.com/unikorn-cloud/identity/pkg/principal"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -62,6 +64,9 @@ const (
 	userBobSubject = "bob@example.com"
 	userBobID      = "user-bob"
 	orgUserBobID   = "orguser-bob"
+
+	radarRoleID   = "radar-id"
+	radarRoleName = "radar"
 )
 
 type userTestFixture struct {
@@ -456,6 +461,515 @@ func TestClient_Update(t *testing.T) {
 	})
 }
 
+// radarRole builds a role scoped to an endpoint no built-in role holds, so only a caller
+// whose ACL is extended to cover it can grant the role.
+func radarRole() *unikornv1.Role {
+	return &unikornv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      radarRoleID,
+			Labels:    map[string]string{constants.NameLabel: radarRoleName},
+		},
+		Spec: unikornv1.RoleSpec{
+			Scopes: unikornv1.RoleScopes{
+				Organization: []unikornv1.RoleScope{
+					{Name: "radar:things", Operations: []unikornv1.Operation{unikornv1.Read}},
+				},
+			},
+		},
+	}
+}
+
+// newRadarGroup builds a group already carrying the ungrantable role, standing in for one
+// seeded by a third-party service or a more privileged admin.
+func newRadarGroup(name string, userIDs []string, subjects []unikornv1.GroupSubject) *unikornv1.Group {
+	return &unikornv1.Group{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testOrgNS,
+			Name:      name,
+		},
+		Spec: unikornv1.GroupSpec{
+			RoleIDs:  []string{radarRoleID},
+			UserIDs:  userIDs,
+			Subjects: subjects,
+		},
+	}
+}
+
+// newPlainGroup builds a group carrying no roles, so joining it is never a grant.
+func newPlainGroup(name string) *unikornv1.Group {
+	return &unikornv1.Group{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testOrgNS,
+			Name:      name,
+		},
+	}
+}
+
+// aclContext layers an ACL granting only the given organization-scoped endpoints on top of
+// newContext's authorization and principal info.
+func aclContext(t *testing.T, endpoints openapi.AclEndpoints) context.Context {
+	t.Helper()
+
+	organizations := openapi.AclOrganizationList{{Id: testOrgID, Endpoints: &endpoints}}
+
+	return rbac.NewContext(newContext(t), &openapi.Acl{Organizations: &organizations})
+}
+
+func aliceSubject() unikornv1.GroupSubject {
+	return unikornv1.GroupSubject{
+		ID:     userAliceSubject,
+		Email:  userAliceSubject,
+		Issuer: testIssuerURL,
+	}
+}
+
+// TestClient_GroupMembershipGrantGate covers the grant hidden inside a user write: adding a
+// user to a group hands them every role the group carries, so it is refused unless the
+// caller could grant those roles.  Removals confer nothing and stay open.
+func TestClient_GroupMembershipGrantGate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("refuses adding a user to a group whose role the caller cannot grant", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			newGlobalUser(userAliceID, userAliceSubject),
+			newOrganizationUser(orgUserAliceID, userAliceID),
+			radarRole(),
+			newRadarGroup(groupAlphaID, nil, nil),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Update}},
+		})
+
+		request := &openapi.UserWrite{
+			Spec: openapi.UserSpec{
+				Subject:  userAliceSubject,
+				State:    openapi.Active,
+				GroupIDs: openapi.GroupIDs{groupAlphaID},
+			},
+		}
+
+		_, err := fixture.usersClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), orgUserAliceID, request)
+		require.Error(t, err)
+		require.True(t, errors.IsForbidden(err))
+		assert.Contains(t, err.Error(), radarRoleName)
+
+		alphaGroup := getGroup(ctx, t, fixture.client, groupAlphaID)
+		assert.Empty(t, alphaGroup.Spec.UserIDs)
+		assert.Empty(t, alphaGroup.Spec.Subjects)
+	})
+
+	t.Run("allows adding a user when the caller holds the group's role", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			newGlobalUser(userAliceID, userAliceSubject),
+			newOrganizationUser(orgUserAliceID, userAliceID),
+			radarRole(),
+			newRadarGroup(groupAlphaID, nil, nil),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Update}},
+			{Name: "radar:things", Operations: openapi.AclOperations{openapi.Read}},
+		})
+
+		request := &openapi.UserWrite{
+			Spec: openapi.UserSpec{
+				Subject:  userAliceSubject,
+				State:    openapi.Active,
+				GroupIDs: openapi.GroupIDs{groupAlphaID},
+			},
+		}
+
+		result, err := fixture.usersClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), orgUserAliceID, request)
+		require.NoError(t, err)
+		assert.Equal(t, openapi.GroupIDs{groupAlphaID}, result.Spec.GroupIDs)
+
+		alphaGroup := getGroup(ctx, t, fixture.client, groupAlphaID)
+		assert.Contains(t, alphaGroup.Spec.UserIDs, orgUserAliceID)
+	})
+
+	t.Run("leaves every group untouched when one addition in the write is refused", func(t *testing.T) {
+		t.Parallel()
+
+		// group-alpha carries no roles and would be allowed on its own, and
+		// it sorts first so the reconciliation reaches it before the refusal.
+		// A membership write is one request: if any addition in it is a grant
+		// the caller cannot make, none of them may land.
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			newGlobalUser(userAliceID, userAliceSubject),
+			newOrganizationUser(orgUserAliceID, userAliceID),
+			radarRole(),
+			newPlainGroup(groupAlphaID),
+			newRadarGroup(groupBetaID, nil, nil),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Update}},
+		})
+
+		request := &openapi.UserWrite{
+			Spec: openapi.UserSpec{
+				Subject:  userAliceSubject,
+				State:    openapi.Active,
+				GroupIDs: openapi.GroupIDs{groupAlphaID, groupBetaID},
+			},
+		}
+
+		_, err := fixture.usersClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), orgUserAliceID, request)
+		require.Error(t, err)
+		require.True(t, errors.IsForbidden(err))
+		assert.Contains(t, err.Error(), radarRoleName)
+
+		alphaGroup := getGroup(ctx, t, fixture.client, groupAlphaID)
+		assert.Empty(t, alphaGroup.Spec.UserIDs,
+			"the permitted addition must not land when another in the same write is refused")
+		assert.Empty(t, alphaGroup.Spec.Subjects)
+
+		betaGroup := getGroup(ctx, t, fixture.client, groupBetaID)
+		assert.Empty(t, betaGroup.Spec.UserIDs)
+		assert.Empty(t, betaGroup.Spec.Subjects)
+	})
+
+	t.Run("allows removing a user from a group whose role the caller cannot grant", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			newGlobalUser(userAliceID, userAliceSubject),
+			newOrganizationUser(orgUserAliceID, userAliceID),
+			radarRole(),
+			newRadarGroup(groupAlphaID, []string{orgUserAliceID}, []unikornv1.GroupSubject{aliceSubject()}),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Update}},
+		})
+
+		request := &openapi.UserWrite{
+			Spec: openapi.UserSpec{
+				Subject:  userAliceSubject,
+				State:    openapi.Active,
+				GroupIDs: openapi.GroupIDs{},
+			},
+		}
+
+		result, err := fixture.usersClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), orgUserAliceID, request)
+		require.NoError(t, err)
+		assert.Empty(t, result.Spec.GroupIDs)
+
+		alphaGroup := getGroup(ctx, t, fixture.client, groupAlphaID)
+		assert.NotContains(t, alphaGroup.Spec.UserIDs, orgUserAliceID)
+		assert.NotContains(t, alphaGroup.Spec.Subjects, aliceSubject())
+		assert.Equal(t, []string{radarRoleID}, alphaGroup.Spec.RoleIDs)
+	})
+
+	t.Run("refuses a create joining an ungrantable group without persisting any record", func(t *testing.T) {
+		t.Parallel()
+
+		// Create writes a global user and an organization membership before it
+		// reconciles groups.  Discovering the refusal after that would leave
+		// both records behind for an account the caller was told it could not
+		// create.
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			radarRole(),
+			newRadarGroup(groupAlphaID, nil, nil),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Create}},
+		})
+
+		request := &openapi.UserWrite{
+			Spec: openapi.UserSpec{
+				Subject:  userAliceSubject,
+				State:    openapi.Active,
+				GroupIDs: openapi.GroupIDs{groupAlphaID},
+			},
+		}
+
+		_, err := fixture.usersClient.Create(ctx, ids.MustParseOrganizationID(testOrgID), request)
+		require.Error(t, err)
+		require.True(t, errors.IsForbidden(err))
+		assert.Contains(t, err.Error(), radarRoleName)
+
+		globalUsers := &unikornv1.UserList{}
+		require.NoError(t, fixture.client.List(ctx, globalUsers, &client.ListOptions{Namespace: testNamespace}))
+		assert.Empty(t, globalUsers.Items, "a refused create must not leave a global user behind")
+
+		organizationUsers := &unikornv1.OrganizationUserList{}
+		require.NoError(t, fixture.client.List(ctx, organizationUsers, &client.ListOptions{Namespace: testOrgNS}))
+		assert.Empty(t, organizationUsers.Items, "a refused create must not leave an organization membership behind")
+
+		alphaGroup := getGroup(ctx, t, fixture.client, groupAlphaID)
+		assert.Empty(t, alphaGroup.Spec.UserIDs)
+		assert.Empty(t, alphaGroup.Spec.Subjects)
+	})
+
+	t.Run("creates the user when the caller holds the requested group's role", func(t *testing.T) {
+		t.Parallel()
+
+		// The counterpart: validating up front must not block a create the
+		// caller is entitled to make, and the whole flow still has to run.
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			radarRole(),
+			newRadarGroup(groupAlphaID, nil, nil),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Create}},
+			{Name: "radar:things", Operations: openapi.AclOperations{openapi.Read}},
+		})
+
+		request := &openapi.UserWrite{
+			Spec: openapi.UserSpec{
+				Subject:  userAliceSubject,
+				State:    openapi.Active,
+				GroupIDs: openapi.GroupIDs{groupAlphaID},
+			},
+		}
+
+		result, err := fixture.usersClient.Create(ctx, ids.MustParseOrganizationID(testOrgID), request)
+		require.NoError(t, err)
+		assert.Equal(t, userAliceSubject, result.Spec.Subject)
+		assert.Equal(t, openapi.GroupIDs{groupAlphaID}, result.Spec.GroupIDs)
+
+		globalUsers := &unikornv1.UserList{}
+		require.NoError(t, fixture.client.List(ctx, globalUsers, &client.ListOptions{Namespace: testNamespace}))
+		require.Len(t, globalUsers.Items, 1)
+		assert.Equal(t, userAliceSubject, globalUsers.Items[0].Spec.Subject)
+
+		organizationUsers := &unikornv1.OrganizationUserList{}
+		require.NoError(t, fixture.client.List(ctx, organizationUsers, &client.ListOptions{Namespace: testOrgNS}))
+		require.Len(t, organizationUsers.Items, 1)
+		assert.Equal(t, result.Metadata.Id, organizationUsers.Items[0].Name)
+
+		alphaGroup := getGroup(ctx, t, fixture.client, groupAlphaID)
+		assert.Contains(t, alphaGroup.Spec.UserIDs, result.Metadata.Id)
+		assert.Contains(t, alphaGroup.Spec.Subjects, aliceSubject())
+	})
+
+	t.Run("allows deleting a user held by a group whose role the caller cannot grant", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			newGlobalUser(userAliceID, userAliceSubject),
+			newOrganizationUser(orgUserAliceID, userAliceID),
+			radarRole(),
+			newRadarGroup(groupAlphaID, []string{orgUserAliceID}, []unikornv1.GroupSubject{aliceSubject()}),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Delete}},
+		})
+
+		// Deletion strips memberships as cleanup.  It confers nothing, so it
+		// must not be blocked by the group's ungrantable role.
+		require.NoError(t, fixture.usersClient.Delete(ctx, ids.MustParseOrganizationID(testOrgID), orgUserAliceID))
+
+		alphaGroup := getGroup(ctx, t, fixture.client, groupAlphaID)
+		assert.Empty(t, alphaGroup.Spec.UserIDs)
+		assert.Empty(t, alphaGroup.Spec.Subjects)
+	})
+}
+
+// TestClient_GroupMembershipDanglingRole covers a group referencing a role that no longer
+// resolves.  The reference cannot be grant-checked, and role IDs are derived from the role
+// name, so the role rebinds to the group if it is ever re-applied.
+func TestClient_GroupMembershipDanglingRole(t *testing.T) {
+	t.Parallel()
+
+	t.Run("refuses adding a user to a group whose role reference does not resolve", func(t *testing.T) {
+		t.Parallel()
+
+		// The role is absent, so nothing can grant-check it.  Waving the
+		// addition through would also break the victim's whole organization
+		// ACL, which fails closed on a dangling reference — a denial primitive
+		// for anyone holding users update.
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			newGlobalUser(userAliceID, userAliceSubject),
+			newOrganizationUser(orgUserAliceID, userAliceID),
+			newRadarGroup(groupAlphaID, nil, nil),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Update}},
+			{Name: "radar:things", Operations: openapi.AclOperations{openapi.Read}},
+		})
+
+		request := &openapi.UserWrite{
+			Spec: openapi.UserSpec{
+				Subject:  userAliceSubject,
+				State:    openapi.Active,
+				GroupIDs: openapi.GroupIDs{groupAlphaID},
+			},
+		}
+
+		_, err := fixture.usersClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), orgUserAliceID, request)
+		require.Error(t, err)
+		require.True(t, errors.IsForbidden(err))
+		assert.Contains(t, err.Error(), radarRoleID, "the error must name the role that cannot be resolved")
+
+		alphaGroup := getGroup(ctx, t, fixture.client, groupAlphaID)
+		assert.Empty(t, alphaGroup.Spec.UserIDs)
+		assert.Empty(t, alphaGroup.Spec.Subjects)
+	})
+}
+
+// TestClient_GroupMembershipUnknownGroup covers a requested group the organization does
+// not have.  Reconciliation walks the groups that exist and matches the request against
+// them, so an ID that matches nothing used to fall through every branch: the caller got a
+// 200 whose body simply did not mention the group it asked for.
+func TestClient_GroupMembershipUnknownGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("refuses an update naming a group that does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			newGlobalUser(userAliceID, userAliceSubject),
+			newOrganizationUser(orgUserAliceID, userAliceID),
+			newPlainGroup(groupAlphaID),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Update}},
+		})
+
+		request := &openapi.UserWrite{
+			Spec: openapi.UserSpec{
+				Subject:  userAliceSubject,
+				State:    openapi.Active,
+				GroupIDs: openapi.GroupIDs{groupAlphaID, "group-that-does-not-exist"},
+			},
+		}
+
+		_, err := fixture.usersClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), orgUserAliceID, request)
+		require.Error(t, err)
+		require.True(t, errors.IsBadRequest(err))
+		assert.Contains(t, err.Error(), "group-that-does-not-exist")
+
+		// The check runs in the pre-pass, so the membership the request would
+		// also have applied has not landed either.
+		alphaGroup := getGroup(ctx, t, fixture.client, groupAlphaID)
+		assert.Empty(t, alphaGroup.Spec.UserIDs)
+	})
+
+	t.Run("refuses a create naming a group that does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			newPlainGroup(groupAlphaID),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Create}},
+		})
+
+		request := &openapi.UserWrite{
+			Spec: openapi.UserSpec{
+				Subject:  userAliceSubject,
+				State:    openapi.Active,
+				GroupIDs: openapi.GroupIDs{"group-that-does-not-exist"},
+			},
+		}
+
+		_, err := fixture.usersClient.Create(ctx, ids.MustParseOrganizationID(testOrgID), request)
+		require.Error(t, err)
+		require.True(t, errors.IsBadRequest(err))
+		assert.Contains(t, err.Error(), "group-that-does-not-exist")
+
+		globalUsers := &unikornv1.UserList{}
+		require.NoError(t, fixture.client.List(ctx, globalUsers, &client.ListOptions{Namespace: testNamespace}))
+		assert.Empty(t, globalUsers.Items, "a refused create must not leave a global user behind")
+	})
+}
+
+// TestClient_GroupMembershipRepresentations covers the two ways a group stores a member.
+// RBAC resolves a principal into a group through either the deprecated organization user
+// ID list or the subject list, so a member present in one already holds the group's roles
+// and writing the other half grants nothing.
+func TestClient_GroupMembershipRepresentations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allows completing the subject half for a member already in the legacy user ID list", func(t *testing.T) {
+		t.Parallel()
+
+		// A group written before Subjects existed lists its members in UserIDs
+		// only.  RBAC resolves membership through either list, so the user
+		// already holds the group's roles and writing the missing half confers
+		// nothing — it must not be gated on a role the caller cannot grant.
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			newGlobalUser(userAliceID, userAliceSubject),
+			newOrganizationUser(orgUserAliceID, userAliceID),
+			radarRole(),
+			newRadarGroup(groupAlphaID, []string{orgUserAliceID}, nil),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Update}},
+		})
+
+		request := &openapi.UserWrite{
+			Spec: openapi.UserSpec{
+				Subject:  userAliceSubject,
+				State:    openapi.Active,
+				GroupIDs: openapi.GroupIDs{groupAlphaID},
+			},
+		}
+
+		_, err := fixture.usersClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), orgUserAliceID, request)
+		require.NoError(t, err)
+
+		alphaGroup := getGroup(ctx, t, fixture.client, groupAlphaID)
+		assert.Equal(t, []string{orgUserAliceID}, alphaGroup.Spec.UserIDs)
+		require.Len(t, alphaGroup.Spec.Subjects, 1)
+		assert.Equal(t, userAliceSubject, alphaGroup.Spec.Subjects[0].ID)
+	})
+
+	t.Run("does not duplicate a stored subject whose email differs from the derived one", func(t *testing.T) {
+		t.Parallel()
+
+		// Email is display data and three writers populate it differently, so a
+		// whole-struct comparison sees the stored subject and the derived one as
+		// different principals and appends a second copy on every write.
+		stored := unikornv1.GroupSubject{
+			ID:     userAliceSubject,
+			Email:  "stale-display@example.com",
+			Issuer: testIssuerURL,
+		}
+
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			newGlobalUser(userAliceID, userAliceSubject),
+			newOrganizationUser(orgUserAliceID, userAliceID),
+			radarRole(),
+			newRadarGroup(groupAlphaID, []string{orgUserAliceID}, []unikornv1.GroupSubject{stored}),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Update}},
+		})
+
+		request := &openapi.UserWrite{
+			Spec: openapi.UserSpec{
+				Subject:  userAliceSubject,
+				State:    openapi.Active,
+				GroupIDs: openapi.GroupIDs{groupAlphaID},
+			},
+		}
+
+		_, err := fixture.usersClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), orgUserAliceID, request)
+		require.NoError(t, err)
+
+		alphaGroup := getGroup(ctx, t, fixture.client, groupAlphaID)
+		assert.Len(t, alphaGroup.Spec.Subjects, 1, "the same principal must not be stored twice")
+		assert.Equal(t, []string{orgUserAliceID}, alphaGroup.Spec.UserIDs)
+	})
+}
+
 func TestClient_Delete(t *testing.T) {
 	t.Parallel()
 
@@ -497,5 +1011,48 @@ func TestClient_Delete(t *testing.T) {
 		alphaGroup := getGroup(ctx, t, fixture.client, groupAlphaID)
 		assert.NotContains(t, alphaGroup.Spec.UserIDs, orgUserBobID)
 		assert.NotContains(t, alphaGroup.Spec.Subjects, subject)
+	})
+}
+
+// TestClient_GroupMembershipWriteOrdering covers what a refusal must leave behind.  An
+// update rewrites the organization user record as well as reconciling group membership,
+// so the grants have to be settled before any of it lands.
+func TestClient_GroupMembershipWriteOrdering(t *testing.T) {
+	t.Parallel()
+
+	t.Run("refuses an update joining an ungrantable group without persisting the state change", func(t *testing.T) {
+		t.Parallel()
+
+		// Update rewrites the organization user record — state, tags, labels,
+		// annotations — as well as reconciling groups.  A membership refusal
+		// discovered after that would leave the state change applied for a
+		// request the caller was told it could not make.
+		fixture := newUserTestFixtureWithObjects(t, []client.Object{
+			newGlobalUser(userAliceID, userAliceSubject),
+			newOrganizationUser(orgUserAliceID, userAliceID),
+			radarRole(),
+			newRadarGroup(groupAlphaID, nil, nil),
+		}, interceptor.Funcs{})
+
+		ctx := aclContext(t, openapi.AclEndpoints{
+			{Name: "identity:users", Operations: openapi.AclOperations{openapi.Update}},
+		})
+
+		request := &openapi.UserWrite{
+			Spec: openapi.UserSpec{
+				Subject:  userAliceSubject,
+				State:    openapi.Suspended,
+				GroupIDs: openapi.GroupIDs{groupAlphaID},
+			},
+		}
+
+		_, err := fixture.usersClient.Update(ctx, ids.MustParseOrganizationID(testOrgID), orgUserAliceID, request)
+		require.Error(t, err)
+		require.True(t, errors.IsForbidden(err))
+
+		organizationUser := &unikornv1.OrganizationUser{}
+		require.NoError(t, fixture.client.Get(ctx, client.ObjectKey{Namespace: testOrgNS, Name: orgUserAliceID}, organizationUser))
+		assert.Equal(t, unikornv1.UserStateActive, organizationUser.Spec.State,
+			"a refused update must not persist the state change")
 	})
 }

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -192,7 +192,8 @@ The always-on, runtime control is the issuer-qualified `(srcIss, subject)` match
 - ACL intersection for impersonated system-account calls is deliberate least-privilege behaviour.
 - Service accounts are organization-bound and their scoped access must remain consistent with that
   binding.
-- Group membership is the main route from actors to roles.
+- Group membership is the main route from actors to roles, so writing a membership is itself a
+  grant and is bounded by the writer's own effective permissions.
 - The ACL output is both an enforcement artifact and a visibility artifact, so incorrect ACL
   construction affects both authorization and UX.
 - Platform-administrator matching is always issuer-qualified at runtime via `(srcIss, subject)`.
@@ -220,8 +221,9 @@ The always-on, runtime control is the issuer-qualified `(srcIss, subject)` match
   organization, then global authority — not flattened to an organization-only check).
   Granting a service's endpoints to a lower role such as `user` or `reader` *without also
   granting them to every role above it in the grant lattice* — `administrator` for any
-  operation, and `auditor` for reads — silently makes that lower role non-grantable and
-  invisible to those roles. Any new endpoint added to a role in
+  operation, and `auditor` for reads — makes that lower role non-grantable by those roles.
+  It stays visible: `GET /roles` returns it with `grantable: false`, so a caller can still
+  resolve and display it, it just cannot put it on a group. Any new endpoint added to a role in
   `charts/identity/values.yaml` must be added to every role that should be able to grant
   it, not just the leaf roles that consume it. `TestBuiltinRoleGrantability` enforces this
   over the parsed chart values.
@@ -229,7 +231,12 @@ The always-on, runtime control is the issuer-qualified `(srcIss, subject)` match
   a group's full `RoleIDs` on every write: `pkg/handler/groups` grant-checks a role being
   added, leaves an already-present role unchecked, and separately requires grant authority to
   drop a role from the group. Create has no prior state, so every role in the request counts
-  as an addition. The guard test suite covers more than the four built-ins: `loadChartRoles`
+  as an addition. Membership is grant-checked against the group's whole role set rather than a
+  delta, because a new member inherits all of it: adding a user, subject or service account to a
+  group requires grant authority over every role that group carries, whether the write arrives
+  through `pkg/handler/groups`, `pkg/handler/users` or `pkg/handler/serviceaccounts`. Removals
+  and principal deletion revoke rather than confer, so they are not gated.
+  The guard test suite covers more than the four built-ins: `loadChartRoles`
   merges any `additionalRoles` chart entry into the role set under test, so
   `TestBuiltinRoleGrantability` requires every non-protected role — `additionalRoles`
   included — to have declared grant relationships, and `TestNonBuiltinRolesAdminGrantable`

--- a/pkg/rbac/groups_test.go
+++ b/pkg/rbac/groups_test.go
@@ -102,7 +102,29 @@ func newContext(t *testing.T) context.Context {
 		Actor: "test-principal",
 	})
 
-	return ctx
+	return rbac.NewContext(ctx, seedingACL())
+}
+
+// seedingACL grants every permission carried by the roles in this file's fixture groups,
+// at the scope the grant check needs.  The users handler treats adding someone to a group
+// as granting that group's roles, so the seeding calls below need an authority that holds
+// all of them; these tests are about the ACL the seeded state produces, not about who may
+// seed it.
+func seedingACL() *openapi.Acl {
+	global := openapi.AclEndpoints{
+		{Name: "users:manage", Operations: openapi.AclOperations{openapi.Create, openapi.Read, openapi.Update, openapi.Delete}},
+	}
+
+	organization := openapi.AclEndpoints{
+		{Name: "org:manage", Operations: openapi.AclOperations{openapi.Create, openapi.Read, openapi.Update, openapi.Delete}},
+		{Name: "org:read", Operations: openapi.AclOperations{openapi.Read}},
+		{Name: "project:deploy", Operations: openapi.AclOperations{openapi.Create, openapi.Update}},
+		{Name: "project:read", Operations: openapi.AclOperations{openapi.Read}},
+	}
+
+	organizations := openapi.AclOrganizationList{{Id: testOrgID, Endpoints: &organization}}
+
+	return &openapi.Acl{Global: &global, Organizations: &organizations}
 }
 
 func createUser(t *testing.T, c client.Client, id, subject string, groups []*unikornv1.Group) {

--- a/pkg/rbac/handler.go
+++ b/pkg/rbac/handler.go
@@ -303,17 +303,31 @@ func AllowProjectScopeCreate(ctx context.Context, client openapi.ClientWithRespo
 //
 // Trust assumption: accepting a permission held in *any* one of the caller's projects is
 // only safe because a granted role cannot take effect in a project the caller does not
-// already administer. Two surrounding invariants enforce that and must be preserved:
+// already administer. Every route that turns an AllowRole result into stored authority is
+// entered behind an organization-scope check that project-scoped authority cannot satisfy,
+// and linking the resulting authority to a project needs authority over that project
+// specifically. The authority-conferring routes are:
 //
-//   - group create/update (the only path to AllowRole via validateRoleIDs) requires
-//     organization-scope identity:groups write, which project-scoped authority cannot
-//     satisfy; and
+//   - group create and update reach AllowRole through validateRoleIDs, and update also
+//     through validateMemberAdditions when it adds a member, behind organization-scope
+//     identity:groups write;
+//   - user create/update reaches it through AllowGroupMembershipAddition when the write
+//     puts the user in a group, behind organization-scope identity:users write;
+//   - service account create/update reaches it the same way, behind organization-scope
+//     identity:serviceaccounts write; and
 //   - linking a group to an existing project requires project-scope identity:projects
 //     update for that specific project.
 //
-// If a role ever grants identity:groups write at project scope, or project-group linking
-// is relaxed to organization scope, this "any project" acceptance would become a
-// cross-project escalation and must be tightened to a specific target project.
+// Read-only and revocation callers reach AllowRole too — the roles list uses it to compute
+// the grantable flag behind identity:roles read, and group update uses it in
+// validateRoleRemovals to decide whether a role may be dropped. Those confer nothing, so
+// the reasoning above does not depend on enumerating them; a new caller only has to be
+// weighed against it if it stores authority.
+//
+// If a role ever grants identity:groups, identity:users or identity:serviceaccounts write
+// at project scope, or project-group linking is relaxed to organization scope, this "any
+// project" acceptance would become a cross-project escalation and must be tightened to a
+// specific target project.
 func allowGrantProjectScope(ctx context.Context, endpoint string, operation openapi.AclOperation, organizationID ids.OrganizationID) error {
 	if AllowOrganizationScopeID(ctx, endpoint, operation, organizationID) == nil {
 		return nil

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -161,8 +161,12 @@ type groupSubjectFilterGetter func(id string) func(unikornv1.Group) bool
 func (r *RBAC) groupSubjectFilter(ctx context.Context, subject string) func(unikornv1.Group) bool {
 	return func(group unikornv1.Group) bool {
 		if slices.ContainsFunc(group.Spec.Subjects, func(s unikornv1.GroupSubject) bool {
-			// The issuer is not validated here. All subjects are expected to have an empty issuer.
-			// See updateGroups in handler/users/client.go.
+			// The issuer is deliberately ignored: records written before
+			// subject issuers existed carry an empty one, while the users and
+			// groups handlers now write the deployment's issuer URL, and both
+			// forms must keep resolving.  The membership grant gates match the
+			// same way (see GroupSpec.HasMemberByID); if this ever becomes
+			// issuer-qualified, they must move with it.
 			return s.ID == subject
 		}) {
 			return false

--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -822,6 +822,34 @@ func (c *APIClient) UpdateUser(ctx context.Context, orgID, userID string, user i
 		c, ctx, c.endpoints.GetUser(orgID, userID), userID, "user", user)
 }
 
+// UpdateUserWithResponse updates a user and returns the generated response
+// struct.  UpdateUser collapses everything but success into an error, so use
+// this where a test needs the rejection itself: the status code and the typed
+// error body (JSON403, JSON404, ...).
+func (c *APIClient) UpdateUserWithResponse(ctx context.Context, orgID, userID string, user identityopenapi.UserWrite) (*identityopenapi.PutApiV1OrganizationsOrganizationIDUsersUserIDResponse, error) {
+	client, err := c.generated()
+	if err != nil {
+		return nil, err
+	}
+
+	organizationID, err := ids.ParseOrganizationID(orgID)
+	if err != nil {
+		return nil, fmt.Errorf("parsing organization ID %q: %w", orgID, err)
+	}
+
+	id, err := ids.ParseUserID(userID)
+	if err != nil {
+		return nil, fmt.Errorf("parsing user ID %q: %w", userID, err)
+	}
+
+	response, err := client.PutApiV1OrganizationsOrganizationIDUsersUserIDWithResponse(ctx, organizationID, id, user)
+	if err != nil {
+		return nil, fmt.Errorf("updating user: %w", err)
+	}
+
+	return response, nil
+}
+
 // DeleteUser deletes a user from an organization.
 func (c *APIClient) DeleteUser(ctx context.Context, orgID, userID string) error {
 	path := c.endpoints.GetUser(orgID, userID)

--- a/test/api/k8s.go
+++ b/test/api/k8s.go
@@ -77,11 +77,10 @@ func OrganizationNamespace(ctx context.Context, cli client.Client, identityNames
 	return org.Status.Namespace, nil
 }
 
-// AddGroupMember writes a user onto a Group custom resource directly.  The
-// groups API refuses to add a member to a group carrying a role the caller
-// cannot grant, because joining the group would confer that role, so a spec
-// that needs to start from "the member is already there" has to seed it out of
-// band.
+// AddGroupMember writes a user onto a Group custom resource directly.  The API
+// refuses to add a member to a group carrying a role the caller cannot grant,
+// because joining the group would confer that role, so a spec that needs to
+// start from "the member is already there" has to seed it out of band.
 func AddGroupMember(ctx context.Context, cli client.Client, namespace, groupID, userID string) error {
 	group := &unikornv1.Group{}
 

--- a/test/api/suites/group_membership_test.go
+++ b/test/api/suites/group_membership_test.go
@@ -22,6 +22,7 @@ package suites
 
 import (
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -85,10 +86,29 @@ func groupUserIDs(group *identityopenapi.GroupRead) []string {
 	return *group.Spec.UserIDs
 }
 
+// readUser returns the organization user record, which carries the subject and
+// the group memberships a user write has to resend to leave them intact.
+func readUser(userID string) identityopenapi.UserRead {
+	GinkgoHelper()
+
+	users, err := client.ListUsers(ctx, config.OrgID)
+	Expect(err).NotTo(HaveOccurred())
+
+	for i := range users {
+		if users[i].Metadata.Id == userID {
+			return users[i]
+		}
+	}
+
+	Fail("user " + userID + " is not a member of the test organization")
+
+	return identityopenapi.UserRead{}
+}
+
 // seedGroupMember puts a user into the group out of band and waits for the API
 // to observe it.  Adding a member through the API is a grant of the group's
-// roles and is refused here by design, so removal specs have to start from
-// state the API would not create.
+// roles and is refused here by design, on the groups path and the users path
+// alike, so removal specs have to start from state the API would not create.
 func seedGroupMember(kube kubeclient.Client, orgNamespace, groupID, userID string) {
 	GinkgoHelper()
 
@@ -314,6 +334,60 @@ var _ = Describe("Group role and membership changes with ungrantable roles", fun
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updated.Metadata.Id).To(Equal(groupID))
 				Expect(updated.Metadata.Name).To(Equal(groupName))
+			})
+
+			It("should refuse joining the group through the users API, naming the role", func() {
+				user := readUser(config.UserID)
+
+				payload := api.NewUserPayload().
+					WithSubject(user.Spec.Subject).
+					WithState(user.Spec.State).
+					WithGroupIDs(append(slices.Clone(user.Spec.GroupIDs), groupID)).
+					Build()
+
+				response, err := client.UpdateUserWithResponse(ctx, config.OrgID, config.UserID, payload)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response.StatusCode()).To(Equal(http.StatusForbidden))
+				Expect(response.JSON403).NotTo(BeNil(),
+					"a refusal must come back as a typed forbidden response")
+				Expect(response.JSON403.Error).To(Equal(coreopenapi.Forbidden))
+				Expect(response.JSON403.ErrorDescription).To(ContainSubstring(roleID),
+					"the error must name the role that blocked the addition")
+				Expect(response.JSON403.ErrorDescription).To(ContainSubstring(roleName),
+					"the error must give the role's display name, not only its ID")
+				Expect(response.JSON403.ErrorDescription).To(ContainSubstring("members cannot be added to the group"),
+					"the membership guard must be the one that refused, not the role grant or removal guard")
+
+				stored := readGroupResource(kube, orgNamespace, groupID)
+				Expect(stored.Spec.UserIDs).To(BeEmpty(),
+					"a refused user write must leave the group untouched")
+				Expect(stored.Spec.Subjects).To(BeEmpty())
+
+				GinkgoWriter.Printf("Refused user-path member addition: %s\n", response.JSON403.ErrorDescription)
+			})
+
+			It("should allow leaving the group through the users API", func() {
+				// Read the memberships before seeding, so resending them is a
+				// write that drops the fixture group and nothing else.
+				user := readUser(config.UserID)
+
+				seedGroupMember(kube, orgNamespace, groupID, config.UserID)
+
+				payload := api.NewUserPayload().
+					WithSubject(user.Spec.Subject).
+					WithState(user.Spec.State).
+					WithGroupIDs(slices.Clone(user.Spec.GroupIDs)).
+					Build()
+
+				updated, err := client.UpdateUser(ctx, config.OrgID, config.UserID, payload)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updated.Metadata.Id).To(Equal(config.UserID))
+				Expect(updated.Spec.GroupIDs).NotTo(ContainElement(groupID),
+					"the user must no longer report the group it just left")
+
+				// Leaving confers nothing, so nothing gates it on the group's
+				// roles: the membership really is gone from the group.
+				expectGroupEmptiedOfMembers(groupID, roleID)
 			})
 		})
 	})


### PR DESCRIPTION
Fourth and final PR splitting the group-permission work ([ID-368](https://linear.app/nscale-workspace/issue/ID-368/clarify-permission-management-for-group-membership)). **Stacked on #529** — review #527, #528 and #529 first; the base retargets as each merges.

This one also closes acceptance criterion 1 of [ID-367](https://linear.app/nscale-workspace/issue/ID-367/nvidia-bug-revoke-elevated-access-after-role-downgrade).

## Problem

#529 established that adding a member to a group confers that group's roles, and gated it — on the groups path. Two other paths write group membership and had **no grant check at all**:

- `PUT /users/{id}` reconciles a requested `groupIDs` list into membership.
- Service-account create and update do the same, and a service account carries a long-lived bearer token whose authority is independent of whoever created it. A user whose own authority is being reduced could mint one attached to a group they could not grant, and the token outlives the downgrade.

Both also wrote before they authorized: a refused request had already persisted its other changes.

## Change

- **The same gate on both paths.** Every group the principal would newly join is checked against the caller's authority; a refusal names the blocking role. Removals are not gated, and principal deletion is exempt — it strips memberships as cleanup, and gating it would make a principal sitting in a group with ungrantable roles undeletable.
- **Validate then apply.** Authorization for a multi-group write is settled before the first patch, so a refusal applies nothing.
- **Validate before persisting.** `users.Create` no longer writes the global user or organization user, and service-account create no longer creates the account or issues its token, until authorization has passed. Both paths are idempotent and reuse existing records, so the pre-flight resolves what the principal already has without creating it and exempts memberships they already hold — a legitimate re-create is not refused.
- **Unknown group IDs are refused.** A requested group that does not exist in the organization was silently dropped from the write and reported as success; it is now an explicit error.
- **Service-account responses report the groups actually joined**, rather than a pre-write snapshot.
- **`pkg/rbac/handler.go`'s trust note is corrected.** It justifies the grant lattice's laxest rule — accepting a project-scoped permission held in *any* of the caller's projects — on an enumeration of every route to `AllowRole`. This stack adds routes; the enumeration is now complete and each entry's organization-scope check is named, so the recorded security reasoning is true when the stack lands.

## Compatibility

No CRD schema changes, no migration.

Release notes:

- **Member additions on `PUT /users/{id}` and service-account create/update now require the caller to hold the group's roles.** These paths were unguarded, so any org relying on that will see new 403s. The error names the blocking role.
- **An unknown group ID in a request is now 400 rather than a silent success.** This is a compatibility break beyond the security fix and is called out deliberately: clients previously got a 200 and a response body that quietly omitted the group.

## Testing

- Unit: 23 new subtests across users, service accounts and the shared helper — refusal named, removal allowed, roleless group allowed, holder allowed, multi-group atomicity (nothing applied on refusal), no principal or service account persisted when a create is refused, idempotent re-create still permitted, unknown group refused.
- Integration, against a live deployment: joining a group with an ungrantable role through the users API is refused naming the role; leaving it is allowed.
- Full suite measured against a `main` baseline on the same cluster: the branch's failures are a strict subset of the baseline's — zero new failures. Those baseline failures are a broken `USER_AUTH_TOKEN` fixture on that cluster, unrelated to any branch and worth its own ticket.

## Known limitation, stated rather than hidden

These paths are atomic against *refusals* — authorization is fully settled before the first write — but not against infrastructure failures partway through a multi-write request. That is pre-existing and now documented in the package READMEs rather than left implicit.
