### PR TITLE
Register block storage capacity quota

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ cover.out
 cover.html
 identity-render.yaml
 .codex
+/docs/superpowers/
 
 # Test artifacts
 test/.env

--- a/charts/identity/templates/quotametadata.yaml
+++ b/charts/identity/templates/quotametadata.yaml
@@ -4,8 +4,12 @@ apiVersion: identity.unikorn-cloud.org/v1alpha1
 kind: QuotaMetadata
 metadata:
   name: {{ $name }}
+  {{- with $metadata.kind }}
+  annotations:
+    identity.unikorn-cloud.org/quota-kind: {{ . | quote }}
+  {{- end }}
   labels:
     {{- include "unikorn.labels" $ | nindent 4 }}
 spec:
-  {{- toYaml $metadata | nindent 2 }}
+  {{- toYaml (omit $metadata "kind") | nindent 2 }}
 {{- end }}

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -431,6 +431,11 @@ quotas:
     description: Persistent network file storage.
     default: 1Ti
     format: binary
+  volumegib:
+    kind: volumeGiB
+    displayName: Volume Capacity
+    description: Total requested block storage capacity in GiB.
+    default: 0
 
 ingress:
   # Sets the ingress class to use.

--- a/pkg/apis/unikorn/v1alpha1/README.md
+++ b/pkg/apis/unikorn/v1alpha1/README.md
@@ -34,6 +34,14 @@ machinery also implement helper behaviour such as:
 The schema/helper mix is by design. The package is part of the common contract that lets
 the controller layer in `core` handle resources generically.
 
+## Quota Metadata Kinds
+
+The `QuotaMetadata` resource name is normally the quota kind used by allocation clients. Block
+storage is the exception: its built-in metadata object is named `volumegib`, following the compact
+lowercase style of the catalogue, and identity exposes it as the ticket-defined public kind
+`volumeGiB`. The chart marks that built-in object with the public-kind annotation, so an existing
+custom `volumegib` or `volume-gib` object without the marker keeps its original meaning.
+
 ## Scoping Model
 
 Kubernetes namespace layout and platform tenancy are separate concerns.

--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -28,9 +28,30 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+const (
+	quotaKindAnnotation        = "identity.unikorn-cloud.org/quota-kind"
+	volumeGiBQuotaMetadataName = "volumegib"
+	volumeGiBQuotaKind         = "volumeGiB"
+)
+
 var (
 	ErrReference = errors.New("resource reference error")
 )
+
+// ResourceKind returns the quota kind exposed to allocation clients.
+func (q *QuotaMetadata) ResourceKind() string {
+	kind := q.Annotations[quotaKindAnnotation]
+	if IsQuotaKindAlias(q.Name, kind) {
+		return kind
+	}
+
+	return q.Name
+}
+
+// IsQuotaKindAlias reports whether a metadata name maps to a distinct public quota kind.
+func IsQuotaKindAlias(metadataName, kind string) bool {
+	return metadataName == volumeGiBQuotaMetadataName && kind == volumeGiBQuotaKind
+}
 
 // Paused implements the ReconcilePauser interface.
 func (c *OAuth2Client) Paused() bool {

--- a/pkg/handler/common/common.go
+++ b/pkg/handler/common/common.go
@@ -150,10 +150,22 @@ func (c *Client) GetQuota(ctx context.Context, organizationID ids.OrganizationID
 	names := make([]string, len(metadata.Items))
 
 	for i, meta := range metadata.Items {
-		names[i] = meta.Name
+		kind := meta.ResourceKind()
+		names[i] = kind
+
+		if kind != meta.Name && slices.ContainsFunc(quota.Spec.Quotas, func(q unikornv1.ResourceQuota) bool {
+			return q.Kind == meta.Name
+		}) {
+			return nil, false, fmt.Errorf(
+				"%w: existing quota kind %q conflicts with built-in %q; migrate the quota before enabling the built-in kind",
+				coreerrors.ErrConsistency,
+				meta.Name,
+				kind,
+			)
+		}
 
 		findQuota := func(q unikornv1.ResourceQuota) bool {
-			return q.Kind == meta.Name
+			return q.Kind == kind
 		}
 
 		if index := slices.IndexFunc(quota.Spec.Quotas, findQuota); index >= 0 {
@@ -161,7 +173,7 @@ func (c *Client) GetQuota(ctx context.Context, organizationID ids.OrganizationID
 		}
 
 		quota.Spec.Quotas = append(quota.Spec.Quotas, unikornv1.ResourceQuota{
-			Kind:     meta.Name,
+			Kind:     kind,
 			Quantity: meta.Spec.Default,
 		})
 	}
@@ -253,7 +265,18 @@ func checkQuotaConsistency(quota *unikornv1.Quota, allocations *unikornv1.Alloca
 	}
 
 	for k, v := range totals {
-		if capacity, ok := capacities[k]; ok && v > capacity {
+		capacity, ok := capacities[k]
+		if !ok {
+			for kind := range capacities {
+				if unikornv1.IsQuotaKindAlias(k, kind) {
+					return fmt.Errorf("%w: allocation kind %q has no matching quota", coreerrors.ErrConsistency, k)
+				}
+			}
+
+			continue
+		}
+
+		if v > capacity {
 			// NOTE: AI has given the options as 403 (forbidden), 402 (payment required)
 			// and 507 (insufficient storage).  403 with a good error message is the
 			// most prevalent.

--- a/pkg/handler/common/quota_test.go
+++ b/pkg/handler/common/quota_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:revive,paralleltest // Dot imports and serial suite entry points are standard for Ginkgo.
+package common_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/unikorn-cloud/core/pkg/constants"
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/identity/pkg/handler/common"
+	"github.com/unikorn-cloud/identity/pkg/ids"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	quotaChartValuesPath    = "../../../charts/identity/values.yaml"
+	quotaTestOrganizationID = "00000000-0000-4000-8000-000000000001"
+)
+
+type chartQuota struct {
+	Default any    `json:"default"`
+	Kind    string `json:"kind"`
+}
+
+type quotaChartValues struct {
+	Quotas map[string]chartQuota `json:"quotas"`
+}
+
+func TestQuotaMetadata(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Quota Metadata Suite")
+}
+
+func newQuotaMetadata(name, displayName, description string, defaultQuantity int64) *unikornv1.QuotaMetadata {
+	return &unikornv1.QuotaMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "identity",
+		},
+		Spec: unikornv1.QuotaMetadataSpec{
+			DisplayName: displayName,
+			Description: description,
+			Default:     resource.NewQuantity(defaultQuantity, resource.DecimalSI),
+		},
+	}
+}
+
+func newQuotaMetadataClient(metadata ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	Expect(unikornv1.AddToScheme(scheme)).To(Succeed())
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(metadata...).
+		Build()
+}
+
+func loadQuotaChartValues() quotaChartValues {
+	raw, err := os.ReadFile(filepath.Clean(quotaChartValuesPath))
+	Expect(err).NotTo(HaveOccurred())
+
+	var values quotaChartValues
+
+	Expect(yaml.Unmarshal(raw, &values)).To(Succeed())
+	Expect(values.Quotas).NotTo(BeEmpty())
+
+	return values
+}
+
+var _ = Describe("Quota metadata", func() {
+	Context("When resolving the default organization quota", func() {
+		Describe("Given the compact lowercase block storage kind", func() {
+			It("uses the public kind in the quota contract", func(ctx SpecContext) {
+				metadata := newQuotaMetadata(
+					"volumegib",
+					"Volume Capacity",
+					"Total requested block storage capacity in GiB.",
+					0,
+				)
+				metadata.Annotations = map[string]string{
+					"identity.unikorn-cloud.org/quota-kind": "volumeGiB",
+				}
+				client := newQuotaMetadataClient(metadata)
+
+				quota, virtual, err := common.New(client).GetQuota(ctx, ids.MustParseOrganizationID(quotaTestOrganizationID))
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(virtual).To(BeTrue())
+				Expect(quota.Spec.Quotas).To(HaveLen(1))
+				Expect(quota.Spec.Quotas[0].Kind).To(Equal("volumeGiB"))
+				Expect(quota.Spec.Quotas[0].Quantity.Value()).To(BeZero())
+			})
+		})
+
+		Describe("Given an existing custom volume-gib quota kind", func() {
+			It("preserves the existing quota contract", func(ctx SpecContext) {
+				metadata := newQuotaMetadata("volume-gib", "Custom Volume Capacity", "Custom quota.", 500)
+				client := newQuotaMetadataClient(metadata)
+
+				quota, virtual, err := common.New(client).GetQuota(ctx, ids.MustParseOrganizationID(quotaTestOrganizationID))
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(virtual).To(BeTrue())
+				Expect(quota.Spec.Quotas).To(HaveLen(1))
+				Expect(quota.Spec.Quotas[0].Kind).To(Equal("volume-gib"))
+				Expect(quota.Spec.Quotas[0].Quantity.Value()).To(Equal(int64(500)))
+			})
+		})
+
+		Describe("Given an existing custom volumegib quota kind", func() {
+			It("preserves the existing quota contract", func(ctx SpecContext) {
+				metadata := newQuotaMetadata("volumegib", "Custom Volume Capacity", "Custom quota.", 500)
+				client := newQuotaMetadataClient(metadata)
+
+				quota, virtual, err := common.New(client).GetQuota(ctx, ids.MustParseOrganizationID(quotaTestOrganizationID))
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(virtual).To(BeTrue())
+				Expect(quota.Spec.Quotas).To(HaveLen(1))
+				Expect(quota.Spec.Quotas[0].Kind).To(Equal("volumegib"))
+				Expect(quota.Spec.Quotas[0].Quantity.Value()).To(Equal(int64(500)))
+			})
+		})
+
+		Describe("Given stored custom volumegib quota state when the built-in marker appears", func() {
+			It("fails closed instead of replacing the existing limit", func(ctx SpecContext) {
+				metadata := newQuotaMetadata("volumegib", "Volume Capacity", "Block storage capacity.", 0)
+				metadata.Annotations = map[string]string{
+					"identity.unikorn-cloud.org/quota-kind": "volumeGiB",
+				}
+				stored := &unikornv1.Quota{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "organization-quota",
+						Namespace: "organization",
+						Labels: map[string]string{
+							constants.OrganizationLabel: quotaTestOrganizationID,
+						},
+					},
+					Spec: unikornv1.QuotaSpec{
+						Quotas: []unikornv1.ResourceQuota{
+							{
+								Kind:     "volumegib",
+								Quantity: resource.NewQuantity(500, resource.DecimalSI),
+							},
+						},
+					},
+				}
+				client := newQuotaMetadataClient(metadata, stored)
+
+				quota, virtual, err := common.New(client).GetQuota(ctx, ids.MustParseOrganizationID(quotaTestOrganizationID))
+
+				Expect(err).To(MatchError(ContainSubstring(`existing quota kind "volumegib" conflicts with built-in "volumeGiB"`)))
+				Expect(quota).To(BeNil())
+				Expect(virtual).To(BeFalse())
+			})
+		})
+
+		Describe("Given legacy allocation state without a matching capacity", func() {
+			It("fails closed instead of ignoring the allocation", func(ctx SpecContext) {
+				metadata := newQuotaMetadata("volumegib", "Volume Capacity", "Block storage capacity.", 0)
+				metadata.Annotations = map[string]string{
+					"identity.unikorn-cloud.org/quota-kind": "volumeGiB",
+				}
+				allocation := &unikornv1.Allocation{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "legacy-volume",
+						Namespace: "organization",
+						Labels: map[string]string{
+							constants.OrganizationLabel: quotaTestOrganizationID,
+						},
+					},
+					Spec: unikornv1.AllocationSpec{
+						Allocations: []unikornv1.ResourceAllocation{
+							{
+								Kind:      "volumegib",
+								Committed: resource.NewQuantity(1, resource.DecimalSI),
+								Reserved:  resource.NewQuantity(0, resource.DecimalSI),
+							},
+						},
+					},
+				}
+				client := newQuotaMetadataClient(metadata, allocation)
+
+				err := common.New(client).CheckQuotaConsistency(
+					ctx,
+					ids.MustParseOrganizationID(quotaTestOrganizationID),
+					nil,
+					nil,
+				)
+
+				Expect(err).To(MatchError(ContainSubstring(`allocation kind "volumegib" has no matching quota`)))
+			})
+		})
+
+		Describe("Given an unrelated retired custom allocation kind", func() {
+			It("preserves the existing quota consistency behavior", func(ctx SpecContext) {
+				metadata := newQuotaMetadata("volumegib", "Volume Capacity", "Block storage capacity.", 0)
+				metadata.Annotations = map[string]string{
+					"identity.unikorn-cloud.org/quota-kind": "volumeGiB",
+				}
+				allocation := &unikornv1.Allocation{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "retired-custom-resource",
+						Namespace: "organization",
+						Labels: map[string]string{
+							constants.OrganizationLabel: quotaTestOrganizationID,
+						},
+					},
+					Spec: unikornv1.AllocationSpec{
+						Allocations: []unikornv1.ResourceAllocation{
+							{
+								Kind:      "retired-custom",
+								Committed: resource.NewQuantity(1, resource.DecimalSI),
+								Reserved:  resource.NewQuantity(0, resource.DecimalSI),
+							},
+						},
+					},
+				}
+				client := newQuotaMetadataClient(metadata, allocation)
+
+				err := common.New(client).CheckQuotaConsistency(
+					ctx,
+					ids.MustParseOrganizationID(quotaTestOrganizationID),
+					nil,
+					nil,
+				)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+	})
+
+	Context("When loading the built-in quota catalogue", func() {
+		Describe("Given block storage quota defaults", func() {
+			It("registers only capacity with a zero default", func() {
+				values := loadQuotaChartValues()
+				capacity, ok := values.Quotas["volumegib"]
+
+				Expect(ok).To(BeTrue())
+				Expect(capacity.Default).To(BeNumerically("==", 0))
+				Expect(capacity.Kind).To(Equal("volumeGiB"))
+				Expect(values.Quotas).NotTo(HaveKey("volumes"))
+			})
+		})
+	})
+})

--- a/pkg/handler/quotas/README.md
+++ b/pkg/handler/quotas/README.md
@@ -34,6 +34,22 @@ used, free, committed, and reserved totals.
 
 Without that metadata, the numeric values are not meaningfully usable.
 
+### Built-In Block Storage Kind
+
+The default Helm catalogue registers one quota kind for Region block storage:
+
+| Kind | Meaning | Default |
+|---|---|---:|
+| `volumeGiB` | Total block storage capacity requested by Volumes, measured in GiB | 0 |
+
+`volumeGiB` is a count of GiB units rather than a byte quantity. Region allocation calls therefore
+submit the requested Volume capacity directly in GiB; Volume count is not quota-controlled. The
+zero default denies block storage capacity until an operator overrides it through the chart's
+`quotas` values. Its backing `QuotaMetadata` object is named `volumegib`, following the compact
+lowercase style of the other built-in quota metadata names. A chart-managed annotation maps it to
+the public `volumeGiB` kind required by Region without reinterpreting an unmarked custom
+`volumegib` kind.
+
 ### Missing Internal Partitioning
 
 The main current model gap is that quotas are organization-wide only.
@@ -49,6 +65,8 @@ reporting and dashboard problem.
 - quota reads are derived from stored quota values, quota metadata, and current allocation totals
 - quota updates must not reduce capacity below already committed plus reserved usage
 - `QuotaMetadata` is mandatory contextual data, not optional display garnish
+- stored quota or allocation kinds that would be orphaned by an alias fail with a consistency error
+  instead of being silently retired or ignored
 
 ## Caveats
 

--- a/pkg/handler/quotas/client.go
+++ b/pkg/handler/quotas/client.go
@@ -140,7 +140,7 @@ func (c *Client) convert(ctx context.Context, in *unikornv1.Quota, organizationI
 		quota := &in.Spec.Quotas[i]
 
 		metaIndex := slices.IndexFunc(metadata.Items, func(m unikornv1.QuotaMetadata) bool {
-			return m.Name == quota.Kind
+			return m.ResourceKind() == quota.Kind
 		})
 
 		meta := &metadata.Items[metaIndex]

--- a/test/api/suites/quotas_test.go
+++ b/test/api/suites/quotas_test.go
@@ -39,8 +39,11 @@ var _ = Describe("Quota Management", func() {
 
 				expectedQuotaKinds := []string{"clusters", "servers", "networks", "gpus"}
 				foundCoreQuotas := 0
+				actualQuotaKinds := make([]string, 0, len(quotasResponse.Quotas))
 
 				for _, quota := range quotasResponse.Quotas {
+					actualQuotaKinds = append(actualQuotaKinds, quota.Kind)
+
 					Expect(quota.Kind).NotTo(BeEmpty(), "Quota kind should not be empty")
 					Expect(quota.DisplayName).NotTo(BeEmpty(), "Quota display name should not be empty")
 					Expect(quota.Description).NotTo(BeEmpty(), "Quota description should not be empty")
@@ -50,6 +53,9 @@ var _ = Describe("Quota Management", func() {
 					Expect(quota.Reserved).To(BeNumerically(">=", 0), "Quota reserved should be non-negative")
 					Expect(quota.Committed).To(BeNumerically(">=", 0), "Quota committed should be non-negative")
 					Expect(quota.Default).To(BeNumerically(">=", 0), "Quota default should be non-negative")
+					if quota.Kind == "volumeGiB" {
+						Expect(quota.Default).To(Equal(0), "Block storage capacity should default to denied")
+					}
 
 					totalQuota := quota.Used + quota.Free
 					Expect(totalQuota).To(Equal(quota.Quantity),
@@ -73,6 +79,10 @@ var _ = Describe("Quota Management", func() {
 
 				Expect(foundCoreQuotas).To(BeNumerically(">", 0),
 					"At least one core quota type should be present (clusters, servers, networks, or gpus)")
+				Expect(actualQuotaKinds).To(ContainElement("volumeGiB"),
+					"Block storage capacity quota should be registered")
+				Expect(actualQuotaKinds).NotTo(ContainElement("volumes"),
+					"Volume count should not be a built-in quota kind")
 			})
 		})
 


### PR DESCRIPTION
## Summary

- register `volumeGiB` as the public block-storage capacity quota with built-in default `0`
- use the compact lowercase `volumegib` Helm/Kubernetes metadata name and an explicit public-kind marker
- omit Volume count from the built-in quota contract; no `volumes` kind is registered
- preserve unmarked custom `volumegib` and `volume-gib` kinds, and fail closed when stored legacy state requires migration
- document and regression-test quota resolution, chart defaults, upgrade compatibility, and API exposure
- remove repository-local Superpowers artifacts and ignore `/docs/superpowers/`

## Testing

- `make touch` — passed
- `make license` — passed
- `make validate` — passed
- `make lint` — passed; 0 Go issues and 1 Helm chart passed
- `make generate` — passed; generated API, client, deepcopy, and CRD artifacts unchanged
- `make test-unit` — passed
- `go test ./...` — passed
- `go test -tags=integration ./test/api/suites -run '^$' -count=1` — passed compilation with no tests run
- `helm template identity charts/identity` — rendered `volumegib`, `volumeGiB` marker, and default `0`; no `volumes`
- independent final review — no Critical or Important findings

Live KinD integration tests were not run.

Linear: STO-117