### PR TITLE
feat(rbac): generic global role bindings replace the platform-admin fast-path (ID-398)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,7 @@ lint: $(GENDIR)
 	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(LINT_VERSION)
 	$(GOBIN)/golangci-lint run ./...
 	helm lint --strict charts/identity
+	./hack/check_chart_render.sh
 
 # Validate the server OpenAPI schema is legit.
 .PHONY: validate

--- a/charts/identity/templates/identity/deployment.yaml
+++ b/charts/identity/templates/identity/deployment.yaml
@@ -43,6 +43,42 @@ spec:
           {{- $systemAccounts = append $systemAccounts (printf "%s=%s" $k (include "resource.id" $v)) }}
         {{- end }}
         - --system-account-roles-ids={{ join "," $systemAccounts }}
+        {{- range $i, $b := .Values.globalRoleBindings }}
+          {{- if not (trim (default "" $b.issuer)) }}
+            {{- fail (printf "globalRoleBindings[%d]: issuer is required" $i) }}
+          {{- end }}
+          {{- if and (hasKey $b "subject") (hasKey $b "subjects") }}
+            {{- fail (printf "globalRoleBindings[%d]: subject and subjects are mutually exclusive" $i) }}
+          {{- end }}
+          {{- $subjects := list }}
+          {{- if hasKey $b "subject" }}
+            {{- $subjects = list $b.subject }}
+          {{- else }}
+            {{- $subjects = default (list) $b.subjects }}
+          {{- end }}
+          {{- if not $subjects }}
+            {{- fail (printf "globalRoleBindings[%d]: exactly one of subject or non-empty subjects required" $i) }}
+          {{- end }}
+          {{- range $si, $subject := $subjects }}
+            {{- if not (trim (default "" $subject)) }}
+              {{- fail (printf "globalRoleBindings[%d].subjects[%d]: empty or whitespace-only subject" $i $si) }}
+            {{- end }}
+          {{- end }}
+          {{- if not $b.roles }}
+            {{- fail (printf "globalRoleBindings[%d]: roles must be non-empty" $i) }}
+          {{- end }}
+          {{- $allRoles := merge (dict) (default (dict) $.Values.roles) (default (dict) $.Values.additionalRoles) }}
+          {{- $roles := list }}
+          {{- range $b.roles }}
+            {{- if not (hasKey $allRoles .) }}
+              {{- fail (printf "globalRoleBindings[%d]: unknown role %q" $i .) }}
+            {{- end }}
+            {{- $roles = append $roles (include "resource.id" .) }}
+          {{- end }}
+          {{- range $subject := $subjects }}
+        - {{ printf "--global-role-binding=%s::%s::%s" $b.issuer $subject (join "," $roles) | quote }}
+          {{- end }}
+        {{- end }}
         {{- range $i, $arg := .Values.server.extraFlags }}
         - {{ $arg }}
         {{- end }}

--- a/charts/identity/templates/identity/deployment.yaml
+++ b/charts/identity/templates/identity/deployment.yaml
@@ -37,6 +37,21 @@ spec:
           {{- $adminRoles = append $adminRoles (include "resource.id" $name) }}
         {{- end }}
         - --platform-administrator-role-ids={{ join "," $adminRoles }}
+        {{- range $i, $s := .Values.platformAdministrators.subjects }}
+          {{- /*
+          The server matches subjects case-sensitively; only the "::"-separated
+          subject part is checked, mirroring how the flag parser splits issuer
+          from subject.
+          */}}
+          {{- $subj := $s }}
+          {{- $cut := splitn "::" 2 $s }}
+          {{- if $cut._1 }}
+            {{- $subj = $cut._1 }}
+          {{- end }}
+          {{- if and (ne $subj "*") (regexMatch "[A-Z]" $subj) }}
+            {{- fail (printf "platformAdministrators.subjects[%d]: subject must be its canonical lower-case form" $i) }}
+          {{- end }}
+        {{- end }}
         - --platform-administrator-subjects={{ join "," .Values.platformAdministrators.subjects }}
         {{- $systemAccounts := list }}
         {{- range $k, $v := .Values.systemAccounts }}
@@ -82,6 +97,9 @@ spec:
             {{- end }}
             {{- if contains "::" $trimmed }}
               {{- fail (printf "globalRoleBindings[%d].subjects[%d]: subject must not contain \"::\"" $i $si) }}
+            {{- end }}
+            {{- if and (ne $trimmed "*") (regexMatch "[A-Z]" $trimmed) }}
+              {{- fail (printf "globalRoleBindings[%d].subjects[%d]: subject must be its canonical lower-case form" $i $si) }}
             {{- end }}
             {{- if and (eq $b.issuer "uni") (eq $trimmed "*") }}
               {{- fail (printf "globalRoleBindings[%d]: wildcard subject not allowed on the UNI sentinel issuer" $i) }}

--- a/charts/identity/templates/identity/deployment.yaml
+++ b/charts/identity/templates/identity/deployment.yaml
@@ -51,11 +51,9 @@ spec:
             {{- fail (printf "globalRoleBindings[%d]: issuer must not contain whitespace" $i) }}
           {{- end }}
           {{- /*
-          The server parses issuer::subject::roles right-anchored on the last
-          two separators, so a "::" anywhere in the issuer or subject silently
-          shifts the boundary. Only the chart still knows the intended split —
-          once the flag string is built the mis-parse is undetectable — so both
-          sides are rejected here rather than in pkg/rbac.
+          Right-anchored parsing means a "::" in either field silently shifts
+          the boundary, undetectably once the flag is built. Reject it here,
+          while the intended split is still known.
           */}}
           {{- if contains "::" $b.issuer }}
             {{- fail (printf "globalRoleBindings[%d]: issuer must not contain \"::\"" $i) }}
@@ -73,10 +71,8 @@ spec:
             {{- fail (printf "globalRoleBindings[%d]: exactly one of subject or non-empty subjects required" $i) }}
           {{- end }}
           {{- /*
-          Trim once, up front: the server trims the subject before matching, so
-          every guard below and the emitted flag must agree on the same value.
-          Guarding the raw string lets a padded " * " slip past the wildcard
-          checks and deploy as a real wildcard binding.
+          Trim before validating and emitting, so a padded " * " cannot slip
+          past the wildcard guards and then match as a wildcard server-side.
           */}}
           {{- $trimmedSubjects := list }}
           {{- range $si, $subject := $subjects }}

--- a/charts/identity/templates/identity/deployment.yaml
+++ b/charts/identity/templates/identity/deployment.yaml
@@ -50,6 +50,16 @@ spec:
           {{- if regexMatch "\\s" $b.issuer }}
             {{- fail (printf "globalRoleBindings[%d]: issuer must not contain whitespace" $i) }}
           {{- end }}
+          {{- /*
+          The server parses issuer::subject::roles right-anchored on the last
+          two separators, so a "::" anywhere in the issuer or subject silently
+          shifts the boundary. Only the chart still knows the intended split —
+          once the flag string is built the mis-parse is undetectable — so both
+          sides are rejected here rather than in pkg/rbac.
+          */}}
+          {{- if contains "::" $b.issuer }}
+            {{- fail (printf "globalRoleBindings[%d]: issuer must not contain \"::\"" $i) }}
+          {{- end }}
           {{- if and (hasKey $b "subject") (hasKey $b "subjects") }}
             {{- fail (printf "globalRoleBindings[%d]: subject and subjects are mutually exclusive" $i) }}
           {{- end }}
@@ -62,13 +72,25 @@ spec:
           {{- if not $subjects }}
             {{- fail (printf "globalRoleBindings[%d]: exactly one of subject or non-empty subjects required" $i) }}
           {{- end }}
+          {{- /*
+          Trim once, up front: the server trims the subject before matching, so
+          every guard below and the emitted flag must agree on the same value.
+          Guarding the raw string lets a padded " * " slip past the wildcard
+          checks and deploy as a real wildcard binding.
+          */}}
+          {{- $trimmedSubjects := list }}
           {{- range $si, $subject := $subjects }}
-            {{- if not (trim (default "" $subject)) }}
+            {{- $trimmed := trim (default "" $subject) }}
+            {{- if not $trimmed }}
               {{- fail (printf "globalRoleBindings[%d].subjects[%d]: empty or whitespace-only subject" $i $si) }}
             {{- end }}
-            {{- if and (eq $b.issuer "uni") (eq $subject "*") }}
+            {{- if contains "::" $trimmed }}
+              {{- fail (printf "globalRoleBindings[%d].subjects[%d]: subject must not contain \"::\"" $i $si) }}
+            {{- end }}
+            {{- if and (eq $b.issuer "uni") (eq $trimmed "*") }}
               {{- fail (printf "globalRoleBindings[%d]: wildcard subject not allowed on the UNI sentinel issuer" $i) }}
             {{- end }}
+            {{- $trimmedSubjects = append $trimmedSubjects $trimmed }}
           {{- end }}
           {{- if not $b.roles }}
             {{- fail (printf "globalRoleBindings[%d]: roles must be non-empty" $i) }}
@@ -87,7 +109,7 @@ spec:
           accumulateGlobalReadPermissions (pkg/rbac/bindings.go); full
           rationale in pkg/rbac/README.md#global-role-bindings.
           */}}
-          {{- if has "*" $subjects }}
+          {{- if has "*" $trimmedSubjects }}
             {{- range $b.roles }}
               {{- $roleName := . }}
               {{- $role := index $allRoles $roleName }}
@@ -102,7 +124,7 @@ spec:
               {{- end }}
             {{- end }}
           {{- end }}
-          {{- range $subject := $subjects }}
+          {{- range $subject := $trimmedSubjects }}
         - {{ printf "--global-role-binding=%s::%s::%s" $b.issuer $subject (join "," $roles) | quote }}
           {{- end }}
         {{- end }}

--- a/charts/identity/templates/identity/deployment.yaml
+++ b/charts/identity/templates/identity/deployment.yaml
@@ -81,6 +81,27 @@ spec:
             {{- end }}
             {{- $roles = append $roles (include "resource.id" .) }}
           {{- end }}
+          {{- /*
+          Render-time guard: a wildcard binding's roles must declare no
+          non-read global operation. Complementary to the runtime clamp in
+          accumulateGlobalReadPermissions (pkg/rbac/bindings.go); full
+          rationale in pkg/rbac/README.md#global-role-bindings.
+          */}}
+          {{- if has "*" $subjects }}
+            {{- range $b.roles }}
+              {{- $roleName := . }}
+              {{- $role := index $allRoles $roleName }}
+              {{- $roleScopes := default (dict) $role.scopes }}
+              {{- $globalScopes := default (dict) $roleScopes.global }}
+              {{- range $scopeName, $ops := $globalScopes }}
+                {{- range $ops }}
+                  {{- if ne . "read" }}
+                    {{- fail (printf "globalRoleBindings[%d]: wildcard binding role %q grants non-read global operation %q on scope %q" $i $roleName . $scopeName) }}
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
           {{- range $subject := $subjects }}
         - {{ printf "--global-role-binding=%s::%s::%s" $b.issuer $subject (join "," $roles) | quote }}
           {{- end }}

--- a/charts/identity/templates/identity/deployment.yaml
+++ b/charts/identity/templates/identity/deployment.yaml
@@ -47,6 +47,9 @@ spec:
           {{- if not (trim (default "" $b.issuer)) }}
             {{- fail (printf "globalRoleBindings[%d]: issuer is required" $i) }}
           {{- end }}
+          {{- if regexMatch "\\s" $b.issuer }}
+            {{- fail (printf "globalRoleBindings[%d]: issuer must not contain whitespace" $i) }}
+          {{- end }}
           {{- if and (hasKey $b "subject") (hasKey $b "subjects") }}
             {{- fail (printf "globalRoleBindings[%d]: subject and subjects are mutually exclusive" $i) }}
           {{- end }}
@@ -62,6 +65,9 @@ spec:
           {{- range $si, $subject := $subjects }}
             {{- if not (trim (default "" $subject)) }}
               {{- fail (printf "globalRoleBindings[%d].subjects[%d]: empty or whitespace-only subject" $i $si) }}
+            {{- end }}
+            {{- if and (eq $b.issuer "uni") (eq $subject "*") }}
+              {{- fail (printf "globalRoleBindings[%d]: wildcard subject not allowed on the UNI sentinel issuer" $i) }}
             {{- end }}
           {{- end }}
           {{- if not $b.roles }}

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -133,13 +133,33 @@ issuer:
 # platformAdministratorRole is a role that can be implicitly added to users
 # and service accounts.
 platformAdministrators:
-  # Protected role as defined below to grant.
+  # Protected role as defined below to grant. Also feeds the server's internal
+  # super-context: keep populated even if all subjects move to
+  # globalRoleBindings.
   roles:
   - platform-administrator
 
   # Subjects the role applies to, must be the canonical name from the IdP
   # and not an alias.
   subjects: []
+
+# Global role bindings grant the global scopes of the named roles to matched
+# subjects, replacing membership resolution for that session. Exactly one of
+# `subject` (single) or `subjects` (list, non-empty) per entry. subject "*"
+# matches every subject from the issuer and is clamped to read-only in code.
+# `issuer` must be the verbatim `iss` the IdP emits (Auth0: trailing slash),
+# or `uni` for locally issued tokens (exact subjects only).
+# Rollout ordering: the flag is emitted only when this list is non-empty, and
+# older server binaries do not recognise it — deploy a binary that understands
+# --global-role-binding before enabling bindings; on rollback, clear this
+# value before reverting the binary.
+globalRoleBindings: []
+#  - issuer: https://staff.example.auth0.com/
+#    subject: "*"
+#    roles: [platform-reader] # example only: role must already exist in roles/additionalRoles
+#  - issuer: uni
+#    subjects: [alice@example.com, bob@example.com]
+#    roles: [platform-administrator]
 
 # System accounts map X.509 Common Names to roles.
 systemAccounts:

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -144,19 +144,14 @@ platformAdministrators:
   subjects: []
 
 # Global role bindings grant the global scopes of the named roles to matched
-# subjects, replacing membership resolution for that session. Exactly one of
-# `subject` (single) or `subjects` (list, non-empty) per entry. subject "*"
-# matches every subject from the issuer and is clamped to read-only in code.
-# `issuer` must be the verbatim `iss` the IdP emits (Auth0: trailing slash),
-# or `uni` for locally issued tokens (exact subjects only). Neither issuer nor
-# subject may contain "::" (the flag's separator) and subjects are trimmed;
-# both are enforced at render time. Subjects match case-insensitively, but the
-# UNI user lookup does not — see docs/multi-issuer-token-contract.md.
-# Render-time guard: a wildcard binding ("*" as subject or a member of
-# subjects) may only reference roles whose global scopes (if any) are
-# read-only; the render fails otherwise. The runtime clamp still applies on
-# top (roles are live CRDs). None of the roles shipped below qualify for
-# wildcard use today. See pkg/rbac/README.md#global-role-bindings.
+# subjects, replacing membership resolution for that session. Each entry takes
+# exactly one of `subject` or a non-empty `subjects`, plus one or more roles
+# defined below. `issuer` is the verbatim `iss` the IdP emits (Auth0: trailing
+# slash), or `uni` for locally issued tokens, which allows exact subjects only.
+# Subject "*" matches every subject from the issuer and is clamped to read.
+# Full semantics: pkg/rbac/README.md#global-role-bindings.
+# Helm rejects invalid separators and wildcard bindings on roles that grant any
+# non-read global operation — no role shipped below qualifies for wildcard use.
 # Rollout ordering: the flag is emitted only when this list is non-empty, and
 # older server binaries do not recognise it — deploy a binary that understands
 # --global-role-binding before enabling bindings; on rollback, clear this

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -140,7 +140,8 @@ platformAdministrators:
   - platform-administrator
 
   # Subjects the role applies to, must be the canonical name from the IdP
-  # and not an alias.
+  # and not an alias, in its lower-case form — matching is case-sensitive and
+  # the render fails on an upper-case letter.
   subjects: []
 
 # Global role bindings grant the global scopes of the named roles to matched
@@ -149,6 +150,8 @@ platformAdministrators:
 # defined below. `issuer` is the verbatim `iss` the IdP emits (Auth0: trailing
 # slash), or `uni` for locally issued tokens, which allows exact subjects only.
 # Subject "*" matches every subject from the issuer and is clamped to read.
+# Every other subject is matched case-sensitively, so it must be the
+# canonical lower-case form — the render fails on an upper-case letter.
 # Group membership never grants global scopes for user accounts; exact,
 # per-subject bindings here are the only route to global write authority.
 # Full semantics: pkg/rbac/README.md#global-role-bindings.

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -148,7 +148,10 @@ platformAdministrators:
 # `subject` (single) or `subjects` (list, non-empty) per entry. subject "*"
 # matches every subject from the issuer and is clamped to read-only in code.
 # `issuer` must be the verbatim `iss` the IdP emits (Auth0: trailing slash),
-# or `uni` for locally issued tokens (exact subjects only).
+# or `uni` for locally issued tokens (exact subjects only). Neither issuer nor
+# subject may contain "::" (the flag's separator) and subjects are trimmed;
+# both are enforced at render time. Subjects match case-insensitively, but the
+# UNI user lookup does not — see docs/multi-issuer-token-contract.md.
 # Render-time guard: a wildcard binding ("*" as subject or a member of
 # subjects) may only reference roles whose global scopes (if any) are
 # read-only; the render fails otherwise. The runtime clamp still applies on

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -149,6 +149,8 @@ platformAdministrators:
 # defined below. `issuer` is the verbatim `iss` the IdP emits (Auth0: trailing
 # slash), or `uni` for locally issued tokens, which allows exact subjects only.
 # Subject "*" matches every subject from the issuer and is clamped to read.
+# Group membership never grants global scopes for user accounts; exact,
+# per-subject bindings here are the only route to global write authority.
 # Full semantics: pkg/rbac/README.md#global-role-bindings.
 # Helm rejects invalid separators and wildcard bindings on roles that grant any
 # non-read global operation — no role shipped below qualifies for wildcard use.

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -133,9 +133,9 @@ issuer:
 # platformAdministratorRole is a role that can be implicitly added to users
 # and service accounts.
 platformAdministrators:
-  # Protected role as defined below to grant. Also feeds the server's internal
-  # super-context: keep populated even if all subjects move to
-  # globalRoleBindings.
+  # Protected role as defined below to grant. Translated verbatim into global
+  # role bindings for each subject below, so it is only needed while subjects
+  # remain here rather than in globalRoleBindings.
   roles:
   - platform-administrator
 

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -149,6 +149,11 @@ platformAdministrators:
 # matches every subject from the issuer and is clamped to read-only in code.
 # `issuer` must be the verbatim `iss` the IdP emits (Auth0: trailing slash),
 # or `uni` for locally issued tokens (exact subjects only).
+# Render-time guard: a wildcard binding ("*" as subject or a member of
+# subjects) may only reference roles whose global scopes (if any) are
+# read-only; the render fails otherwise. The runtime clamp still applies on
+# top (roles are live CRDs). None of the roles shipped below qualify for
+# wildcard use today. See pkg/rbac/README.md#global-role-bindings.
 # Rollout ordering: the flag is emitted only when this list is non-empty, and
 # older server binaries do not recognise it — deploy a binary that understands
 # --global-role-binding before enabling bindings; on rollback, clear this

--- a/docs/multi-issuer-token-contract.md
+++ b/docs/multi-issuer-token-contract.md
@@ -81,9 +81,11 @@ UNI distinguishes two different not-found-or-not-usable cases:
   `UserDatabase.GetUser` compares `spec.subject` verbatim, while the bearer path lower-cases the
   email claim first (`auth0.Validator.validateEmail`) and the create API stores `spec.subject` as
   supplied. A mixed-case record is therefore treated as *never onboarded* and admitted with empty
-  `orgIds` under `allowExternalIdentity: true`, even while suspended — and global role bindings,
-  which match case-insensitively, still grant it authority. Until storage and lookup agree on
-  normalization, create users with lower-case subjects.
+  `orgIds` under `allowExternalIdentity: true`, even while suspended. Global role binding matching
+  is case-sensitive too, so a mixed-case record gains no unearned authority through that path — the
+  residual gap is narrower than a bypass: the inactive-user rejection simply cannot fire on a record
+  its case-sensitive lookup cannot find. Until storage and lookup agree on normalization, create
+  users with lower-case subjects.
 
 ## The `https://unikorn-cloud.org/authz` claim
 
@@ -130,11 +132,13 @@ Bindings are registered with the repeated flag:
 
 `issuer` must be the exact issuer URL the authenticating IdP emits (verbatim, matching the token's
 `iss` — for Auth0, including the trailing slash) or the `uni` sentinel for UNI-local tokens.
-`subject` is either an exact subject (an email address, matched case-insensitively with surrounding
+`subject` is either an exact subject (an email address, matched case-sensitively with surrounding
 whitespace trimmed on both sides) or the literal wildcard `*`, which matches every subject
 authenticated by that issuer. Parsing is right-anchored — the role list follows the
 *last* `::`, the subject sits between the second-to-last and last `::` — so issuer URLs containing
-`::` (IPv6 literals) parse unambiguously.
+`::` (IPv6 literals) parse unambiguously. Because matching is case-sensitive and the authenticated
+subject always arrives lower-cased, a binding's subject must be in its canonical lower-case form;
+the chart fails to render one that contains an upper-case ASCII letter (the wildcard `*` is exempt).
 
 **Wildcard semantics.** A wildcard-subject binding is clamped to the `read` operation of each
 referenced role's global scopes, and can never be combined with the `uni` sentinel issuer, which

--- a/docs/multi-issuer-token-contract.md
+++ b/docs/multi-issuer-token-contract.md
@@ -63,13 +63,21 @@ UNI is authoritative for organization membership. The external token's claimed `
 are discarded. Organization membership is always resolved through the UNI user database by
 email address lookup.
 
-When the email is found, the resolved `orgIds` from UNI are used. When the email is not found:
+When the email is found and the local user is active, the resolved `orgIds` from UNI are used.
+UNI distinguishes two different not-found-or-not-usable cases:
 
-- If `allowExternalIdentity: false` (the default), the request is rejected with
-  `access_denied`.
-- If `allowExternalIdentity: true`, the subject is accepted with an empty `orgIds` slice.
-  RBAC decides what that principal can reach. This is intended for platform-administrator
-  subjects that are not registered as ordinary UNI users (e.g. CI service identities).
+- **Never onboarded** (no local user record for the email at all): if
+  `allowExternalIdentity: false` (the default), the request is rejected with `access_denied`.
+  If `allowExternalIdentity: true`, the subject is accepted with an empty `orgIds` slice — RBAC
+  decides what that principal can reach. This is intended for global-role-binding subjects that
+  are not registered as ordinary UNI users (e.g. CI service identities or staff accounts).
+- **Exists but inactive** (the global `User` record's `state` is not `Active`): the request is
+  always rejected with `access_denied`, **regardless of `allowExternalIdentity`**. A local
+  suspension is a deliberate revocation; `allowExternalIdentity` only widens admission for
+  identities UNI has never seen, never re-admits one UNI has explicitly deactivated. This check is
+  scoped to the global `User` record only — nothing in the product currently writes a non-active
+  global `User`, and a user suspended (or removed) from every organization instead resolves to an
+  empty `orgIds` list with no error. That path is not closed by this change.
 
 ## The `https://unikorn-cloud.org/authz` claim
 
@@ -88,10 +96,10 @@ database, not from the token.
 ## `allowExternalIdentity` semantics
 
 `allowExternalIdentity: true` does not grant any permissions by itself. A subject accepted with
-an empty `orgIds` slice can only reach resources through the platform-administrator fast-path in
-RBAC (if listed in `--platform-administrator-subjects`) or through other RBAC paths that do not
-require organization membership. Ordinary user access to organization resources requires a UNI
-user record and group membership.
+an empty `orgIds` slice can only reach resources through RBAC's global role binding resolution (if
+matched by a `--global-role-binding` or legacy `--platform-administrator-subjects` entry) or
+through other RBAC paths that do not require organization membership. Ordinary user access to
+organization resources requires a UNI user record and group membership.
 
 ## Signing algorithms
 
@@ -100,34 +108,81 @@ When empty, it defaults to `[RS256]`. Only asymmetric algorithms are permitted; 
 algorithms (e.g. `HS256`) and `none` are rejected at trust-list build time. This constraint
 applies regardless of what the provider's JWKS endpoint advertises.
 
-## The `issuer::subject` admin-list contract
+## The `--global-role-binding` contract
 
-Platform administrators are registered via the `--platform-administrator-subjects` flag using the
-`issuer::subject` syntax, where `issuer` is the exact issuer URL of the authenticating IdP (verbatim,
-matching the token's `iss`) and `subject` is the email address of the administrator:
+Global privileges — platform administrators and any future issuer-wide grant — are all expressed
+through one mechanism: a **global role binding**, mapping an `(issuer, subject | "*")` pair to a
+set of role IDs. Implementation and full rationale live in
+[`pkg/rbac/README.md`](../pkg/rbac/README.md#global-role-bindings); this section states the
+operator-facing contract.
+
+Bindings are registered with the repeated flag:
 
 ```
---platform-administrator-subjects https://my-idp.example.com/::admin@example.com
+--global-role-binding=<issuer>::<subject>::<roleID>[,<roleID>...]
 ```
 
-Multiple administrators may be given as repeated flags or as a single comma-separated value —
-the Helm chart renders `platformAdministrators.subjects` as the latter.
+`issuer` must be the exact issuer URL the authenticating IdP emits (verbatim, matching the token's
+`iss` — for Auth0, including the trailing slash) or the `uni` sentinel for UNI-local tokens.
+`subject` is either an exact subject (an email address, matched case-insensitively with surrounding
+whitespace trimmed on both sides) or the literal wildcard `*`, which matches every subject
+authenticated by that issuer. Parsing is right-anchored — the role list follows the
+*last* `::`, the subject sits between the second-to-last and last `::` — so issuer URLs containing
+`::` (IPv6 literals) parse unambiguously.
 
-For UNI-local tokens (access tokens issued by the UNI identity service itself), the issuer is the
-`uni` sentinel and a bare subject without the `::` prefix is equivalent.
+**Wildcard semantics.** A wildcard-subject binding is clamped in code to the `read` operation of
+each referenced role's global scopes, never the role's write operations, regardless of role
+content. That clamp bounds verbs only — it does not vet what a read endpoint's response contains —
+so the role(s) referenced by a wildcard binding must be individually audited for read-surface
+sensitivity (some read endpoints return credential material) before being used with a wildcard
+binding. A wildcard subject can never be combined with the `uni` sentinel issuer, since that would
+grant every UNI-local user.
 
-Bare entries carry legacy-compatible semantics: while the deprecated `--auth0-exchange-issuer`
-flag is set, each bare entry is mirrored at server construction onto that flag's issuer, so it
-matches both UNI-login and Auth0-exchange sessions — exactly the issuer-unaware behaviour that
-predates issuer qualification. A bare entry never matches a CRD-declared `bearerTrust` issuer.
-Migration to explicit `issuer::subject` form is therefore recommended but not forced: a
-deployment that has at least one `bearerTrust` provider and still carries a bare admin subject
-logs a startup warning (`Options.Validate`) and continues to boot. The always-on runtime control
-is the issuer-qualified match in `processUserAccountACL`.
+**Parse-time rejections.** The process fails to start on: malformed grammar (fewer than two `::`
+separators); an empty issuer, empty subject, or empty role-list member; a wildcard subject
+combined with the `uni` sentinel; and an issuer that is neither the `uni` sentinel nor an absolute
+URL (scheme + host, no commas or whitespace — this specifically catches accidentally comma-joining
+multiple bindings into one flag value).
 
-Note the mirror copies the flag value verbatim: a flag issuer lacking Auth0's canonical trailing
-slash will not match the emitted `iss` — the same match-`iss`-verbatim rule stated above for the
-`issuer::subject` syntax applies to the flag too.
+Legacy `--platform-administrator-subjects` / `--platform-administrator-role-ids` continue to work,
+each subject translated into an exact (non-wildcard) global role binding. For UNI-local tokens the
+issuer is the `uni` sentinel and a bare subject without the `::` prefix is equivalent. Bare entries
+carry legacy-compatible semantics: while the deprecated `--auth0-exchange-issuer` flag is set, each
+bare entry is mirrored at server construction onto that flag's issuer, so it matches both UNI-login
+and Auth0-exchange sessions — exactly the issuer-unaware behaviour that predates issuer
+qualification. A bare entry never matches a CRD-declared `bearerTrust` issuer, and a legacy subject
+that is literally `*` stays an exact match — it never gains wildcard semantics.
+
+Multiple administrators, or multiple bindings, may be given as repeated flags; the Helm chart
+renders `platformAdministrators.subjects` as a single comma-joined `--platform-administrator-subjects`
+value and `globalRoleBindings` as one `--global-role-binding` flag per subject in each entry.
+
+### Operator invariants
+
+**(1) Migration to explicit `issuer::subject` form is recommended but not forced.** A deployment
+that has at least one `bearerTrust` provider and still carries a bare (UNI-sentinel)
+`--platform-administrator-subjects` entry logs a startup warning (`Options.Validate`) and
+continues to boot. The always-on runtime control is the issuer-qualified match in
+`processUserAccountACL`, not the warning.
+
+**(2) Every `--global-role-binding` issuer should be a trusted issuer.** `Options.Validate` also
+warns, without blocking startup, when a binding's issuer is neither the `uni` sentinel nor one of
+the currently trusted non-UNI `bearerTrust` issuers — note the deprecated `--auth0-exchange-issuer`
+value is deliberately excluded from that trusted set, so a binding aimed at the legacy exchange
+issuer warns too, even though it can still match a real token. Most often, though, this catches a
+mistyped or stale issuer that can never match a real token. As with (1), the warning is advisory;
+the issuer-qualified runtime match is the actual control.
+
+Both (1) and (2) are skipped entirely when the trusted non-UNI issuer list is empty. The caller
+that computes that list treats a `List` failure on the `OAuth2Provider` resources as non-fatal and
+returns an empty slice in that case too, indistinguishable from "no non-UNI issuers are actually
+trusted". Reporting on an empty list would therefore produce a false advisory — every external
+binding flagged as untrusted — on any startup where the provider list could not be read, so the
+check is skipped rather than risking that.
+
+Note the legacy-flag mirror copies the flag value verbatim: a flag issuer lacking Auth0's canonical
+trailing slash will not match the emitted `iss` — the same match-`iss`-verbatim rule stated above
+applies to the flag too.
 
 ## Invariants
 

--- a/docs/multi-issuer-token-contract.md
+++ b/docs/multi-issuer-token-contract.md
@@ -130,13 +130,19 @@ authenticated by that issuer. Parsing is right-anchored — the role list follow
 *last* `::`, the subject sits between the second-to-last and last `::` — so issuer URLs containing
 `::` (IPv6 literals) parse unambiguously.
 
-**Wildcard semantics.** A wildcard-subject binding is clamped in code to the `read` operation of
-each referenced role's global scopes, never the role's write operations, regardless of role
-content. That clamp bounds verbs only — it does not vet what a read endpoint's response contains —
-so the role(s) referenced by a wildcard binding must be individually audited for read-surface
-sensitivity (some read endpoints return credential material) before being used with a wildcard
-binding. A wildcard subject can never be combined with the `uni` sentinel issuer, since that would
-grant every UNI-local user.
+**Wildcard semantics.** A wildcard-subject binding is clamped to the `read` operation of each
+referenced role's global scopes, regardless of role content — but the clamp bounds verbs only, not
+response sensitivity, so any role referenced by a wildcard binding must be individually
+read-surface-audited before use (some read endpoints return credential material). Full rationale:
+[`pkg/rbac/README.md#global-role-bindings`](../pkg/rbac/README.md#global-role-bindings). A wildcard
+subject can never be combined with the `uni` sentinel issuer, since that would grant every
+UNI-local user.
+
+**Chart guard, not a substitute for the clamp.** The Helm chart also fails to render a wildcard
+binding whose role(s) declare any non-`read` global operation, naming the offending binding, role,
+and scope — no role shipped in `charts/identity/values.yaml` passes it today, so a wildcard binding
+needs a dedicated, audited read-only role. It does not replace the runtime clamp above; why:
+[`pkg/rbac/README.md#global-role-bindings`](../pkg/rbac/README.md#global-role-bindings).
 
 **Parse-time rejections.** The process fails to start on: malformed grammar (fewer than two `::`
 separators); an empty issuer, empty subject, or empty role-list member; a wildcard subject

--- a/docs/multi-issuer-token-contract.md
+++ b/docs/multi-issuer-token-contract.md
@@ -79,6 +79,16 @@ UNI distinguishes two different not-found-or-not-usable cases:
   global `User`, and a user suspended (or removed) from every organization instead resolves to an
   empty `orgIds` list with no error. That path is not closed by this change.
 
+  The check can only fire on a record the lookup actually finds, and the lookup is **case
+  sensitive**: `UserDatabase.GetUser` compares `spec.subject` verbatim, while the bearer path
+  lower-cases the email claim before lookup (`auth0.Validator.validateEmail`). A `User` created
+  with a mixed-case subject — the create API stores `spec.subject` as supplied — is therefore
+  never matched, falls into the *never onboarded* branch above, and is admitted with empty
+  `orgIds` when `allowExternalIdentity: true`, even while its record says suspended. Global role
+  bindings match case-insensitively, so such a principal keeps its bound authority. Until the
+  lookup and storage agree on normalization, revocation is only reliable for subjects stored
+  lower-case; create users with lower-case subjects.
+
 ## The `https://unikorn-cloud.org/authz` claim
 
 The `https://unikorn-cloud.org/authz` claim is an optional UNI-defined claim emitted by the

--- a/docs/multi-issuer-token-contract.md
+++ b/docs/multi-issuer-token-contract.md
@@ -173,12 +173,13 @@ issuer warns too, even though it can still match a real token. Most often, thoug
 mistyped or stale issuer that can never match a real token. As with (1), the warning is advisory;
 the issuer-qualified runtime match is the actual control.
 
-Both (1) and (2) are skipped entirely when the trusted non-UNI issuer list is empty. The caller
-that computes that list treats a `List` failure on the `OAuth2Provider` resources as non-fatal and
-returns an empty slice in that case too, indistinguishable from "no non-UNI issuers are actually
-trusted". Reporting on an empty list would therefore produce a false advisory — every external
-binding flagged as untrusted — on any startup where the provider list could not be read, so the
-check is skipped rather than risking that.
+Only (1) is skipped when the trusted non-UNI issuer list is empty — a bare admin entry only matters
+once a non-UNI issuer is trusted to migrate away from. (2) has no such gate: it runs even against a
+genuinely empty list, so with no `bearerTrust` providers configured every non-UNI binding issuer is
+reported as untrusted. The caller that computes the trusted-issuer list distinguishes a `List`
+failure on the `OAuth2Provider` resources from a genuinely empty result — on failure it logs that
+the advisory check was skipped and does not call `Validate` at all, rather than risk misreading
+"provider list unavailable" as "no non-UNI issuers trusted".
 
 Note the legacy-flag mirror copies the flag value verbatim: a flag issuer lacking Auth0's canonical
 trailing slash will not match the emitted `iss` — the same match-`iss`-verbatim rule stated above

--- a/docs/multi-issuer-token-contract.md
+++ b/docs/multi-issuer-token-contract.md
@@ -72,22 +72,18 @@ UNI distinguishes two different not-found-or-not-usable cases:
   decides what that principal can reach. This is intended for global-role-binding subjects that
   are not registered as ordinary UNI users (e.g. CI service identities or staff accounts).
 - **Exists but inactive** (the global `User` record's `state` is not `Active`): the request is
-  always rejected with `access_denied`, **regardless of `allowExternalIdentity`**. A local
-  suspension is a deliberate revocation; `allowExternalIdentity` only widens admission for
-  identities UNI has never seen, never re-admits one UNI has explicitly deactivated. This check is
-  scoped to the global `User` record only — nothing in the product currently writes a non-active
-  global `User`, and a user suspended (or removed) from every organization instead resolves to an
-  empty `orgIds` list with no error. That path is not closed by this change.
+  always rejected with `access_denied`, **regardless of `allowExternalIdentity`**, because a local
+  suspension is a deliberate revocation. The check covers the global `User` record only — nothing
+  currently writes a non-active global `User`, while a user suspended in (or removed from) every
+  organization still resolves to an empty `orgIds` list with no error.
 
-  The check can only fire on a record the lookup actually finds, and the lookup is **case
-  sensitive**: `UserDatabase.GetUser` compares `spec.subject` verbatim, while the bearer path
-  lower-cases the email claim before lookup (`auth0.Validator.validateEmail`). A `User` created
-  with a mixed-case subject — the create API stores `spec.subject` as supplied — is therefore
-  never matched, falls into the *never onboarded* branch above, and is admitted with empty
-  `orgIds` when `allowExternalIdentity: true`, even while its record says suspended. Global role
-  bindings match case-insensitively, so such a principal keeps its bound authority. Until the
-  lookup and storage agree on normalization, revocation is only reliable for subjects stored
-  lower-case; create users with lower-case subjects.
+  It can also only fire on a record the lookup finds, and the lookup is **case sensitive**:
+  `UserDatabase.GetUser` compares `spec.subject` verbatim, while the bearer path lower-cases the
+  email claim first (`auth0.Validator.validateEmail`) and the create API stores `spec.subject` as
+  supplied. A mixed-case record is therefore treated as *never onboarded* and admitted with empty
+  `orgIds` under `allowExternalIdentity: true`, even while suspended — and global role bindings,
+  which match case-insensitively, still grant it authority. Until storage and lookup agree on
+  normalization, create users with lower-case subjects.
 
 ## The `https://unikorn-cloud.org/authz` claim
 
@@ -141,17 +137,12 @@ authenticated by that issuer. Parsing is right-anchored — the role list follow
 `::` (IPv6 literals) parse unambiguously.
 
 **Wildcard semantics.** A wildcard-subject binding is clamped to the `read` operation of each
-referenced role's global scopes, regardless of role content — but the clamp bounds verbs only, not
-response sensitivity, so any role referenced by a wildcard binding must be individually
-read-surface-audited before use (some read endpoints return credential material). Full rationale:
-[`pkg/rbac/README.md#global-role-bindings`](../pkg/rbac/README.md#global-role-bindings). A wildcard
-subject can never be combined with the `uni` sentinel issuer, since that would grant every
-UNI-local user.
-
-**Chart guard, not a substitute for the clamp.** The Helm chart also fails to render a wildcard
-binding whose role(s) declare any non-`read` global operation, naming the offending binding, role,
-and scope — no role shipped in `charts/identity/values.yaml` passes it today, so a wildcard binding
-needs a dedicated, audited read-only role. It does not replace the runtime clamp above; why:
+referenced role's global scopes, and can never be combined with the `uni` sentinel issuer, which
+would grant every UNI-local user. The clamp bounds verbs, not response sensitivity — some read
+endpoints return credential material — so any role used this way needs a read-surface audit first.
+The chart additionally refuses to render a wildcard binding on a role declaring any non-`read`
+global operation; no role shipped in `charts/identity/values.yaml` passes that guard today. Why
+both layers exist:
 [`pkg/rbac/README.md#global-role-bindings`](../pkg/rbac/README.md#global-role-bindings).
 
 **Parse-time rejections.** The process fails to start on: malformed grammar (fewer than two `::`
@@ -175,27 +166,13 @@ value and `globalRoleBindings` as one `--global-role-binding` flag per subject i
 
 ### Operator invariants
 
-**(1) Migration to explicit `issuer::subject` form is recommended but not forced.** A deployment
-that has at least one `bearerTrust` provider and still carries a bare (UNI-sentinel)
-`--platform-administrator-subjects` entry logs a startup warning (`Options.Validate`) and
-continues to boot. The always-on runtime control is the issuer-qualified match in
-`processUserAccountACL`, not the warning.
-
-**(2) Every `--global-role-binding` issuer should be a trusted issuer.** `Options.Validate` also
-warns, without blocking startup, when a binding's issuer is neither the `uni` sentinel nor one of
-the currently trusted non-UNI `bearerTrust` issuers — note the deprecated `--auth0-exchange-issuer`
-value is deliberately excluded from that trusted set, so a binding aimed at the legacy exchange
-issuer warns too, even though it can still match a real token. Most often, though, this catches a
-mistyped or stale issuer that can never match a real token. As with (1), the warning is advisory;
-the issuer-qualified runtime match is the actual control.
-
-Only (1) is skipped when the trusted non-UNI issuer list is empty — a bare admin entry only matters
-once a non-UNI issuer is trusted to migrate away from. (2) has no such gate: it runs even against a
-genuinely empty list, so with no `bearerTrust` providers configured every non-UNI binding issuer is
-reported as untrusted. The caller that computes the trusted-issuer list distinguishes a `List`
-failure on the `OAuth2Provider` resources from a genuinely empty result — on failure it logs that
-the advisory check was skipped and does not call `Validate` at all, rather than risk misreading
-"provider list unavailable" as "no non-UNI issuers trusted".
+`Options.Validate` logs two advisory startup warnings and never blocks boot: a bare (UNI-sentinel)
+`--platform-administrator-subjects` entry that should migrate to explicit `issuer::subject` form,
+and a `--global-role-binding` issuer outside the currently trusted set — usually a stale or
+mistyped issuer that can never match a real token. Neither warning is a security control; the
+issuer-qualified runtime match in `processUserAccountACL` is. Their gating, the deliberately
+excluded legacy exchange issuer, and provider-list failure handling are documented in
+[`pkg/rbac/README.md#global-role-bindings`](../pkg/rbac/README.md#global-role-bindings).
 
 Note the legacy-flag mirror copies the flag value verbatim: a flag issuer lacking Auth0's canonical
 trailing slash will not match the emitted `iss` — the same match-`iss`-verbatim rule stated above

--- a/docs/multi-issuer-token-contract.md
+++ b/docs/multi-issuer-token-contract.md
@@ -167,7 +167,7 @@ value and `globalRoleBindings` as one `--global-role-binding` flag per subject i
 ### Operator invariants
 
 `Options.Validate` logs two advisory startup warnings and never blocks boot: a bare (UNI-sentinel)
-`--platform-administrator-subjects` entry that should migrate to explicit `issuer::subject` form,
+`--platform-administrator-subjects` entry that should migrate to a `globalRoleBindings` entry,
 and a `--global-role-binding` issuer outside the currently trusted set — usually a stale or
 mistyped issuer that can never match a real token. Neither warning is a security control; the
 issuer-qualified runtime match in `processUserAccountACL` is. Their gating, the deliberately

--- a/hack/check_chart_render.sh
+++ b/hack/check_chart_render.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nscale.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Render assertions for globalRoleBindings; wired into `make lint`.
+set -euo pipefail
+
+CHART=charts/identity
+
+render() { helm template test "$CHART" --set-json "globalRoleBindings=$1"; }
+
+die() { echo "FAIL: $*" >&2; exit 1; }
+
+# role_id_of <friendly-name> resolves a Role manifest name from a render on
+# stdin: remember the most recent metadata name, emit it on the matching label.
+role_id_of() { awk -v want="$1" '$1=="name:"{n=$2} $0 ~ "unikorn-cloud.org/name: "want{print n; exit}'; }
+
+# assert_one_match <output> <pattern> — anchors on a resolved role ID so an
+# empty/absent ID (or a duplicate/missing flag) can't pass vacuously.
+assert_one_match() { [[ $(grep -c -- "$2" <<<"$1") -eq 1 ]] || die "expected exactly one match for: $2"; }
+
+# must_fail asserts the render fails for the SPECIFIC reason under test, not
+# merely that it failed somehow (else a different broken guard would pass).
+must_fail() {
+	local out
+	if out=$(render "$1" 2>&1 >/dev/null); then
+		die "expected render failure (fragment: $2), but render succeeded"
+	fi
+	if ! grep -qF -- "$2" <<<"$out"; then
+		die "render failed, but not for the expected reason
+  expected fragment: $2
+  actual output:     $out"
+	fi
+}
+
+out=$(render '[{"issuer":"https://staff.example.com/","subject":"*","roles":["reader"]}]')
+reader_role_id=$(role_id_of reader <<<"$out")
+[[ -n "$reader_role_id" ]] || die "could not resolve role ID for 'reader'"
+assert_one_match "$out" "--global-role-binding=https://staff.example.com/::\*::${reader_role_id}\""
+
+out=$(render '[{"issuer":"uni","subjects":["a@x.com","b@x.com"],"roles":["platform-administrator"]}]')
+role_id=$(role_id_of platform-administrator <<<"$out")
+[[ -n "$role_id" ]] || die "could not resolve role ID for 'platform-administrator'"
+assert_one_match "$out" "--global-role-binding=uni::a@x.com::${role_id}\""
+assert_one_match "$out" "--global-role-binding=uni::b@x.com::${role_id}\""
+
+must_fail '[{"issuer":"uni","subject":"a@x.com","subjects":["b@x.com"],"roles":["reader"]}]' \
+	"subject and subjects are mutually exclusive"
+must_fail '[{"issuer":"uni","subjects":[],"roles":["reader"]}]' \
+	"exactly one of subject or non-empty subjects required"
+must_fail '[{"issuer":"uni","subjects":["a@x.com",""],"roles":["reader"]}]' \
+	"empty or whitespace-only subject"
+must_fail '[{"issuer":"uni","subject":"a@x.com"}]' \
+	"roles must be non-empty"
+must_fail '[{"issuer":"uni","subject":"a@x.com","roles":["no-such-role"]}]' \
+	'unknown role "no-such-role"'
+must_fail '[{"subject":"a@x.com","roles":["reader"]}]' \
+	"issuer is required"
+
+echo "chart render checks OK"

--- a/hack/check_chart_render.sh
+++ b/hack/check_chart_render.sh
@@ -95,4 +95,38 @@ out=$(render '[{"issuer":"https://staff.example.com/","subject":" alice@x.com ",
 reader_role_id=$(role_id_of reader <<<"$out")
 assert_one_match "$out" "--global-role-binding=https://staff.example.com/::alice@x.com::${reader_role_id}\""
 
+# The server matches subjects case-sensitively, so a mixed-case subject would
+# silently stop matching once deployed; reject it at render time instead.
+must_fail '[{"issuer":"https://staff.example.com/","subject":"Alice@x.com","roles":["reader"]}]' \
+	"globalRoleBindings[0].subjects[0]: subject must be its canonical lower-case form"
+must_fail '[{"issuer":"https://staff.example.com/","subjects":["alice@x.com","Bob@x.com"],"roles":["reader"]}]' \
+	"globalRoleBindings[0].subjects[1]: subject must be its canonical lower-case form"
+
+# The wildcard subject itself must never trip the case guard: it has no
+# letters to begin with, but the guard explicitly skips it for clarity.
+out=$(render '[{"issuer":"https://staff.example.com/","subject":"*","roles":["reader"]}]')
+reader_role_id=$(role_id_of reader <<<"$out")
+assert_one_match "$out" "--global-role-binding=https://staff.example.com/::\*::${reader_role_id}\""
+
+# platformAdministrators.subjects is translated into the same bindings and
+# must be guarded equivalently, for both the bare (UNI-sentinel) and
+# issuer-qualified forms.
+render_admin() { helm template test "$CHART" --set-json "platformAdministrators.subjects=$1"; }
+must_fail_admin() {
+	local out
+	if out=$(render_admin "$1" 2>&1 >/dev/null); then
+		die "expected render failure (fragment: $2), but render succeeded"
+	fi
+	if ! grep -qF -- "$2" <<<"$out"; then
+		die "render failed, but not for the expected reason
+  expected fragment: $2
+  actual output:     $out"
+	fi
+}
+
+must_fail_admin '["Admin@x.com"]' \
+	"platformAdministrators.subjects[0]: subject must be its canonical lower-case form"
+must_fail_admin '["https://staff.example.com/::Admin@x.com"]' \
+	"platformAdministrators.subjects[0]: subject must be its canonical lower-case form"
+
 echo "chart render checks OK"

--- a/hack/check_chart_render.sh
+++ b/hack/check_chart_render.sh
@@ -71,5 +71,9 @@ must_fail '[{"issuer":"uni","subject":"*","roles":["reader"]}]' \
 	"globalRoleBindings[0]: wildcard subject not allowed on the UNI sentinel issuer"
 must_fail '[{"issuer":"https://a.com/ ","subject":"a@x.com","roles":["reader"]}]' \
 	"globalRoleBindings[0]: issuer must not contain whitespace"
+must_fail '[{"issuer":"https://staff.example.com/","subject":"*","roles":["platform-administrator"]}]' \
+	'globalRoleBindings[0]: wildcard binding role "platform-administrator" grants non-read global operation'
+must_fail '[{"issuer":"https://staff.example.com/","subjects":["alice@x.com","*"],"roles":["platform-administrator"]}]' \
+	'globalRoleBindings[0]: wildcard binding role "platform-administrator" grants non-read global operation'
 
 echo "chart render checks OK"

--- a/hack/check_chart_render.sh
+++ b/hack/check_chart_render.sh
@@ -76,4 +76,23 @@ must_fail '[{"issuer":"https://staff.example.com/","subject":"*","roles":["platf
 must_fail '[{"issuer":"https://staff.example.com/","subjects":["alice@x.com","*"],"roles":["platform-administrator"]}]' \
 	'globalRoleBindings[0]: wildcard binding role "platform-administrator" grants non-read global operation'
 
+# A padded subject must reach every guard trimmed: the server trims before
+# matching, so guarding the raw string would deploy " * " as a real wildcard.
+must_fail '[{"issuer":"https://staff.example.com/","subject":" * ","roles":["platform-administrator"]}]' \
+	'globalRoleBindings[0]: wildcard binding role "platform-administrator" grants non-read global operation'
+must_fail '[{"issuer":"uni","subject":" * ","roles":["reader"]}]' \
+	"globalRoleBindings[0]: wildcard subject not allowed on the UNI sentinel issuer"
+
+# "::" on either side shifts the right-anchored parse boundary; unrejected here
+# it is undetectable server-side, so it must fail the render, not the pod.
+must_fail '[{"issuer":"uni","subject":"a::b","roles":["reader"]}]' \
+	'globalRoleBindings[0].subjects[0]: subject must not contain "::"'
+must_fail '[{"issuer":"https://x.com/?q=a::b","subject":"alice@x.com","roles":["reader"]}]' \
+	'globalRoleBindings[0]: issuer must not contain "::"'
+
+# The trimmed subject is what gets emitted, not the padded original.
+out=$(render '[{"issuer":"https://staff.example.com/","subject":" alice@x.com ","roles":["reader"]}]')
+reader_role_id=$(role_id_of reader <<<"$out")
+assert_one_match "$out" "--global-role-binding=https://staff.example.com/::alice@x.com::${reader_role_id}\""
+
 echo "chart render checks OK"

--- a/hack/check_chart_render.sh
+++ b/hack/check_chart_render.sh
@@ -30,8 +30,8 @@ role_id_of() { awk -v want="$1" '$1=="name:"{n=$2} $0 ~ "unikorn-cloud.org/name:
 # empty/absent ID (or a duplicate/missing flag) can't pass vacuously.
 assert_one_match() { [[ $(grep -c -- "$2" <<<"$1") -eq 1 ]] || die "expected exactly one match for: $2"; }
 
-# must_fail asserts the render fails for the SPECIFIC reason under test, not
-# merely that it failed somehow (else a different broken guard would pass).
+# must_fail requires the expected message, so another failing guard cannot
+# satisfy the check.
 must_fail() {
 	local out
 	if out=$(render "$1" 2>&1 >/dev/null); then

--- a/hack/check_chart_render.sh
+++ b/hack/check_chart_render.sh
@@ -24,7 +24,7 @@ die() { echo "FAIL: $*" >&2; exit 1; }
 
 # role_id_of <friendly-name> resolves a Role manifest name from a render on
 # stdin: remember the most recent metadata name, emit it on the matching label.
-role_id_of() { awk -v want="$1" '$1=="name:"{n=$2} $0 ~ "unikorn-cloud.org/name: "want{print n; exit}'; }
+role_id_of() { awk -v want="$1" '$1=="name:"{n=$2} $0 ~ "unikorn-cloud.org/name: "want"$"{print n; exit}'; }
 
 # assert_one_match <output> <pattern> — anchors on a resolved role ID so an
 # empty/absent ID (or a duplicate/missing flag) can't pass vacuously.
@@ -67,5 +67,9 @@ must_fail '[{"issuer":"uni","subject":"a@x.com","roles":["no-such-role"]}]' \
 	'unknown role "no-such-role"'
 must_fail '[{"subject":"a@x.com","roles":["reader"]}]' \
 	"issuer is required"
+must_fail '[{"issuer":"uni","subject":"*","roles":["reader"]}]' \
+	"globalRoleBindings[0]: wildcard subject not allowed on the UNI sentinel issuer"
+must_fail '[{"issuer":"https://a.com/ ","subject":"a@x.com","roles":["reader"]}]' \
+	"globalRoleBindings[0]: issuer must not contain whitespace"
 
 echo "chart render checks OK"

--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -565,6 +565,36 @@ func main() {
 	userGlobalID := findGlobalUserID(ctx, k8s, *namespace, ciFixtureUserSubject)
 	userToken := issueUserToken(ctx, k8s, *namespace, *baseURL, ciFixtureUserSubject, userGlobalID)
 
+	// ── Create identities bound via the legacy and new global admin paths ─────
+	// Each subject is pre-bound in hack/ci/test-values.yaml: legacyAdminSubject
+	// via platformAdministrators.subjects, bindingAdminSubject via
+	// globalRoleBindings. Used to prove the two paths grant equivalent authority.
+	const (
+		legacyAdminSubject  = "ci-legacy-admin@nscale.test"
+		bindingAdminSubject = "ci-binding-admin@nscale.test"
+	)
+
+	// legacyAdminSubject's authority comes entirely from the legacy
+	// platformAdministrators.subjects binding, so it needs no group membership
+	// at all; userSpec.groupIDs has no minItems constraint and updateGroups
+	// tolerates an empty list, so this is a supported shape, not a workaround.
+	createUser(ctx, ac, orgID, legacyAdminSubject, []string{})
+	legacyAdminToken := issueUserToken(ctx, k8s, *namespace, *baseURL, legacyAdminSubject,
+		findGlobalUserID(ctx, k8s, *namespace, legacyAdminSubject))
+
+	// ci-bound-admin-group: dedicated group for bindingAdminSubject, kept
+	// separate from ci-user-group so its org membership doesn't inflate
+	// TEST_USER_GROUP_ID's UserIDs/Subjects (see groups_test.go's fixture
+	// assertions). bindingAdminSubject must remain an organization member (via
+	// this group) so the replace-semantics assertion in
+	// global_role_bindings_test.go — that the resolved ACL is Global-only with
+	// Organizations nil, not both — is non-vacuous.
+	boundAdminGroupID := createGroup(ctx, ac, orgID, "ci-bound-admin-group", []string{userRoleID})
+
+	createUser(ctx, ac, orgID, bindingAdminSubject, []string{boundAdminGroupID})
+	bindingAdminToken := issueUserToken(ctx, k8s, *namespace, *baseURL, bindingAdminSubject,
+		findGlobalUserID(ctx, k8s, *namespace, bindingAdminSubject))
+
 	// ── Output .env fragment to stdout ────────────────────────────────────────
 	fmt.Printf("IDENTITY_BASE_URL=%s\n", *baseURL)
 	fmt.Printf("IDENTITY_CA_CERT=%s\n", *caCertPath)
@@ -582,4 +612,6 @@ func main() {
 	fmt.Printf("USER_AUTH_TOKEN=%s\n", userToken)
 	fmt.Printf("SERVICE_ACCOUNT_TOKEN=%s\n", serviceAccountToken)
 	fmt.Printf("AUDIT_AUTH_TOKEN=%s\n", auditToken)
+	fmt.Printf("PLATFORM_ADMIN_AUTH_TOKEN=%s\n", legacyAdminToken)
+	fmt.Printf("BINDING_ADMIN_AUTH_TOKEN=%s\n", bindingAdminToken)
 }

--- a/hack/ci/test-values.yaml
+++ b/hack/ci/test-values.yaml
@@ -2,3 +2,16 @@
 # Passed to hack/ci/install via --values.
 systemAccounts:
   ci-fixtures: platform-administrator
+
+# Bound via the legacy platformAdministrators.subjects path; map-merges with
+# the chart default so the default platformAdministrators.roles survives.
+platformAdministrators:
+  subjects:
+  - ci-legacy-admin@nscale.test
+
+# Bound via the new globalRoleBindings path, for equivalence testing against
+# the legacy platformAdministrators.subjects binding above.
+globalRoleBindings:
+- issuer: uni
+  subject: ci-binding-admin@nscale.test
+  roles: [platform-administrator]

--- a/pkg/middleware/openapi/README.md
+++ b/pkg/middleware/openapi/README.md
@@ -55,12 +55,9 @@ that keeps those two models separate while presenting handlers with one normaliz
   of authorization.
 - Service identity and delegated principal identity are separate concepts.
 - ACL cache keys must distinguish direct calls from impersonated calls so cached results do not
-  overgrant. Keys are also qualified by the authenticated issuer (`src_iss`), since a subject is
-  only unique within its issuer: identities sharing a subject value across issuers never share a
-  cache entry. Every user-influenced segment (subject, issuer, impersonation actor) is
-  length-prefixed before being joined, since subjects such as Auth0's `auth0|<id>` routinely
-  contain the join delimiter and could otherwise be crafted to collide with a different identity's
-  key.
+  overgrant. Keys are also qualified by the authenticated issuer (`src_iss`), and every
+  user-influenced segment is length-prefixed so a subject containing the join delimiter cannot be
+  crafted to collide with another identity's key.
 - OpenAPI validation, authentication, principal propagation, and ACL resolution are colocated so
   handlers receive already-normalized request context.
 

--- a/pkg/middleware/openapi/README.md
+++ b/pkg/middleware/openapi/README.md
@@ -55,7 +55,12 @@ that keeps those two models separate while presenting handlers with one normaliz
   of authorization.
 - Service identity and delegated principal identity are separate concepts.
 - ACL cache keys must distinguish direct calls from impersonated calls so cached results do not
-  overgrant.
+  overgrant. Keys are also qualified by the authenticated issuer (`src_iss`), since a subject is
+  only unique within its issuer: identities sharing a subject value across issuers never share a
+  cache entry. Every user-influenced segment (subject, issuer, impersonation actor) is
+  length-prefixed before being joined, since subjects such as Auth0's `auth0|<id>` routinely
+  contain the join delimiter and could otherwise be crafted to collide with a different identity's
+  key.
 - OpenAPI validation, authentication, principal propagation, and ACL resolution are colocated so
   handlers receive already-normalized request context.
 

--- a/pkg/middleware/openapi/cachekey_test.go
+++ b/pkg/middleware/openapi/cachekey_test.go
@@ -56,8 +56,8 @@ func TestACLCacheKey(t *testing.T) {
 		scoped, err := aclCacheKey(t.Context(), directInfo, "org-1")
 		require.NoError(t, err)
 
-		require.Equal(t, "direct|user-1|_global", global)
-		require.Equal(t, "direct|user-1|org-1", scoped)
+		require.Equal(t, "direct|6:user-1|0:|_global", global)
+		require.Equal(t, "direct|6:user-1|0:|org-1", scoped)
 		require.NotEqual(t, global, scoped)
 	})
 
@@ -71,7 +71,7 @@ func TestACLCacheKey(t *testing.T) {
 		key, err := aclCacheKey(ctx, serviceInfo, "org-1")
 		require.NoError(t, err)
 
-		require.Equal(t, "direct|compute-service|org-1", key)
+		require.Equal(t, "direct|15:compute-service|0:|org-1", key)
 	})
 
 	t.Run("ImpersonatedDiffersFromDirect", func(t *testing.T) {
@@ -88,8 +88,8 @@ func TestACLCacheKey(t *testing.T) {
 		impersonated, err := aclCacheKey(ctx, serviceInfo, "org-1")
 		require.NoError(t, err)
 
-		require.Equal(t, "direct|compute-service|org-1", direct)
-		require.Equal(t, "impersonated|compute-service|user-1|org-1", impersonated)
+		require.Equal(t, "direct|15:compute-service|0:|org-1", direct)
+		require.Equal(t, "impersonated|15:compute-service|0:|6:user-1|org-1", impersonated)
 		require.NotEqual(t, direct, impersonated)
 	})
 
@@ -115,8 +115,8 @@ func TestACLCacheKey(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NotEqual(t, computeKey, regionKey)
-		require.Equal(t, "impersonated|compute-service|user-1|org-1", computeKey)
-		require.Equal(t, "impersonated|region-service|user-1|org-1", regionKey)
+		require.Equal(t, "impersonated|15:compute-service|0:|6:user-1|org-1", computeKey)
+		require.Equal(t, "impersonated|14:region-service|0:|6:user-1|org-1", regionKey)
 	})
 
 	t.Run("ImpersonatedIncludesOrganizationScope", func(t *testing.T) {
@@ -133,9 +133,46 @@ func TestACLCacheKey(t *testing.T) {
 		scoped, err := aclCacheKey(ctx, serviceInfo, "org-1")
 		require.NoError(t, err)
 
-		require.Equal(t, "impersonated|compute-service|user-1|_global", global)
-		require.Equal(t, "impersonated|compute-service|user-1|org-1", scoped)
+		require.Equal(t, "impersonated|15:compute-service|0:|6:user-1|_global", global)
+		require.Equal(t, "impersonated|15:compute-service|0:|6:user-1|org-1", scoped)
 		require.NotEqual(t, global, scoped)
+	})
+
+	t.Run("DirectIncludesSrcIss", func(t *testing.T) {
+		t.Parallel()
+
+		issA := &authorization.Info{Userinfo: &identityapi.Userinfo{Sub: "alice@x.com"}, SrcIss: "https://a.com/"}
+		issB := &authorization.Info{Userinfo: &identityapi.Userinfo{Sub: "alice@x.com"}, SrcIss: "https://b.com/"}
+
+		keyA, err := aclCacheKey(t.Context(), issA, "")
+		require.NoError(t, err)
+
+		keyB, err := aclCacheKey(t.Context(), issB, "")
+		require.NoError(t, err)
+
+		// Same email from two issuers must never share an ACL (ID-367 finding 6).
+		require.NotEqual(t, keyA, keyB)
+	})
+
+	t.Run("SubjectContainingDelimiterCannotForgeAnotherIdentity", func(t *testing.T) {
+		t.Parallel()
+
+		// Auth0 subjects look like "auth0|507f1f77bcf86cd799439011": the
+		// subject itself contains the "|" join delimiter. Under the old
+		// unescaped "sub|srcIss" concatenation, this pair and the pair below
+		// render to the identical string "auth0|abc|def" for the sub+srcIss
+		// segment even though they are two different (subject, issuer)
+		// tuples. Length-prefixing must keep them apart.
+		infoA := &authorization.Info{Userinfo: &identityapi.Userinfo{Sub: "auth0|abc"}, SrcIss: "def"}
+		infoB := &authorization.Info{Userinfo: &identityapi.Userinfo{Sub: "auth0"}, SrcIss: "abc|def"}
+
+		keyA, err := aclCacheKey(t.Context(), infoA, "org-1")
+		require.NoError(t, err)
+
+		keyB, err := aclCacheKey(t.Context(), infoB, "org-1")
+		require.NoError(t, err)
+
+		require.NotEqual(t, keyA, keyB)
 	})
 
 	t.Run("SyntheticImpersonationWithoutActorErrors", func(t *testing.T) {

--- a/pkg/middleware/openapi/openapi.go
+++ b/pkg/middleware/openapi/openapi.go
@@ -177,6 +177,13 @@ func hasHTTPAuthorization(r *http.Request) bool {
 // The impersonated cache key therefore includes both:
 // - the authenticated calling service subject.
 // - the impersonated actor.
+//
+// All key shapes also include info.SrcIss (the authenticated issuer). Subjects
+// are only unique within an issuer, so omitting it would let the same subject
+// value from two different issuers collide on one cached ACL (ID-367 finding 6).
+// Every user-influenced segment is length-prefixed, because subjects (e.g.
+// Auth0's "auth0|<id>") routinely contain the "|" delimiter and could
+// otherwise be crafted to collide with a different (subject, issuer) pair.
 func aclCacheKey(ctx context.Context, info *authorization.Info, organizationID string) (string, error) {
 	scope := organizationID
 	if scope == "" {
@@ -193,10 +200,17 @@ func aclCacheKey(ctx context.Context, info *authorization.Info, organizationID s
 			return "", fmt.Errorf("%w: impersonated principal actor missing", ErrHeader)
 		}
 
-		return "impersonated|" + info.Userinfo.Sub + "|" + p.Actor + "|" + scope, nil
+		return fmt.Sprintf("impersonated|%d:%s|%d:%s|%d:%s|%s",
+			len(info.Userinfo.Sub), info.Userinfo.Sub,
+			len(info.SrcIss), info.SrcIss,
+			len(p.Actor), p.Actor,
+			scope), nil
 	}
 
-	return "direct|" + info.Userinfo.Sub + "|" + scope, nil
+	return fmt.Sprintf("direct|%d:%s|%d:%s|%s",
+		len(info.Userinfo.Sub), info.Userinfo.Sub,
+		len(info.SrcIss), info.SrcIss,
+		scope), nil
 }
 
 // validateAuthentication is invoked on an oauth2 endpoint.  It is responsible for extracting

--- a/pkg/middleware/openapi/openapi.go
+++ b/pkg/middleware/openapi/openapi.go
@@ -178,15 +178,11 @@ func hasHTTPAuthorization(r *http.Request) bool {
 // - the authenticated calling service subject.
 // - the impersonated actor.
 //
-// All key shapes also include info.SrcIss (the authenticated issuer). Subjects
-// are only unique within an issuer, so omitting it would let the same subject
-// value from two different issuers collide on one cached ACL (ID-367 finding 6).
-// Every segment preceding scope is length-prefixed, because subjects (e.g.
-// Auth0's "auth0|<id>") routinely contain the "|" delimiter and could
-// otherwise be crafted to collide with a different (subject, issuer) pair.
-// scope itself is not length-prefixed, but it is terminal — nothing follows
-// it in the key — so it cannot be crafted to shift the boundaries of the
-// prefixed segments before it, and the key stays injective.
+// All key shapes also include info.SrcIss, because subjects are only unique
+// within an issuer (ID-367 finding 6). Every segment preceding scope is
+// length-prefixed, since subjects such as Auth0's "auth0|<id>" contain the "|"
+// delimiter and could otherwise be crafted to collide with another identity's
+// key. scope needs no prefix: it is terminal, so the key stays injective.
 func aclCacheKey(ctx context.Context, info *authorization.Info, organizationID string) (string, error) {
 	scope := organizationID
 	if scope == "" {

--- a/pkg/middleware/openapi/openapi.go
+++ b/pkg/middleware/openapi/openapi.go
@@ -181,9 +181,12 @@ func hasHTTPAuthorization(r *http.Request) bool {
 // All key shapes also include info.SrcIss (the authenticated issuer). Subjects
 // are only unique within an issuer, so omitting it would let the same subject
 // value from two different issuers collide on one cached ACL (ID-367 finding 6).
-// Every user-influenced segment is length-prefixed, because subjects (e.g.
+// Every segment preceding scope is length-prefixed, because subjects (e.g.
 // Auth0's "auth0|<id>") routinely contain the "|" delimiter and could
 // otherwise be crafted to collide with a different (subject, issuer) pair.
+// scope itself is not length-prefixed, but it is terminal — nothing follows
+// it in the key — so it cannot be crafted to shift the boundaries of the
+// prefixed segments before it, and the key stays injective.
 func aclCacheKey(ctx context.Context, info *authorization.Info, organizationID string) (string, error) {
 	scope := organizationID
 	if scope == "" {

--- a/pkg/oauth2/README.md
+++ b/pkg/oauth2/README.md
@@ -177,11 +177,9 @@ audit label, e.g. the `OAuth2Provider` name) and a `SrcIss` (the issuer URL verb
 (`(srcIss, subject)` matching against `--global-role-binding` / legacy
 `--platform-administrator-subjects` entries — see [`pkg/rbac/README.md`](../rbac/README.md#global-role-bindings)).
 The sentinel `"uni"` is deliberately not a valid URL so it cannot collide with a real issuer.
-`externalUserinfo` rejects an existing-but-inactive local user regardless of
-`allowExternalIdentity`; that check covers only the global `User` record, not org-level suspension
-— see
-[`docs/multi-issuer-token-contract.md#membership-resolution`](../../docs/multi-issuer-token-contract.md#membership-resolution)
-for the scope of that check and the gap it leaves open.
+Membership admission — including `externalUserinfo`'s inactive-user rejection and the gaps it
+leaves — is defined in
+[`docs/multi-issuer-token-contract.md#membership-resolution`](../../docs/multi-issuer-token-contract.md#membership-resolution).
 
 ### Per-provider claim contract
 

--- a/pkg/oauth2/README.md
+++ b/pkg/oauth2/README.md
@@ -178,10 +178,10 @@ audit label, e.g. the `OAuth2Provider` name) and a `SrcIss` (the issuer URL verb
 `--platform-administrator-subjects` entries — see [`pkg/rbac/README.md`](../rbac/README.md#global-role-bindings)).
 The sentinel `"uni"` is deliberately not a valid URL so it cannot collide with a real issuer.
 `externalUserinfo` rejects an existing-but-inactive local user regardless of
-`allowExternalIdentity`, but that check only covers a globally-inactive `User` record — a user
-suspended (or removed) from every organization instead resolves to an empty `orgIds` list with no
-error, so that path can still ride an external token into an empty-`orgIds` passport. This change
-does not close it.
+`allowExternalIdentity`; that check covers only the global `User` record, not org-level suspension
+— see
+[`docs/multi-issuer-token-contract.md#membership-resolution`](../../docs/multi-issuer-token-contract.md#membership-resolution)
+for the scope of that check and the gap it leaves open.
 
 ### Per-provider claim contract
 

--- a/pkg/oauth2/README.md
+++ b/pkg/oauth2/README.md
@@ -173,8 +173,15 @@ token are discarded.
 **The `src_iss` claim.** The resulting `dispatchResult` carries both a `Source` (coarse provider
 audit label, e.g. the `OAuth2Provider` name) and a `SrcIss` (the issuer URL verbatim, or the
 `PassportSourceUNI` sentinel for UNI-local tokens). `SrcIss` is stamped on the minted passport as
-`src_iss` and is the security-load-bearing value used by RBAC's platform-administrator fast-path.
+`src_iss` and is the security-load-bearing value used by RBAC's global role binding resolution
+(`(srcIss, subject)` matching against `--global-role-binding` / legacy
+`--platform-administrator-subjects` entries — see [`pkg/rbac/README.md`](../rbac/README.md#global-role-bindings)).
 The sentinel `"uni"` is deliberately not a valid URL so it cannot collide with a real issuer.
+`externalUserinfo` rejects an existing-but-inactive local user regardless of
+`allowExternalIdentity`, but that check only covers a globally-inactive `User` record — a user
+suspended (or removed) from every organization instead resolves to an empty `orgIds` list with no
+error, so that path can still ride an external token into an empty-`orgIds` passport. This change
+does not close it.
 
 ### Per-provider claim contract
 

--- a/pkg/oauth2/passport.go
+++ b/pkg/oauth2/passport.go
@@ -430,15 +430,10 @@ func peekIssuer(token string) (string, error) {
 // source-claims pair. It is the single implementation for all bearer-trust
 // paths; dispatchUserinfo wires it for every JWS path via validatorForIssuer.
 //
-// When the email is not found in the UNI user database (ErrResourceReference)
-// and trust.AllowExternalIdentity is true, the subject is accepted with an
-// empty orgIds slice — RBAC decides what it can reach. If AllowExternalIdentity
-// is false, the request is rejected with the same error message as the prior
-// unconditional rejection, preserving the existing wire contract. A user record
-// that exists but is not active (ErrUserInactive) is always rejected, regardless
-// of AllowExternalIdentity: a locally-suspended user must not be re-admitted
-// with an empty-membership passport just because the identity is externally
-// asserted.
+// A user missing from the UNI database is admitted without memberships only
+// when trust.AllowExternalIdentity is true; an inactive one is always
+// rejected. Rejections reuse the prior error message, preserving the existing
+// wire contract. See docs/multi-issuer-token-contract.md#membership-resolution.
 //
 // sourceClaims.Issuer is stamped with rawIss (the verbatim issuer the IdP
 // emitted, as resolved by validatorForIssuer) so that srcIssForSource can compute
@@ -455,9 +450,8 @@ func (a *Authenticator) externalUserinfo(ctx context.Context, r *http.Request, t
 	orgIDs, err := a.userdb.GetOrganizationIDs(ctx, user.Email)
 	if err != nil {
 		switch {
+		// Must precede the ErrResourceReference cases: ErrUserInactive wraps it.
 		case goerrors.Is(err, userdb.ErrUserInactive):
-			// Inactive is a deliberate local revocation: reject regardless of
-			// AllowExternalIdentity, never resurrect with an empty membership.
 			return nil, nil, errors.OAuth2AccessDenied("user identity not found or inactive").WithError(err)
 		case goerrors.Is(err, userdb.ErrResourceReference) && !trust.AllowExternalIdentity:
 			return nil, nil, errors.OAuth2AccessDenied("user identity not found or inactive").WithError(err)

--- a/pkg/oauth2/passport.go
+++ b/pkg/oauth2/passport.go
@@ -434,7 +434,11 @@ func peekIssuer(token string) (string, error) {
 // and trust.AllowExternalIdentity is true, the subject is accepted with an
 // empty orgIds slice — RBAC decides what it can reach. If AllowExternalIdentity
 // is false, the request is rejected with the same error message as the prior
-// unconditional rejection, preserving the existing wire contract.
+// unconditional rejection, preserving the existing wire contract. A user record
+// that exists but is not active (ErrUserInactive) is always rejected, regardless
+// of AllowExternalIdentity: a locally-suspended user must not be re-admitted
+// with an empty-membership passport just because the identity is externally
+// asserted.
 //
 // sourceClaims.Issuer is stamped with rawIss (the verbatim issuer the IdP
 // emitted, as resolved by validatorForIssuer) so that srcIssForSource can compute
@@ -450,13 +454,16 @@ func (a *Authenticator) externalUserinfo(ctx context.Context, r *http.Request, t
 	// membership. Claimed orgIds from the external token are discarded.
 	orgIDs, err := a.userdb.GetOrganizationIDs(ctx, user.Email)
 	if err != nil {
-		if goerrors.Is(err, userdb.ErrResourceReference) {
-			if !trust.AllowExternalIdentity {
-				return nil, nil, errors.OAuth2AccessDenied("user identity not found or inactive").WithError(err)
-			}
-
+		switch {
+		case goerrors.Is(err, userdb.ErrUserInactive):
+			// Inactive is a deliberate local revocation: reject regardless of
+			// AllowExternalIdentity, never resurrect with an empty membership.
+			return nil, nil, errors.OAuth2AccessDenied("user identity not found or inactive").WithError(err)
+		case goerrors.Is(err, userdb.ErrResourceReference) && !trust.AllowExternalIdentity:
+			return nil, nil, errors.OAuth2AccessDenied("user identity not found or inactive").WithError(err)
+		case goerrors.Is(err, userdb.ErrResourceReference):
 			orgIDs = nil // accepted with no memberships; authority decided by RBAC
-		} else {
+		default:
 			return nil, nil, fmt.Errorf("%w: failed to query organization IDs", err)
 		}
 	}

--- a/pkg/oauth2/passport_internal_test.go
+++ b/pkg/oauth2/passport_internal_test.go
@@ -860,6 +860,10 @@ const (
 
 	// externalTestAudience is the audience used by externalUserinfo tests.
 	externalTestAudience = "https://external-idp.example.com"
+
+	// emailInactiveUser is the email of a UNI user record that exists but is
+	// not active.
+	emailInactiveUser = "inactive@example.com"
 )
 
 type externalUserinfoTestIssuer struct {
@@ -946,12 +950,19 @@ func (i *externalUserinfoTestIssuer) token(t *testing.T, audience, email string,
 // helpers below.
 type externalUserinfoTestConfig struct {
 	allowExternalIdentity bool
+	seedObjects           []client.Object
 }
 
 type externalUserinfoOpt func(*externalUserinfoTestConfig)
 
 func withAllowExternalIdentity(v bool) externalUserinfoOpt {
 	return func(c *externalUserinfoTestConfig) { c.allowExternalIdentity = v }
+}
+
+// withSeedObjects pre-populates the fake client backing the test environment,
+// e.g. with a User record to exercise lookups that must find something.
+func withSeedObjects(objs ...client.Object) externalUserinfoOpt {
+	return func(c *externalUserinfoTestConfig) { c.seedObjects = objs }
 }
 
 // buildExternalUserinfoEnv constructs a minimal Authenticator backed by a fake
@@ -970,7 +981,7 @@ func buildExternalUserinfoEnv(t *testing.T, opts ...externalUserinfoOpt) (*Authe
 	require.NoError(t, scheme.AddToScheme(s))
 	require.NoError(t, unikornv1.AddToScheme(s))
 
-	cli := fake.NewClientBuilder().WithScheme(s).Build()
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg.seedObjects...).Build()
 
 	udb := userdb.NewUserDatabase(cli, passportTestNamespace)
 
@@ -1046,6 +1057,27 @@ func TestExternalUserinfoRejectsUnknownWhenNotAllowed(t *testing.T) {
 	if _, _, err := tryExternalUserinfo(t, withAllowExternalIdentity(false)); err == nil {
 		t.Fatal("expected reject for unknown user when AllowExternalIdentity is false")
 	}
+}
+
+// Inactive is a deliberate local revocation: allowExternalIdentity must not
+// resurrect the subject with an empty-membership passport.
+func TestExternalUserinfoRejectsInactiveUserDespiteAllowExternalIdentity(t *testing.T) {
+	t.Parallel()
+
+	user := &unikornv1.User{
+		ObjectMeta: metav1.ObjectMeta{Namespace: passportTestNamespace, Name: "inactive-user"},
+		Spec:       unikornv1.UserSpec{Subject: emailInactiveUser, State: unikornv1.UserStateSuspended},
+	}
+
+	a, iss, trust, v := buildExternalUserinfoEnv(t, withAllowExternalIdentity(true), withSeedObjects(user))
+
+	tok := iss.token(t, externalTestAudience, emailInactiveUser, time.Now().Add(30*time.Second))
+
+	req := httptest.NewRequest(http.MethodGet, "https://test.example.com/api/v1/x", nil)
+
+	_, _, err := a.externalUserinfo(t.Context(), req, tok, iss.issuer(), trust, v)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user identity not found or inactive")
 }
 
 func TestExternalUserinfoStampsIssuer(t *testing.T) {

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -29,8 +29,9 @@ The package enforces several important security rules:
 - a caller may only grant a role if the caller already holds all permissions contained in that role
 - when a system service acts as an impersonated principal, the effective ACL is the intersection of
   the principal's ACL and the service's ACL
-- platform-administrator matching is issuer-qualified: a subject is only recognized as a
-  platform administrator when the token's `src_iss` matches the registered issuer entry
+- global role binding matching is issuer-qualified: a principal is only granted a binding's
+  roles when the token's `src_iss` matches the binding's registered issuer exactly — this covers
+  both platform-administrator entries and the general `--global-role-binding` mechanism
 
 Those rules prevent several different forms of privilege escalation:
 
@@ -166,35 +167,104 @@ When a system account carries an impersonated principal, RBAC does not simply sw
 principal's ACL. Instead, it intersects the principal ACL with the system account ACL so the service
 cannot exercise permissions that either side lacks.
 
-### Platform-administrator issuer-aware fast-path
+### Global role bindings
 
-User account ACL resolution includes a fast-path for platform administrators. The match is on the
-pair `(srcIss, subject)` where `srcIss` is the issuer URL (verbatim, as the IdP emits it) carried in
-the passport's `src_iss` claim (or the `"uni"` sentinel for UNI-local tokens). The match is an exact
-string comparison against each `PlatformAdministratorSubject` entry registered via
-`--platform-administrator-subjects`; the configured issuer must equal the emitted `iss` exactly
-(for Auth0, including the trailing slash).
+Global privileges are expressed through a single mechanism: a **global role binding** maps an
+`(issuer, subject | "*")` pair to a set of role IDs. Every kind of global principal — platform
+administrators today, and any future issuer-wide grant such as ID-399's planned platform-reader —
+is expressed as data through this one mechanism; no per-class fast-path or role name is hardcoded
+in Go. `resolveGlobalRoleBindings` is the only path by which global privileges are granted,
+evaluated at the top of `processUserAccountACL` before membership resolution.
 
-Platform-administrator subjects should be registered in `issuer::subject` form when any non-UNI
-bearer-trust provider is configured. A bare subject (no `::` prefix) defaults the issuer to the
-UNI sentinel, which cannot be forged by an external token because the sentinel is deliberately
-not a valid URL.
+Bindings are configured with the repeated flag
+`--global-role-binding=<issuer>::<subject>::<roleID>[,<roleID>...]`, rendered by the chart from
+`globalRoleBindings` (`charts/identity/values.yaml`). Parsing is **right-anchored**: the role list
+follows the *last* `::`, the subject sits between the second-to-last and last `::`, and everything
+before that is the issuer — this keeps issuer URLs that themselves contain `::` (IPv6 literals such
+as `https://[2001:db8::1]/`) unambiguous. `issuer` must be either the verbatim `iss` the IdP emits
+(exact string match, including Auth0's trailing slash) or the `uni` sentinel for UNI-local tokens.
+`subject` is either an exact subject (matched case-insensitively, with surrounding whitespace
+trimmed on both sides) or the literal wildcard `*`, which matches any subject authenticated by
+that issuer. Malformed grammar, empty segments (issuer, subject, or any role in
+the list), a wildcard subject on the `uni` sentinel, and an issuer that is neither the sentinel nor
+an absolute URL (no commas or whitespace) are all rejected at flag-parse time — the process does
+not boot on a malformed binding.
 
-**Bare entries are mirrored onto the legacy Auth0 issuer at server construction.** When the
-deprecated `--auth0-exchange-issuer` flag is set, `expandBareAdminSubjects` (in `pkg/server`)
-appends, for every bare entry, a concrete issuer-qualified duplicate for that flag's issuer. This
-reproduces the issuer-unaware matching that predates issuer qualification: a bare entry matches
-both UNI-login sessions (via the retained sentinel entry) and Auth0-exchange sessions (via the
-mirror), and never a CRD-declared `bearerTrust` issuer. The mirror grants nothing the old
-issuer-blind match did not already grant.
+**Replace, not additive.** When one or more bindings match the authenticated `(srcIss, subject)`,
+the resulting ACL is exactly the union of those bindings' global scopes (read-clamped for wildcard
+bindings), and organization/project membership resolution is skipped entirely for that session.
+This is a deliberate session-level privilege separation: a hybrid principal (bound issuer/subject
+*and* a UNI organization membership) loses their own-org write permissions while authenticated
+through the bound issuer — authenticating via the other issuer restores them. Multiple matching
+bindings (for example an
+exact and a wildcard entry on the same issuer) accumulate together.
 
-**`Options.Validate` is a startup-only, advisory migration check.** When called during startup
-with the list of non-UNI `bearerTrust` issuers currently present in the operator namespace (the
-legacy flag issuer is deliberately excluded — the mirroring above already covers it), it reports
-any admin entry still in bare (UNI-sentinel) form. The caller logs a warning; startup is never
-rejected, since a bare entry cannot match a CRD-declared issuer and a boot-time failure would
-otherwise fire at an unrelated pod restart long after the first `bearerTrust` CRD was created.
-The always-on, runtime control is the issuer-qualified `(srcIss, subject)` match in
+**The wildcard clamp bounds verbs, not sensitivity.** A wildcard-subject binding is clamped in
+code (`accumulateGlobalReadPermissions`) to the `read` operation of each
+referenced role's global scopes, regardless of what the role otherwise grants — pointing a
+wildcard at a CRUD role yields read-everything, never write. That clamp says nothing about what a
+read endpoint *returns*: some read endpoints return credential material (for example object-storage
+access keys), so any role referenced by a wildcard binding needs its own read-surface audit before
+being used that way. `platform-reader` receives that audit under ID-399; this mechanism only
+bounds the verb, not the payload sensitivity.
+
+**Sentinel and impersonation rules.** A wildcard subject can never match the `uni` sentinel or an
+empty issuer — rejected at parse time for the sentinel case, and guarded again at match time
+(`resolveGlobalRoleBindings`) as defence in depth for an issuer left unset by any future caller;
+today, impersonated principals and pre-`src_iss` passports are always given the UNI sentinel before
+reaching this check, so the empty-issuer branch is currently unreachable. Bindings resolve against
+the *authenticating* issuer: impersonated principals are always evaluated against the UNI sentinel
+(`processImpersonatedPrincipalACL` /
+`srcIssOrUNISentinel`), so an external-issuer binding never applies on a delegated service hop —
+it fails closed — while a `uni`-exact binding still applies there, intersected with the service's
+ACL, exactly as legacy bare admin subjects always have.
+
+**Legacy flags translate verbatim.** `--platform-administrator-subjects` and
+`--platform-administrator-role-ids` continue to work: each subject is translated into an exact
+(non-wildcard) `GlobalRoleBinding` at RBAC construction (`effectiveGlobalRoleBindings`),
+byte-for-byte reproducing today's admin behavior, including the `pkg/server` mirroring onto the
+deprecated `--auth0-exchange-issuer` flag for bare entries (see below). Translation is verbatim in
+the literal sense too: a legacy subject that happens to be the string `*` stays an exact-match
+subject and never gains wildcard semantics — only the new `--global-role-binding` flag's subject
+`*` is treated as a wildcard.
+
+A bare legacy subject (no `::` prefix) defaults the issuer to the UNI sentinel, which cannot be
+forged by an external token because the sentinel is deliberately not a valid URL. **Bare entries
+are mirrored onto the legacy Auth0 issuer at server construction:** when the deprecated
+`--auth0-exchange-issuer` flag is set, `expandBareAdminSubjects` (in `pkg/server`) appends, for
+every bare entry, a concrete issuer-qualified duplicate for that flag's issuer. This reproduces the
+issuer-unaware matching that predates issuer qualification: a bare entry matches both UNI-login
+sessions (via the retained sentinel entry) and Auth0-exchange sessions (via the mirror), and never
+a CRD-declared `bearerTrust` issuer. The mirror grants nothing the old issuer-blind match did not
+already grant.
+
+`--platform-administrator-role-ids` also independently feeds `NewSuperContext`, which derives the
+server's internal super-ACL directly from that role list. That path is untouched by bindings and is
+not a principal-facing decision, so it must not be shaped by the wildcard clamp or by
+`GlobalRoleBindings`; the flag remains required even for deployments that express every admin
+*subject* through `--global-role-binding`.
+
+**Operator guidance.** An issuer-wide (wildcard) binding is only appropriate for an issuer whose
+entire user population is itself an authorization decision — for example a staff-only IdP, where
+"authenticated by this issuer" already means "should see this data" — never for a general-purpose
+IdP with a mixed user base.
+
+**`Options.Validate` checks two startup-only, advisory conditions and reports both when present**
+(joined with the stdlib `errors.Join`, so `errors.Is` still matches each individually); it does not
+block startup: (1) a bare (UNI-sentinel) `--platform-administrator-subjects` entry while a non-UNI
+issuer is trusted (the pre-existing migration check), and (2) a `--global-role-binding` entry whose
+issuer is neither the UNI sentinel nor one of the currently trusted non-UNI issuers
+(`ErrUntrustedBindingIssuer`) — the deprecated `--auth0-exchange-issuer` value is deliberately
+excluded from that trusted set, so a binding aimed at the legacy exchange issuer also warns even
+though it can still match a real token. Both surface the dominant failure mode — most often a stray
+or mistyped issuer that can never match a real token — as an operator-visible warning; the warning
+is not the runtime security control. Within each of the two conditions, only the first offending
+entry is reported, so a second offending entry of the *same* kind stays silent until the first is
+fixed. Both checks are gated on a non-empty trusted-issuer list: the caller
+(`computeTrustedNonUNIIssuers`) cannot distinguish "genuinely no trusted non-UNI issuers" from "the
+provider `List` failed", so an empty list skips both checks rather than risk a false advisory on
+every startup where the list is transiently unavailable. The always-on control is the
+issuer-qualified `(srcIss, subject)` match performed by `resolveGlobalRoleBindings` inside
 `processUserAccountACL`. Operators must not rely on `Options.Validate` as a protection.
 
 ## Invariants
@@ -208,10 +278,20 @@ The always-on, runtime control is the issuer-qualified `(srcIss, subject)` match
 - Group membership is the main route from actors to roles.
 - The ACL output is both an enforcement artifact and a visibility artifact, so incorrect ACL
   construction affects both authorization and UX.
-- Platform-administrator matching is always issuer-qualified at runtime via `(srcIss, subject)`.
-  `Options.Validate` is a startup-only advisory warning; it does not replace the runtime control.
-  Bare entries match only the UNI sentinel plus, via the startup mirror in `pkg/server`, the
+- Global role binding matching is always issuer-qualified at runtime via `(srcIss, subject)`,
+  evaluated by `resolveGlobalRoleBindings`. `Options.Validate` checks two startup-only advisory
+  conditions (stale bare admin entries; untrusted binding issuers) and reports both when present,
+  but within each condition only the first offending entry, and does not replace the runtime
+  control. Both conditions are skipped outright when the trusted non-UNI issuer list is empty,
+  since the caller cannot distinguish that from a transient failure to list providers. Bare legacy
+  admin entries match only the UNI sentinel plus, via the startup mirror in `pkg/server`, the
   legacy auth0-exchange flag issuer — never a CRD-declared issuer.
+- A wildcard-subject binding is always clamped to the `read` operation at authorization time. The
+  clamp bounds verbs only; it says nothing about a read endpoint's response sensitivity, so any
+  role referenced by a wildcard binding must be individually read-surface-audited before use.
+- Bindings resolve against the authenticating issuer, never a client-supplied one. Impersonated
+  principals are always evaluated against the UNI sentinel, so an external-issuer binding can
+  never apply through a delegated service hop — it fails closed.
 - The confused-deputy invariant: a system service acting as an impersonated principal cannot hold
   permissions that either the principal's ACL or the service's ACL denies. The ACL intersection
   enforces this regardless of which IdP authenticated the principal.

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -183,12 +183,20 @@ follows the *last* `::`, the subject sits between the second-to-last and last `:
 before that is the issuer — this keeps issuer URLs that themselves contain `::` (IPv6 literals such
 as `https://[2001:db8::1]/`) unambiguous. `issuer` must be either the verbatim `iss` the IdP emits
 (exact string match, including Auth0's trailing slash) or the `uni` sentinel for UNI-local tokens.
-`subject` is either an exact subject (matched case-insensitively, with surrounding whitespace
+`subject` is either an exact subject (matched case-sensitively, with surrounding whitespace
 trimmed on both sides) or the literal wildcard `*`, which matches any subject authenticated by
 that issuer. Malformed grammar, empty segments (issuer, subject, or any role in the list), a
 wildcard subject on the `uni` sentinel, and an issuer that is neither the sentinel nor an absolute
 URL (no commas or whitespace) are all rejected at flag-parse time — the process does not boot on a
 malformed binding.
+
+**Subjects must be in their canonical lower-case form.** Matching is case-sensitive end to end: the
+authenticated subject arrives already lower-cased (Auth0's `validateEmail` normalizes the claim
+before it reaches RBAC), so a binding subject typed in any other case would simply stop matching.
+The chart fails to render if a `globalRoleBindings` or `platformAdministrators.subjects` entry
+contains an upper-case ASCII letter (the literal wildcard `*` is exempt, having no letters to
+begin with), catching the mistake before deploy rather than deploying a binding that silently
+never matches.
 
 **Replace, not additive.** When one or more bindings match the authenticated `(srcIss, subject)`,
 the resulting ACL is exactly the union of those bindings' global scopes (read-clamped for wildcard

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -253,6 +253,18 @@ entire user population is itself an authorization decision — for example a sta
 "authenticated by this issuer" already means "should see this data" — never for a general-purpose
 IdP with a mixed user base.
 
+**There is no group-based path to global authority.** `acl.Global` is populated from exactly two
+sources: `resolveGlobalRoleBindings` (feeding `accumulateGlobalPermissions` or, for wildcard
+bindings, `accumulateGlobalReadPermissions`) and `processSystemAccountACL`'s X.509-CN-to-role
+mapping for system accounts. Group membership resolves only `Role.Spec.Scopes.Organization` and
+`Role.Spec.Scopes.Project` (`accumulateOrganizationPermissions`, `accumulateProjectPermissions`);
+`accumulateGlobalPermissions` deliberately takes a role ID list rather than groups, precisely so
+standard users cannot be granted global permissions through membership. This means "grant platform
+administrators via a group" is not an available alternative to exact per-subject bindings — a
+group-based grant would be runtime-mutable and centrally auditable in a way an exact binding is
+not, so the absence of that path is a real limitation of the current mechanism, not just an
+unused option.
+
 **`Options.Validate` reports every finding from two advisory startup checks**, joined with the
 stdlib `errors.Join` so `errors.Is` still matches each individually. It never blocks startup:
 (1) a bare (UNI-sentinel) `--platform-administrator-subjects` entry while a non-UNI issuer is

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -238,11 +238,10 @@ sessions (via the retained sentinel entry) and Auth0-exchange sessions (via the 
 a CRD-declared `bearerTrust` issuer. The mirror grants nothing the old issuer-blind match did not
 already grant.
 
-`--platform-administrator-role-ids` also independently feeds `NewSuperContext`, which derives the
-server's internal super-ACL directly from that role list. That path is untouched by bindings and is
-not a principal-facing decision, so it must not be shaped by the wildcard clamp or by
-`GlobalRoleBindings`; the flag remains required even for deployments that express every admin
-*subject* through `--global-role-binding`.
+`--platform-administrator-role-ids` supplies the role list for those translated bindings and has no
+other consumer, so it is needed only while admin subjects are still expressed through
+`--platform-administrator-subjects`. A deployment that expresses every admin through
+`--global-role-binding` does not need it.
 
 **Operator guidance.** An issuer-wide (wildcard) binding is only appropriate for an issuer whose
 entire user population is itself an authorization decision — for example a staff-only IdP, where

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -208,6 +208,16 @@ access keys), so any role referenced by a wildcard binding needs its own read-su
 being used that way. `platform-reader` receives that audit under ID-399; this mechanism only
 bounds the verb, not the payload sensitivity.
 
+**A chart render-time guard complements the runtime clamp.** The chart
+(`charts/identity/templates/identity/deployment.yaml`) fails to render if a wildcard binding
+references a role whose global scopes include any non-`read` operation, naming the binding index,
+role, and offending scope. This is config-time enforcement, not a substitute for the clamp above:
+it keeps the Role CRD authoritative for what an operator *configures* a wildcard binding to grant,
+but Roles are live CRDs that can gain write scopes after the binding is rendered, which no
+render-time check can see — the runtime clamp remains the defence-in-depth backstop for that case.
+As a consequence, no role currently shipped in `charts/identity/values.yaml` passes this guard;
+only a dedicated, audited read-only role (`platform-reader`, ID-399) will.
+
 **Sentinel and impersonation rules.** A wildcard subject can never match the `uni` sentinel or an
 empty issuer — rejected at parse time for the sentinel case, and guarded again at match time
 (`resolveGlobalRoleBindings`) as defence in depth for an issuer left unset by any future caller;
@@ -288,6 +298,10 @@ is the issuer-qualified `(srcIss, subject)` match performed by `resolveGlobalRol
 - A wildcard-subject binding is always clamped to the `read` operation at authorization time. The
   clamp bounds verbs only; it says nothing about a read endpoint's response sensitivity, so any
   role referenced by a wildcard binding must be individually read-surface-audited before use.
+- The chart additionally fails to render a wildcard binding whose role(s) declare any non-`read`
+  global operation, config-time enforcement that keeps the Role CRD authoritative for what an
+  operator can configure — but roles can gain write scopes after render time, so the runtime clamp
+  above still applies as a backstop and is not made redundant by the render-time guard.
 - Bindings resolve against the authenticating issuer, never a client-supplied one. Impersonated
   principals are always evaluated against the UNI sentinel, so an external-issuer binding can
   never apply through a delegated service hop — it fails closed.

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -185,10 +185,10 @@ as `https://[2001:db8::1]/`) unambiguous. `issuer` must be either the verbatim `
 (exact string match, including Auth0's trailing slash) or the `uni` sentinel for UNI-local tokens.
 `subject` is either an exact subject (matched case-insensitively, with surrounding whitespace
 trimmed on both sides) or the literal wildcard `*`, which matches any subject authenticated by
-that issuer. Malformed grammar, empty segments (issuer, subject, or any role in
-the list), a wildcard subject on the `uni` sentinel, and an issuer that is neither the sentinel nor
-an absolute URL (no commas or whitespace) are all rejected at flag-parse time — the process does
-not boot on a malformed binding.
+that issuer. Malformed grammar, empty segments (issuer, subject, or any role in the list), a
+wildcard subject on the `uni` sentinel, and an issuer that is neither the sentinel nor an absolute
+URL (no commas or whitespace) are all rejected at flag-parse time — the process does not boot on a
+malformed binding.
 
 **Replace, not additive.** When one or more bindings match the authenticated `(srcIss, subject)`,
 the resulting ACL is exactly the union of those bindings' global scopes (read-clamped for wildcard
@@ -196,38 +196,33 @@ bindings), and organization/project membership resolution is skipped entirely fo
 This is a deliberate session-level privilege separation: a hybrid principal (bound issuer/subject
 *and* a UNI organization membership) loses their own-org write permissions while authenticated
 through the bound issuer — authenticating via the other issuer restores them. Multiple matching
-bindings (for example an
-exact and a wildcard entry on the same issuer) accumulate together.
+bindings (for example an exact and a wildcard entry on the same issuer) accumulate together.
 
-**The wildcard clamp bounds verbs, not sensitivity.** A wildcard-subject binding is clamped in
-code (`accumulateGlobalReadPermissions`) to the `read` operation of each
-referenced role's global scopes, regardless of what the role otherwise grants — pointing a
-wildcard at a CRUD role yields read-everything, never write. That clamp says nothing about what a
-read endpoint *returns*: some read endpoints return credential material (for example object-storage
-access keys), so any role referenced by a wildcard binding needs its own read-surface audit before
-being used that way. `platform-reader` receives that audit under ID-399; this mechanism only
-bounds the verb, not the payload sensitivity.
+**The wildcard clamp bounds verbs, not sensitivity.** A wildcard-subject binding is clamped in code
+(`accumulateGlobalReadPermissions`) to the `read` operation of each referenced role's global scopes,
+so pointing a wildcard at a CRUD role yields read-everything, never write. It says nothing about
+what a read endpoint *returns* — some return credential material, such as object-storage access
+keys — so any role referenced by a wildcard binding needs its own read-surface audit first.
+`platform-reader` receives that audit under ID-399.
 
 **A chart render-time guard complements the runtime clamp.** The chart
 (`charts/identity/templates/identity/deployment.yaml`) fails to render if a wildcard binding
 references a role whose global scopes include any non-`read` operation, naming the binding index,
-role, and offending scope. This is config-time enforcement, not a substitute for the clamp above:
-it keeps the Role CRD authoritative for what an operator *configures* a wildcard binding to grant,
-but Roles are live CRDs that can gain write scopes after the binding is rendered, which no
-render-time check can see — the runtime clamp remains the defence-in-depth backstop for that case.
-As a consequence, no role currently shipped in `charts/identity/values.yaml` passes this guard;
-only a dedicated, audited read-only role (`platform-reader`, ID-399) will.
+role, and offending scope. That keeps the Role CRD authoritative for what an operator can
+*configure*, but Roles are live and can gain write scopes after the render — which no render-time
+check can see, so the clamp above remains the backstop. No role currently shipped in
+`charts/identity/values.yaml` passes this guard; only a dedicated, audited read-only role
+(`platform-reader`, ID-399) will.
 
 **Sentinel and impersonation rules.** A wildcard subject can never match the `uni` sentinel or an
-empty issuer — rejected at parse time for the sentinel case, and guarded again at match time
-(`resolveGlobalRoleBindings`) as defence in depth for an issuer left unset by any future caller;
-today, impersonated principals and pre-`src_iss` passports are always given the UNI sentinel before
-reaching this check, so the empty-issuer branch is currently unreachable. Bindings resolve against
-the *authenticating* issuer: impersonated principals are always evaluated against the UNI sentinel
-(`processImpersonatedPrincipalACL` /
-`srcIssOrUNISentinel`), so an external-issuer binding never applies on a delegated service hop —
-it fails closed — while a `uni`-exact binding still applies there, intersected with the service's
-ACL, exactly as legacy bare admin subjects always have.
+empty issuer — rejected at parse time for the sentinel, and guarded again at match time
+(`resolveGlobalRoleBindings`) as defence in depth should a future caller leave the issuer unset;
+today impersonated principals and pre-`src_iss` passports always carry the sentinel, so that branch
+is unreachable. Bindings resolve against the *authenticating* issuer: impersonated principals are
+evaluated against the sentinel (`processImpersonatedPrincipalACL` / `srcIssOrUNISentinel`), so an
+external-issuer binding never applies on a delegated service hop — it fails closed — while a
+`uni`-exact binding still applies there, intersected with the service's ACL, exactly as legacy bare
+admin subjects always have.
 
 **Legacy flags translate verbatim.** `--platform-administrator-subjects` and
 `--platform-administrator-role-ids` continue to work: each subject is translated into an exact
@@ -258,23 +253,21 @@ entire user population is itself an authorization decision — for example a sta
 "authenticated by this issuer" already means "should see this data" — never for a general-purpose
 IdP with a mixed user base.
 
-**`Options.Validate` checks two startup-only, advisory conditions and reports every offending entry
-in each** (joined with the stdlib `errors.Join`, so `errors.Is` still matches each individually); it
-does not block startup: (1) a bare (UNI-sentinel) `--platform-administrator-subjects` entry while a
-non-UNI issuer is trusted (the pre-existing migration check), and (2) a `--global-role-binding`
-entry whose issuer is neither the UNI sentinel nor one of the currently trusted non-UNI issuers
-(`ErrUntrustedBindingIssuer`) — the deprecated `--auth0-exchange-issuer` value is deliberately
-excluded from that trusted set, so a binding aimed at the legacy exchange issuer also warns even
-though it can still match a real token. Both surface the dominant failure mode — most often a stray
-or mistyped issuer that can never match a real token — as an operator-visible warning; the warning
-is not the runtime security control. Only condition (1) is gated on a non-empty trusted-issuer list:
-a bare admin entry only matters once a non-UNI issuer is trusted to migrate away from. Condition (2)
-has no such gate and runs even against a genuinely empty trusted-issuer list, where every non-UNI
-binding issuer is reported as untrusted — the caller must not call `Validate` at all if it cannot
-tell "no trusted issuers configured" apart from "the provider `List` call failed"
-(`computeTrustedNonUNIIssuers` in `pkg/server` returns an error for that case). The always-on control
-is the issuer-qualified `(srcIss, subject)` match performed by `resolveGlobalRoleBindings` inside
-`processUserAccountACL`. Operators must not rely on `Options.Validate` as a protection.
+**`Options.Validate` reports every finding from two advisory startup checks**, joined with the
+stdlib `errors.Join` so `errors.Is` still matches each individually. It never blocks startup:
+(1) a bare (UNI-sentinel) `--platform-administrator-subjects` entry while a non-UNI issuer is
+trusted, and (2) a `--global-role-binding` issuer that is neither the UNI sentinel nor a currently
+trusted non-UNI issuer (`ErrUntrustedBindingIssuer`). Check (2) excludes the deprecated
+`--auth0-exchange-issuer` value from the trusted set, so a binding aimed at the legacy exchange
+issuer warns even though it can still match a real token.
+
+Only check (1) is gated on a non-empty trusted-issuer list — a bare admin entry only matters once
+there is a non-UNI issuer to migrate away from. Check (2) runs even against an empty list, where
+every non-UNI binding issuer is reported, so the caller must skip `Validate` entirely when it
+cannot tell "no trusted issuers configured" from "the provider `List` call failed"
+(`computeTrustedNonUNIIssuers` in `pkg/server` returns an error for that case). These warnings are
+not the security control: that is the issuer-qualified `(srcIss, subject)` match performed by
+`resolveGlobalRoleBindings` inside `processUserAccountACL`.
 
 ## Invariants
 
@@ -288,23 +281,17 @@ is the issuer-qualified `(srcIss, subject)` match performed by `resolveGlobalRol
 - The ACL output is both an enforcement artifact and a visibility artifact, so incorrect ACL
   construction affects both authorization and UX.
 - Global role binding matching is always issuer-qualified at runtime via `(srcIss, subject)`,
-  evaluated by `resolveGlobalRoleBindings`. `Options.Validate` checks two startup-only advisory
-  conditions (stale bare admin entries; untrusted binding issuers) and reports every offending
-  entry in each, not just the first, and does not replace the runtime control. The bare-admin-entry
-  check is skipped when the trusted non-UNI issuer list is empty (nothing to migrate away from yet);
-  the untrusted-binding-issuer check has no such gate. Bare legacy admin entries match only the UNI
-  sentinel plus, via the startup mirror in `pkg/server`, the legacy auth0-exchange flag issuer —
-  never a CRD-declared issuer.
-- A wildcard-subject binding is always clamped to the `read` operation at authorization time. The
-  clamp bounds verbs only; it says nothing about a read endpoint's response sensitivity, so any
-  role referenced by a wildcard binding must be individually read-surface-audited before use.
-- The chart additionally fails to render a wildcard binding whose role(s) declare any non-`read`
-  global operation, config-time enforcement that keeps the Role CRD authoritative for what an
-  operator can configure — but roles can gain write scopes after render time, so the runtime clamp
-  above still applies as a backstop and is not made redundant by the render-time guard.
+  evaluated by `resolveGlobalRoleBindings`. `Options.Validate` is startup-only and advisory and
+  does not replace it. Bare legacy admin entries match only the UNI sentinel plus, via the startup
+  mirror in `pkg/server`, the legacy auth0-exchange flag issuer — never a CRD-declared issuer.
+- A wildcard-subject binding is always clamped to `read` at authorization time. The clamp bounds
+  verbs, not response sensitivity, so any role it references needs a read-surface audit first.
+- The chart additionally refuses to render a wildcard binding on a role declaring any non-`read`
+  global operation. This does not make the runtime clamp redundant: roles can gain write scopes
+  after the render.
 - Bindings resolve against the authenticating issuer, never a client-supplied one. Impersonated
-  principals are always evaluated against the UNI sentinel, so an external-issuer binding can
-  never apply through a delegated service hop — it fails closed.
+  principals are evaluated against the UNI sentinel, so an external-issuer binding never applies
+  on a delegated service hop — it fails closed.
 - The confused-deputy invariant: a system service acting as an impersonated principal cannot hold
   permissions that either the principal's ACL or the service's ACL denies. The ACL intersection
   enforces this regardless of which IdP authenticated the principal.

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -249,22 +249,22 @@ entire user population is itself an authorization decision — for example a sta
 "authenticated by this issuer" already means "should see this data" — never for a general-purpose
 IdP with a mixed user base.
 
-**`Options.Validate` checks two startup-only, advisory conditions and reports both when present**
-(joined with the stdlib `errors.Join`, so `errors.Is` still matches each individually); it does not
-block startup: (1) a bare (UNI-sentinel) `--platform-administrator-subjects` entry while a non-UNI
-issuer is trusted (the pre-existing migration check), and (2) a `--global-role-binding` entry whose
-issuer is neither the UNI sentinel nor one of the currently trusted non-UNI issuers
+**`Options.Validate` checks two startup-only, advisory conditions and reports every offending entry
+in each** (joined with the stdlib `errors.Join`, so `errors.Is` still matches each individually); it
+does not block startup: (1) a bare (UNI-sentinel) `--platform-administrator-subjects` entry while a
+non-UNI issuer is trusted (the pre-existing migration check), and (2) a `--global-role-binding`
+entry whose issuer is neither the UNI sentinel nor one of the currently trusted non-UNI issuers
 (`ErrUntrustedBindingIssuer`) — the deprecated `--auth0-exchange-issuer` value is deliberately
 excluded from that trusted set, so a binding aimed at the legacy exchange issuer also warns even
 though it can still match a real token. Both surface the dominant failure mode — most often a stray
 or mistyped issuer that can never match a real token — as an operator-visible warning; the warning
-is not the runtime security control. Within each of the two conditions, only the first offending
-entry is reported, so a second offending entry of the *same* kind stays silent until the first is
-fixed. Both checks are gated on a non-empty trusted-issuer list: the caller
-(`computeTrustedNonUNIIssuers`) cannot distinguish "genuinely no trusted non-UNI issuers" from "the
-provider `List` failed", so an empty list skips both checks rather than risk a false advisory on
-every startup where the list is transiently unavailable. The always-on control is the
-issuer-qualified `(srcIss, subject)` match performed by `resolveGlobalRoleBindings` inside
+is not the runtime security control. Only condition (1) is gated on a non-empty trusted-issuer list:
+a bare admin entry only matters once a non-UNI issuer is trusted to migrate away from. Condition (2)
+has no such gate and runs even against a genuinely empty trusted-issuer list, where every non-UNI
+binding issuer is reported as untrusted — the caller must not call `Validate` at all if it cannot
+tell "no trusted issuers configured" apart from "the provider `List` call failed"
+(`computeTrustedNonUNIIssuers` in `pkg/server` returns an error for that case). The always-on control
+is the issuer-qualified `(srcIss, subject)` match performed by `resolveGlobalRoleBindings` inside
 `processUserAccountACL`. Operators must not rely on `Options.Validate` as a protection.
 
 ## Invariants
@@ -280,12 +280,12 @@ issuer-qualified `(srcIss, subject)` match performed by `resolveGlobalRoleBindin
   construction affects both authorization and UX.
 - Global role binding matching is always issuer-qualified at runtime via `(srcIss, subject)`,
   evaluated by `resolveGlobalRoleBindings`. `Options.Validate` checks two startup-only advisory
-  conditions (stale bare admin entries; untrusted binding issuers) and reports both when present,
-  but within each condition only the first offending entry, and does not replace the runtime
-  control. Both conditions are skipped outright when the trusted non-UNI issuer list is empty,
-  since the caller cannot distinguish that from a transient failure to list providers. Bare legacy
-  admin entries match only the UNI sentinel plus, via the startup mirror in `pkg/server`, the
-  legacy auth0-exchange flag issuer — never a CRD-declared issuer.
+  conditions (stale bare admin entries; untrusted binding issuers) and reports every offending
+  entry in each, not just the first, and does not replace the runtime control. The bare-admin-entry
+  check is skipped when the trusted non-UNI issuer list is empty (nothing to migrate away from yet);
+  the untrusted-binding-issuer check has no such gate. Bare legacy admin entries match only the UNI
+  sentinel plus, via the startup mirror in `pkg/server`, the legacy auth0-exchange flag issuer —
+  never a CRD-declared issuer.
 - A wildcard-subject binding is always clamped to the `read` operation at authorization time. The
   clamp bounds verbs only; it says nothing about a read endpoint's response sensitivity, so any
   role referenced by a wildcard binding must be individually read-surface-audited before use.

--- a/pkg/rbac/bindings.go
+++ b/pkg/rbac/bindings.go
@@ -146,13 +146,10 @@ func (v *GlobalRoleBindingsValue) String() string {
 
 func (*GlobalRoleBindingsValue) Type() string { return "issuer::subject::roles" }
 
-// accumulateGlobalReadPermissions is accumulateGlobalPermissions with the
-// wildcard clamp, applied at authorization time because Role CRDs are live
-// and can gain write scopes after the chart's render-time guard
-// (charts/identity/templates/identity/deployment.yaml) has already run. This
-// clamp is the defence-in-depth backstop for that gap and must not be
-// removed; see pkg/rbac/README.md#global-role-bindings for the full
-// two-layer rationale.
+// accumulateGlobalReadPermissions clamps wildcard bindings at authorization
+// time, because live Role CRDs can gain write scopes after the chart's
+// render-time guard has run. See pkg/rbac/README.md#global-role-bindings for
+// the two-layer rationale.
 func accumulateGlobalReadPermissions(acl *openapi.Acl, roleIDs []string, roles map[string]*unikornv1.Role) error {
 	for _, roleID := range roleIDs {
 		role, ok := roles[roleID]
@@ -160,8 +157,6 @@ func accumulateGlobalReadPermissions(acl *openapi.Acl, roleIDs []string, roles m
 			return fmt.Errorf("%w: role %s referenced by global role binding", errors.ErrConsistency, roleID)
 		}
 
-		// Clamp: project each scope down to its read operation only, dropping
-		// scopes that don't grant read at all.
 		readScopes := make([]unikornv1.RoleScope, 0, len(role.Spec.Scopes.Global))
 
 		for _, scope := range role.Spec.Scopes.Global {

--- a/pkg/rbac/bindings.go
+++ b/pkg/rbac/bindings.go
@@ -186,7 +186,11 @@ func effectiveGlobalRoleBindings(o *Options) []GlobalRoleBinding {
 
 // resolveGlobalRoleBindings returns the bindings matching the authenticated
 // (issuer, subject) pair. Wildcards never match the sentinel or an unset
-// issuer (impersonated principals, pre-src_iss passports).
+// issuer (impersonated principals, pre-src_iss passports). A non-wildcard
+// subject match is exact (case-sensitive) after trimming surrounding
+// whitespace on both sides: the authenticated subject already arrives
+// lower-cased and trimmed (pkg/oauth2's Auth0 email normalization), so this
+// trim only absorbs whitespace in a configured binding's subject.
 func (r *RBAC) resolveGlobalRoleBindings(srcIss, subject string) []GlobalRoleBinding {
 	var out []GlobalRoleBinding
 
@@ -205,7 +209,7 @@ func (r *RBAC) resolveGlobalRoleBindings(srcIss, subject string) []GlobalRoleBin
 			continue
 		}
 
-		if strings.EqualFold(strings.TrimSpace(b.Subject), strings.TrimSpace(subject)) {
+		if strings.TrimSpace(b.Subject) == strings.TrimSpace(subject) {
 			out = append(out, b)
 		}
 	}

--- a/pkg/rbac/bindings.go
+++ b/pkg/rbac/bindings.go
@@ -147,7 +147,12 @@ func (v *GlobalRoleBindingsValue) String() string {
 func (*GlobalRoleBindingsValue) Type() string { return "issuer::subject::roles" }
 
 // accumulateGlobalReadPermissions is accumulateGlobalPermissions with the
-// wildcard clamp, applied at authorization time (Role CRDs are live).
+// wildcard clamp, applied at authorization time because Role CRDs are live
+// and can gain write scopes after the chart's render-time guard
+// (charts/identity/templates/identity/deployment.yaml) has already run. This
+// clamp is the defence-in-depth backstop for that gap and must not be
+// removed; see pkg/rbac/README.md#global-role-bindings for the full
+// two-layer rationale.
 func accumulateGlobalReadPermissions(acl *openapi.Acl, roleIDs []string, roles map[string]*unikornv1.Role) error {
 	for _, roleID := range roleIDs {
 		role, ok := roles[roleID]

--- a/pkg/rbac/bindings.go
+++ b/pkg/rbac/bindings.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	goerrors "errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+	"unicode"
+
+	"github.com/spf13/pflag"
+
+	"github.com/unikorn-cloud/core/pkg/errors"
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	idconstants "github.com/unikorn-cloud/identity/pkg/constants"
+	"github.com/unikorn-cloud/identity/pkg/openapi"
+)
+
+const WildcardSubject = "*"
+
+// Sentinel errors wrapped with the offending flag value by Set/validateBindingIssuer.
+// Unexported: no consumer needs errors.Is on these, they exist only so err113
+// sees static errors instead of inline construction.
+var (
+	errMalformedBinding   = goerrors.New("want issuer::subject::role[,role...]")
+	errEmptySubject       = goerrors.New("empty subject")
+	errBadRoleID          = goerrors.New("role ID is empty or contains whitespace")
+	errSentinelWildcard   = goerrors.New("wildcard subject not allowed on the UNI sentinel issuer")
+	errIssuerCommaOrSpace = goerrors.New("issuer contains comma or whitespace")
+	errIssuerNotURL       = goerrors.New("issuer is neither the UNI sentinel nor an absolute URL")
+)
+
+// GlobalRoleBinding grants the global scopes of RoleIDs to Subject when
+// authenticated by Issuer. Wildcard is set only by the flag parser (subject
+// "*"): wildcard bindings match any subject and are clamped to read at
+// accumulation time. Legacy-translated bindings are always exact.
+type GlobalRoleBinding struct {
+	Issuer   string
+	Subject  string
+	RoleIDs  []string
+	Wildcard bool
+}
+
+// GlobalRoleBindingsValue parses repeated issuer::subject::role[,role...]
+// flags, one binding per flag occurrence.
+type GlobalRoleBindingsValue []GlobalRoleBinding
+
+var _ pflag.Value = (*GlobalRoleBindingsValue)(nil)
+
+// Set parses right-anchored: subjects and role IDs cannot contain "::", so
+// the last two separators are unambiguous even for IPv6 issuer URLs.
+func (v *GlobalRoleBindingsValue) Set(value string) error {
+	bad := func(err error) error { return fmt.Errorf("invalid global role binding %q: %w", value, err) }
+
+	last := strings.LastIndex(value, "::")
+	if last < 0 {
+		return bad(errMalformedBinding)
+	}
+
+	prev := strings.LastIndex(value[:last], "::")
+	if prev < 0 {
+		return bad(errMalformedBinding)
+	}
+
+	issuer, roleList := value[:prev], value[last+2:]
+	subject := strings.TrimSpace(value[prev+2 : last])
+
+	if subject == "" {
+		return bad(errEmptySubject)
+	}
+
+	if err := validateBindingIssuer(issuer, subject); err != nil {
+		return bad(err)
+	}
+
+	roleIDs := strings.Split(roleList, ",")
+	for _, id := range roleIDs {
+		if id == "" || strings.ContainsFunc(id, unicode.IsSpace) {
+			return bad(errBadRoleID)
+		}
+	}
+
+	*v = append(*v, GlobalRoleBinding{Issuer: issuer, Subject: subject, RoleIDs: roleIDs, Wildcard: subject == WildcardSubject})
+
+	return nil
+}
+
+// validateBindingIssuer accepts the UNI sentinel (exact subjects only — a
+// sentinel wildcard would match every local user) or an absolute URL. Comma
+// and whitespace are rejected explicitly: the legacy flag's comma-join idiom
+// would otherwise parse into one bogus never-matching binding.
+func validateBindingIssuer(issuer, subject string) error {
+	if issuer == idconstants.UNISentinel {
+		if subject == WildcardSubject {
+			return errSentinelWildcard
+		}
+
+		return nil
+	}
+
+	if strings.ContainsRune(issuer, ',') || strings.ContainsFunc(issuer, unicode.IsSpace) {
+		return errIssuerCommaOrSpace
+	}
+
+	if u, err := url.Parse(issuer); err != nil || u.Scheme == "" || u.Host == "" {
+		return errIssuerNotURL
+	}
+
+	return nil
+}
+
+func (v *GlobalRoleBindingsValue) String() string {
+	parts := make([]string, 0, len(*v))
+
+	for _, b := range *v {
+		parts = append(parts, b.Issuer+"::"+b.Subject+"::"+strings.Join(b.RoleIDs, ","))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+func (*GlobalRoleBindingsValue) Type() string { return "issuer::subject::roles" }
+
+// accumulateGlobalReadPermissions is accumulateGlobalPermissions with the
+// wildcard clamp, applied at authorization time (Role CRDs are live).
+func accumulateGlobalReadPermissions(acl *openapi.Acl, roleIDs []string, roles map[string]*unikornv1.Role) error {
+	for _, roleID := range roleIDs {
+		role, ok := roles[roleID]
+		if !ok {
+			return fmt.Errorf("%w: role %s referenced by global role binding", errors.ErrConsistency, roleID)
+		}
+
+		// Clamp: project each scope down to its read operation only, dropping
+		// scopes that don't grant read at all.
+		readScopes := make([]unikornv1.RoleScope, 0, len(role.Spec.Scopes.Global))
+
+		for _, scope := range role.Spec.Scopes.Global {
+			if slices.Contains(scope.Operations, unikornv1.Read) {
+				readScopes = append(readScopes, unikornv1.RoleScope{Name: scope.Name, Operations: []unikornv1.Operation{unikornv1.Read}})
+			}
+		}
+
+		acl.Global = addScopesToEndpointList(acl.Global, readScopes)
+	}
+
+	return nil
+}
+
+// effectiveGlobalRoleBindings translates the legacy admin flags into exact
+// bindings (verbatim — Wildcard is never set, so a legacy subject literally
+// "*" keeps its historical exact-match semantics) and appends the new list.
+func effectiveGlobalRoleBindings(o *Options) []GlobalRoleBinding {
+	out := make([]GlobalRoleBinding, 0, len(o.PlatformAdministratorSubjects)+len(o.GlobalRoleBindings))
+
+	for _, s := range o.PlatformAdministratorSubjects {
+		out = append(out, GlobalRoleBinding{Issuer: s.Issuer, Subject: s.Subject, RoleIDs: o.PlatformAdministratorRoleIDs})
+	}
+
+	return append(out, o.GlobalRoleBindings...)
+}
+
+// resolveGlobalRoleBindings returns the bindings matching the authenticated
+// (issuer, subject) pair. Wildcards never match the sentinel or an unset
+// issuer (impersonated principals, pre-src_iss passports).
+func (r *RBAC) resolveGlobalRoleBindings(srcIss, subject string) []GlobalRoleBinding {
+	var out []GlobalRoleBinding
+
+	for _, b := range r.bindings {
+		if b.Issuer != srcIss {
+			continue
+		}
+
+		if b.Wildcard {
+			if srcIss == "" || srcIss == idconstants.UNISentinel {
+				continue
+			}
+
+			out = append(out, b)
+
+			continue
+		}
+
+		if strings.EqualFold(strings.TrimSpace(b.Subject), strings.TrimSpace(subject)) {
+			out = append(out, b)
+		}
+	}
+
+	return out
+}

--- a/pkg/rbac/bindings.go
+++ b/pkg/rbac/bindings.go
@@ -44,6 +44,7 @@ var (
 	errSentinelWildcard   = goerrors.New("wildcard subject not allowed on the UNI sentinel issuer")
 	errIssuerCommaOrSpace = goerrors.New("issuer contains comma or whitespace")
 	errIssuerNotURL       = goerrors.New("issuer is neither the UNI sentinel nor an absolute URL")
+	errIssuerPathSep      = goerrors.New("issuer URL path contains \"::\"")
 )
 
 // GlobalRoleBinding grants the global scopes of RoleIDs to Subject when
@@ -118,8 +119,16 @@ func validateBindingIssuer(issuer, subject string) error {
 		return errIssuerCommaOrSpace
 	}
 
-	if u, err := url.Parse(issuer); err != nil || u.Scheme == "" || u.Host == "" {
+	u, err := url.Parse(issuer)
+	if err != nil || u.Scheme == "" || u.Host == "" {
 		return errIssuerNotURL
+	}
+
+	// A "::" in the path (not the IPv6-host brackets url.Parse already
+	// consumed) would let a subject containing "::" parse right-anchored
+	// into the issuer instead, silently producing a never-matching binding.
+	if strings.Contains(u.Path, "::") {
+		return errIssuerPathSep
 	}
 
 	return nil

--- a/pkg/rbac/bindings_test.go
+++ b/pkg/rbac/bindings_test.go
@@ -1,0 +1,446 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac_test
+
+import (
+	goerrors "errors"
+	"reflect"
+	"testing"
+
+	"github.com/unikorn-cloud/core/pkg/errors"
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/identity/pkg/constants"
+	"github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGlobalRoleBindingsValueParse(t *testing.T) {
+	t.Parallel()
+
+	accept := []struct {
+		in   string
+		want rbac.GlobalRoleBinding
+	}{
+		{"https://staff.example.com/::*::platform-reader", rbac.GlobalRoleBinding{Issuer: "https://staff.example.com/", Subject: "*", RoleIDs: []string{"platform-reader"}, Wildcard: true}},
+		{"uni::admin@nscale.com::role-a,role-b", rbac.GlobalRoleBinding{Issuer: "uni", Subject: "admin@nscale.com", RoleIDs: []string{"role-a", "role-b"}}},
+		// IPv6 issuer: right-anchored parsing keeps the "::" inside the URL intact.
+		{"https://[2001:db8::1]/::alice@x.com::r1", rbac.GlobalRoleBinding{Issuer: "https://[2001:db8::1]/", Subject: "alice@x.com", RoleIDs: []string{"r1"}}},
+		// Subject whitespace normalizes: padded "*" is a real wildcard, clamped and guarded.
+		{"https://staff.example.com/:: * ::r1", rbac.GlobalRoleBinding{Issuer: "https://staff.example.com/", Subject: "*", RoleIDs: []string{"r1"}, Wildcard: true}},
+	}
+
+	for _, tc := range accept {
+		var v rbac.GlobalRoleBindingsValue
+		if err := v.Set(tc.in); err != nil {
+			t.Fatalf("%q: %v", tc.in, err)
+		}
+
+		if !reflect.DeepEqual([]rbac.GlobalRoleBinding(v), []rbac.GlobalRoleBinding{tc.want}) {
+			t.Fatalf("%q: got %+v", tc.in, v)
+		}
+	}
+
+	reject := []string{
+		"",                                    // empty
+		"no-separators",                       // malformed
+		"uni::only-one-separator",             // malformed
+		"uni::*::platform-reader",             // wildcard on sentinel
+		"uni:: * ::platform-reader",           // padded wildcard on sentinel (normalized, still rejected)
+		"::alice@x.com::r1",                   // empty issuer
+		"not-a-url::alice@x.com::r1",          // issuer not sentinel/URL
+		"https://a.com/::alice@x.com::",       // empty role list
+		"https://a.com/::alice@x.com::r1,",    // empty role member
+		"https://a.com/::::r1",                // empty subject
+		"https://a.com/,https://b.com/::x::r", // comma in issuer (legacy join idiom)
+		"https://a .com/::x::r",               // whitespace in issuer
+		"uni::a@x.com:: r1 ",                  // whitespace-padded role ID
+		"uni::a@x.com::   ",                   // whitespace-only role ID
+	}
+
+	for _, in := range reject {
+		var v rbac.GlobalRoleBindingsValue
+		if err := v.Set(in); err == nil {
+			t.Fatalf("%q: expected error", in)
+		}
+	}
+}
+
+func TestAccumulateGlobalReadPermissionsClampsWrites(t *testing.T) {
+	t.Parallel()
+
+	roles := map[string]*unikornv1.Role{
+		"crud-role": {
+			Spec: unikornv1.RoleSpec{
+				Scopes: unikornv1.RoleScopes{
+					Global: []unikornv1.RoleScope{
+						{Name: "identity:organizations", Operations: []unikornv1.Operation{unikornv1.Create, unikornv1.Read, unikornv1.Update, unikornv1.Delete}},
+						{Name: "identity:writeonly", Operations: []unikornv1.Operation{unikornv1.Create}},
+					},
+				},
+			},
+		},
+	}
+
+	acl := &openapi.Acl{}
+	if err := rbac.AccumulateGlobalReadPermissionsForTest(acl, []string{"crud-role"}, roles); err != nil {
+		t.Fatal(err)
+	}
+
+	want := openapi.AclEndpoints{{Name: "identity:organizations", Operations: []openapi.AclOperation{openapi.Read}}}
+	if !reflect.DeepEqual(*acl.Global, want) {
+		t.Fatalf("got %+v, want %+v", *acl.Global, want)
+	}
+
+	err := rbac.AccumulateGlobalReadPermissionsForTest(&openapi.Acl{}, []string{"missing"}, roles)
+	if !goerrors.Is(err, errors.ErrConsistency) { // core/pkg/errors
+		t.Fatalf("want ErrConsistency for missing role, got %v", err)
+	}
+}
+
+func TestEffectiveGlobalRoleBindings(t *testing.T) {
+	t.Parallel()
+
+	opts := &rbac.Options{
+		PlatformAdministratorRoleIDs: []string{"admin-role"},
+		PlatformAdministratorSubjects: []rbac.PlatformAdministratorSubject{
+			{Issuer: constants.UNISentinel, Subject: "legacy@x.com"},
+			// pkg/server's expandBareAdminSubjects mirrors bare entries onto the
+			// legacy exchange issuer: both forms must translate.
+			{Issuer: "https://legacy-exchange.example.com/", Subject: "legacy@x.com"},
+			// A legacy subject literally "*" stays an EXACT binding (Wildcard
+			// false): translation is verbatim, never widening.
+			{Issuer: "https://a.com/", Subject: "*"},
+		},
+		GlobalRoleBindings: rbac.GlobalRoleBindingsValue{
+			{Issuer: "https://staff.example.com/", Subject: "*", RoleIDs: []string{"reader-role"}, Wildcard: true},
+		},
+	}
+
+	got := rbac.EffectiveGlobalRoleBindingsForTest(opts)
+	want := []rbac.GlobalRoleBinding{
+		{Issuer: constants.UNISentinel, Subject: "legacy@x.com", RoleIDs: []string{"admin-role"}},
+		{Issuer: "https://legacy-exchange.example.com/", Subject: "legacy@x.com", RoleIDs: []string{"admin-role"}},
+		{Issuer: "https://a.com/", Subject: "*", RoleIDs: []string{"admin-role"}},
+		{Issuer: "https://staff.example.com/", Subject: "*", RoleIDs: []string{"reader-role"}, Wildcard: true},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestResolveGlobalRoleBindings(t *testing.T) {
+	t.Parallel()
+
+	bindings := []rbac.GlobalRoleBinding{
+		{Issuer: "https://staff.example.com/", Subject: "*", RoleIDs: []string{"r"}, Wildcard: true},
+		{Issuer: "https://staff.example.com/", Subject: "boss@x.com", RoleIDs: []string{"a"}},
+		// External-exact binding, same subject as the sentinel case below: pins
+		// that matching is issuer-scoped, not subject-only. A resolver that
+		// matched subjects independently of issuer would leak this at the
+		// sentinel.
+
+		{Issuer: constants.UNISentinel, Subject: "local@x.com", RoleIDs: []string{"a"}},
+		// Defense in depth: even if misconfigured into Options directly
+		// (bypassing Set), a sentinel/empty-issuer wildcard never matches.
+		// (Also pins the impersonation path: impersonated principals carry the
+		// sentinel — processImpersonatedPrincipalACL — so they can never
+		// acquire a wildcard or external-issuer binding.)
+		{Issuer: constants.UNISentinel, Subject: "*", RoleIDs: []string{"a"}, Wildcard: true},
+		{Issuer: "", Subject: "*", RoleIDs: []string{"a"}, Wildcard: true},
+	}
+
+	cases := []struct {
+		srcIss, subject string
+		wantSubjects    []string
+	}{
+		{"https://staff.example.com/", "anyone@x.com", []string{"*"}},
+		{"https://staff.example.com/", " BOSS@x.com ", []string{"*", "boss@x.com"}}, // exact match is EqualFold+TrimSpace; both match
+		{constants.UNISentinel, "local@x.com", []string{"local@x.com"}},
+		{constants.UNISentinel, "anyone@x.com", nil}, // sentinel wildcard guarded
+		{"", "anyone@x.com", nil},                    // empty srcIss guarded
+		{"https://other.com/", "boss@x.com", nil},    // issuer exact match
+		// Pin: the external-exact binding's subject ("boss@x.com") must not
+		// match at the sentinel — an impersonated principal (always evaluated
+		// at the sentinel) can never acquire an external-issuer exact binding.
+		{constants.UNISentinel, "boss@x.com", nil},
+	}
+
+	for _, tc := range cases {
+		got := rbac.ResolveGlobalRoleBindingsForTest(bindings, tc.srcIss, tc.subject)
+
+		var gotSubjects []string
+		for _, b := range got {
+			gotSubjects = append(gotSubjects, b.Subject)
+		}
+
+		if !reflect.DeepEqual(gotSubjects, tc.wantSubjects) {
+			t.Fatalf("(%q,%q): got %v, want %v", tc.srcIss, tc.subject, gotSubjects, tc.wantSubjects)
+		}
+	}
+}
+
+// TestOptionsValidateGlobalRoleBindingIssuer covers the three outcomes of the
+// GlobalRoleBindings loop in Options.Validate: an untrusted issuer is
+// reported, a trusted issuer is not, and the UNI sentinel is skipped
+// regardless of the trusted-issuer list.
+func TestOptionsValidateGlobalRoleBindingIssuer(t *testing.T) {
+	t.Parallel()
+
+	const trustedIssuer = "https://staff.example.com/"
+
+	// untrusted issuer (not the UNI sentinel, not in trustedNonUNIIssuers) → reported.
+	untrusted := &rbac.Options{
+		GlobalRoleBindings: rbac.GlobalRoleBindingsValue{
+			{Issuer: "https://untrusted.example.com/", Subject: "alice@x.com", RoleIDs: []string{"r"}},
+		},
+	}
+
+	err := untrusted.Validate([]string{trustedIssuer})
+	if err == nil {
+		t.Fatal("expected untrusted-binding-issuer error, got nil")
+	}
+
+	if !goerrors.Is(err, rbac.ErrUntrustedBindingIssuer) {
+		t.Fatalf("got %v, want ErrUntrustedBindingIssuer", err)
+	}
+
+	// trusted issuer → not reported.
+	trusted := &rbac.Options{
+		GlobalRoleBindings: rbac.GlobalRoleBindingsValue{
+			{Issuer: trustedIssuer, Subject: "alice@x.com", RoleIDs: []string{"r"}},
+		},
+	}
+
+	if err := trusted.Validate([]string{trustedIssuer}); err != nil {
+		t.Fatalf("unexpected error for trusted issuer: %v", err)
+	}
+
+	// UNI sentinel issuer → skipped, never reported, even against an empty
+	// trusted-issuer list.
+	sentinel := &rbac.Options{
+		GlobalRoleBindings: rbac.GlobalRoleBindingsValue{
+			{Issuer: constants.UNISentinel, Subject: "alice@x.com", RoleIDs: []string{"r"}},
+		},
+	}
+
+	if err := sentinel.Validate(nil); err != nil {
+		t.Fatalf("unexpected error for UNI sentinel issuer: %v", err)
+	}
+
+	// both a bare admin subject and an untrusted binding issuer present →
+	// both diagnostics are reported (errors.Join), not just the first found.
+	both := &rbac.Options{
+		PlatformAdministratorSubjects: []rbac.PlatformAdministratorSubject{
+			{Issuer: constants.UNISentinel, Subject: "bare@nscale.com"},
+		},
+		GlobalRoleBindings: rbac.GlobalRoleBindingsValue{
+			{Issuer: "https://untrusted.example.com/", Subject: "alice@x.com", RoleIDs: []string{"r"}},
+		},
+	}
+
+	err = both.Validate([]string{trustedIssuer})
+	if !goerrors.Is(err, rbac.ErrBareAdminSubject) {
+		t.Fatalf("got %v, want ErrBareAdminSubject also reported", err)
+	}
+
+	if !goerrors.Is(err, rbac.ErrUntrustedBindingIssuer) {
+		t.Fatalf("got %v, want ErrUntrustedBindingIssuer also reported", err)
+	}
+
+	// empty trusted-issuer list (e.g. a transient provider List failure in the
+	// caller) → the binding-issuer check is skipped entirely, even though the
+	// configured issuer would be reported as untrusted against a non-empty list.
+	emptyTrustedList := &rbac.Options{
+		GlobalRoleBindings: rbac.GlobalRoleBindingsValue{
+			{Issuer: "https://untrusted.example.com/", Subject: "alice@x.com", RoleIDs: []string{"r"}},
+		},
+	}
+
+	if err := emptyTrustedList.Validate(nil); err != nil {
+		t.Fatalf("unexpected error with empty trusted-issuer list: %v", err)
+	}
+}
+
+// Legacy flags and equivalent bindings must produce identical ACLs.
+func TestLegacyFlagsEquivalentToBindings(t *testing.T) {
+	t.Parallel()
+
+	legacy := &rbac.Options{
+		PlatformAdministratorRoleIDs:  []string{"admin"},
+		PlatformAdministratorSubjects: []rbac.PlatformAdministratorSubject{{Issuer: "https://a.com/", Subject: "admin@x.com"}},
+	}
+
+	viaBindings := &rbac.Options{
+		GlobalRoleBindings: rbac.GlobalRoleBindingsValue{{Issuer: "https://a.com/", Subject: "admin@x.com", RoleIDs: []string{"admin"}}},
+	}
+
+	legacyACL := getACLForSubject(t, legacy, "admin@x.com", "https://a.com/")
+
+	// Guard against vacuous equivalence: DeepEqual alone would also pass if
+	// both sides granted nothing.
+	if legacyACL.Global == nil {
+		t.Fatal("legacy path granted no global ACL; equivalence check would be vacuous")
+	}
+
+	if !reflect.DeepEqual(
+		legacyACL,
+		getACLForSubject(t, viaBindings, "admin@x.com", "https://a.com/"),
+	) {
+		t.Fatal("legacy translation diverges from direct bindings")
+	}
+}
+
+// A wildcard match accumulates clamped scopes; an exact match on the same
+// issuer unions in a different role's full scopes. Two roles with distinct
+// endpoints make a missed accumulation from either binding detectable.
+func TestWildcardClampAndMultiBindingUnion(t *testing.T) {
+	t.Parallel()
+
+	crudRole := &unikornv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: "crud-role"},
+		Spec: unikornv1.RoleSpec{
+			Scopes: unikornv1.RoleScopes{
+				Global: []unikornv1.RoleScope{
+					{Name: "identity:organizations", Operations: []unikornv1.Operation{unikornv1.Create, unikornv1.Read, unikornv1.Update, unikornv1.Delete}},
+				},
+			},
+		},
+	}
+
+	otherRole := &unikornv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: "other-role"},
+		Spec: unikornv1.RoleSpec{
+			Scopes: unikornv1.RoleScopes{
+				Global: []unikornv1.RoleScope{
+					{Name: "identity:groups", Operations: []unikornv1.Operation{unikornv1.Create, unikornv1.Read}},
+				},
+			},
+		},
+	}
+
+	opts := &rbac.Options{GlobalRoleBindings: rbac.GlobalRoleBindingsValue{
+		{Issuer: "https://staff.example.com/", Subject: "*", RoleIDs: []string{"crud-role"}, Wildcard: true},
+	}}
+
+	acl := getACLForSubject(t, opts, "anyone@x.com", "https://staff.example.com/", crudRole, otherRole)
+	if acl.Global == nil {
+		t.Fatal("wildcard binding granted nothing")
+	}
+
+	for _, e := range *acl.Global {
+		if !reflect.DeepEqual(e.Operations, []openapi.AclOperation{openapi.Read}) {
+			t.Fatalf("wildcard grant not clamped: %+v", e)
+		}
+	}
+
+	opts.GlobalRoleBindings = append(opts.GlobalRoleBindings,
+		rbac.GlobalRoleBinding{Issuer: "https://staff.example.com/", Subject: "boss@x.com", RoleIDs: []string{"other-role"}})
+
+	acl = getACLForSubject(t, opts, "boss@x.com", "https://staff.example.com/", crudRole, otherRole)
+
+	// Union must contain BOTH: crud-role's endpoint clamped to read (wildcard)
+	// and other-role's endpoint with full verbs (exact).
+	byName := map[string][]openapi.AclOperation{}
+	for _, e := range *acl.Global {
+		byName[e.Name] = e.Operations
+	}
+
+	if !reflect.DeepEqual(byName["identity:organizations"], []openapi.AclOperation{openapi.Read}) {
+		t.Fatalf("wildcard contribution missing/unclamped: %+v", byName)
+	}
+
+	if len(byName["identity:groups"]) != 2 {
+		t.Fatalf("exact contribution missing full verbs: %+v", byName)
+	}
+
+	// Direct same-role comparison (spec §5 "Tests"): binding the SAME role
+	// (crud-role) exactly, rather than via wildcard, must yield its full
+	// operation set — contrasted directly against the wildcard-bound
+	// "anyone@x.com" case above, which got only read on this same endpoint.
+	// A distinct issuer keeps this exact binding from also matching the
+	// staff.example.com wildcard, which would otherwise union in and mask a
+	// clamp-not-applied bug behind an already-full result.
+	opts.GlobalRoleBindings = append(opts.GlobalRoleBindings,
+		rbac.GlobalRoleBinding{Issuer: "https://other.example.com/", Subject: "admin@x.com", RoleIDs: []string{"crud-role"}})
+
+	acl = getACLForSubject(t, opts, "admin@x.com", "https://other.example.com/", crudRole, otherRole)
+
+	want := []openapi.AclOperation{openapi.Create, openapi.Read, openapi.Update, openapi.Delete}
+
+	byName = map[string][]openapi.AclOperation{}
+	for _, e := range *acl.Global {
+		byName[e.Name] = e.Operations
+	}
+
+	if !reflect.DeepEqual(byName["identity:organizations"], want) {
+		t.Fatalf("exact binding on same role did not yield full operations: got %+v, want %+v", byName["identity:organizations"], want)
+	}
+}
+
+// Regression pin (green before and after this task): an unbound subject gets
+// no global block.
+func TestUnboundSubjectHasNoGlobalACL(t *testing.T) {
+	t.Parallel()
+
+	opts := &rbac.Options{GlobalRoleBindings: rbac.GlobalRoleBindingsValue{
+		{Issuer: "https://staff.example.com/", Subject: "*", RoleIDs: []string{"crud-role"}, Wildcard: true},
+	}}
+
+	if acl := getACLForSubject(t, opts, "anyone@x.com", constants.UNISentinel); acl.Global != nil {
+		t.Fatalf("unbound subject received global ACL: %+v", acl.Global)
+	}
+}
+
+// Replace semantics pin: a bound subject with org memberships in authz skips
+// membership resolution entirely. The fake client has no organization
+// fixtures, so an accidental additive implementation errors on the org
+// lookup instead of returning the global-only ACL. Table covers both an exact
+// binding and its wildcard variant.
+//
+// The wildcard row is intentional, not an oversight — issuer-wide bindings are
+// only appropriate for issuers whose entire user population is itself an
+// authorization decision (e.g. a staff-only issuer), so bypassing
+// ErrNotInOrganization for every subject at that issuer is the point, not a
+// bug to "fix".
+func TestBoundSubjectSkipsMembershipResolution(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		binding rbac.GlobalRoleBinding
+		subject string
+	}{
+		{"exact", rbac.GlobalRoleBinding{Issuer: "https://a.com/", Subject: "admin@x.com", RoleIDs: []string{"admin"}}, "admin@x.com"},
+		{"wildcard", rbac.GlobalRoleBinding{Issuer: "https://staff.example.com/", Subject: "*", RoleIDs: []string{"admin"}, Wildcard: true}, "anyone@x.com"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := &rbac.Options{GlobalRoleBindings: rbac.GlobalRoleBindingsValue{tc.binding}}
+			acl := getACLForSubjectWithOrgIDs(t, opts, tc.subject, tc.binding.Issuer, []string{"some-org"})
+
+			if acl.Global == nil || acl.Organizations != nil {
+				t.Fatalf("expected global-only ACL, got %+v", acl)
+			}
+		})
+	}
+}

--- a/pkg/rbac/bindings_test.go
+++ b/pkg/rbac/bindings_test.go
@@ -19,6 +19,7 @@ package rbac_test
 import (
 	goerrors "errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/unikorn-cloud/core/pkg/errors"
@@ -71,6 +72,7 @@ func TestGlobalRoleBindingsValueParse(t *testing.T) {
 		"https://a .com/::x::r",               // whitespace in issuer
 		"uni::a@x.com:: r1 ",                  // whitespace-padded role ID
 		"uni::a@x.com::   ",                   // whitespace-only role ID
+		"https://a.com/::alice::bob::r1",      // "::" in issuer path swallows a subject segment
 	}
 
 	for _, in := range reject {
@@ -196,10 +198,11 @@ func TestResolveGlobalRoleBindings(t *testing.T) {
 	}
 }
 
-// TestOptionsValidateGlobalRoleBindingIssuer covers the three outcomes of the
+// TestOptionsValidateGlobalRoleBindingIssuer covers the outcomes of the
 // GlobalRoleBindings loop in Options.Validate: an untrusted issuer is
-// reported, a trusted issuer is not, and the UNI sentinel is skipped
-// regardless of the trusted-issuer list.
+// reported (even against an empty trusted-issuer list, since this check is
+// ungated), a trusted issuer is not, and the UNI sentinel is always skipped.
+// See TestOptionsValidateReportsEveryOffender for the multiple-offenders case.
 func TestOptionsValidateGlobalRoleBindingIssuer(t *testing.T) {
 	t.Parallel()
 
@@ -264,17 +267,41 @@ func TestOptionsValidateGlobalRoleBindingIssuer(t *testing.T) {
 		t.Fatalf("got %v, want ErrUntrustedBindingIssuer also reported", err)
 	}
 
-	// empty trusted-issuer list (e.g. a transient provider List failure in the
-	// caller) → the binding-issuer check is skipped entirely, even though the
-	// configured issuer would be reported as untrusted against a non-empty list.
+	// empty trusted-issuer list → the binding-issuer check still runs (it has
+	// no gate), so a genuinely-untrusted issuer is reported even though no
+	// non-UNI issuer is trusted at all.
 	emptyTrustedList := &rbac.Options{
 		GlobalRoleBindings: rbac.GlobalRoleBindingsValue{
 			{Issuer: "https://untrusted.example.com/", Subject: "alice@x.com", RoleIDs: []string{"r"}},
 		},
 	}
 
-	if err := emptyTrustedList.Validate(nil); err != nil {
-		t.Fatalf("unexpected error with empty trusted-issuer list: %v", err)
+	err = emptyTrustedList.Validate(nil)
+	if !goerrors.Is(err, rbac.ErrUntrustedBindingIssuer) {
+		t.Fatalf("got %v, want ErrUntrustedBindingIssuer even with an empty trusted-issuer list", err)
+	}
+}
+
+// TestOptionsValidateReportsEveryOffender pins that Options.Validate reports
+// every offending GlobalRoleBindings entry, not just the first, mirroring the
+// same errors.Join behaviour already covered per-category above.
+func TestOptionsValidateReportsEveryOffender(t *testing.T) {
+	t.Parallel()
+
+	opts := &rbac.Options{
+		GlobalRoleBindings: rbac.GlobalRoleBindingsValue{
+			{Issuer: "https://untrusted-a.example.com/", Subject: "alice@x.com", RoleIDs: []string{"r"}},
+			{Issuer: "https://untrusted-b.example.com/", Subject: "bob@x.com", RoleIDs: []string{"r"}},
+		},
+	}
+
+	err := opts.Validate([]string{"https://staff.example.com/"})
+	if !goerrors.Is(err, rbac.ErrUntrustedBindingIssuer) {
+		t.Fatalf("got %v, want ErrUntrustedBindingIssuer", err)
+	}
+
+	if !strings.Contains(err.Error(), "untrusted-a.example.com") || !strings.Contains(err.Error(), "untrusted-b.example.com") {
+		t.Fatalf("expected both offending issuers named in error, got: %v", err)
 	}
 }
 

--- a/pkg/rbac/bindings_test.go
+++ b/pkg/rbac/bindings_test.go
@@ -173,7 +173,8 @@ func TestResolveGlobalRoleBindings(t *testing.T) {
 		wantSubjects    []string
 	}{
 		{"https://staff.example.com/", "anyone@x.com", []string{"*"}},
-		{"https://staff.example.com/", " BOSS@x.com ", []string{"*", "boss@x.com"}}, // exact match is EqualFold+TrimSpace; both match
+		{"https://staff.example.com/", " boss@x.com ", []string{"*", "boss@x.com"}}, // exact match trims whitespace on both sides
+		{"https://staff.example.com/", " BOSS@x.com ", []string{"*"}},               // mixed case does NOT match the exact binding; only the wildcard catches it
 		{constants.UNISentinel, "local@x.com", []string{"local@x.com"}},
 		{constants.UNISentinel, "anyone@x.com", nil}, // sentinel wildcard guarded
 		{"", "anyone@x.com", nil},                    // empty srcIss guarded

--- a/pkg/rbac/export_test.go
+++ b/pkg/rbac/export_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/identity/pkg/openapi"
+)
+
+// AccumulateGlobalReadPermissionsForTest exports accumulateGlobalReadPermissions for
+// external tests in bindings_test.go (package rbac_test).
+func AccumulateGlobalReadPermissionsForTest(acl *openapi.Acl, roleIDs []string, roles map[string]*unikornv1.Role) error {
+	return accumulateGlobalReadPermissions(acl, roleIDs, roles)
+}
+
+// EffectiveGlobalRoleBindingsForTest exports effectiveGlobalRoleBindings for
+// external tests in bindings_test.go (package rbac_test).
+func EffectiveGlobalRoleBindingsForTest(o *Options) []GlobalRoleBinding {
+	return effectiveGlobalRoleBindings(o)
+}
+
+// ResolveGlobalRoleBindingsForTest exports RBAC.resolveGlobalRoleBindings for
+// external tests in bindings_test.go (package rbac_test).
+func ResolveGlobalRoleBindingsForTest(bindings []GlobalRoleBinding, srcIss, subject string) []GlobalRoleBinding {
+	r := &RBAC{bindings: bindings}
+
+	return r.resolveGlobalRoleBindings(srcIss, subject)
+}

--- a/pkg/rbac/impersonation_test.go
+++ b/pkg/rbac/impersonation_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/identity/pkg/constants"
 	"github.com/unikorn-cloud/identity/pkg/openapi"
 	"github.com/unikorn-cloud/identity/pkg/principal"
 	"github.com/unikorn-cloud/identity/pkg/rbac"
@@ -42,7 +43,20 @@ const (
 func setupImpersonationEnvironment(t *testing.T, serviceGlobalScopes []unikornv1.RoleScope) fixture {
 	t.Helper()
 
+	return setupImpersonationEnvironmentWithBindings(t, serviceGlobalScopes, rbac.Options{})
+}
+
+// setupImpersonationEnvironmentWithBindings is setupImpersonationEnvironment
+// with control over the full rbac.Options (so tests can set GlobalRoleBindings)
+// and extra Role fixtures beyond the fixed impersonation-service role.
+func setupImpersonationEnvironmentWithBindings(t *testing.T, serviceGlobalScopes []unikornv1.RoleScope, opts rbac.Options, extraRoles ...*unikornv1.Role) fixture {
+	t.Helper()
+
 	f, c := setupTestEnvironment(t)
+
+	for _, r := range extraRoles {
+		require.NoError(t, c.Create(t.Context(), r))
+	}
 
 	serviceRole := &unikornv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
@@ -57,9 +71,8 @@ func setupImpersonationEnvironment(t *testing.T, serviceGlobalScopes []unikornv1
 	}
 	require.NoError(t, c.Create(t.Context(), serviceRole))
 
-	f.rbac = rbac.New(c, testNamespace, &rbac.Options{
-		SystemAccountRoleIDs: map[string]string{impersonationServiceCN: roleImpersonationService},
-	})
+	opts.SystemAccountRoleIDs = map[string]string{impersonationServiceCN: roleImpersonationService}
+	f.rbac = rbac.New(c, testNamespace, &opts)
 
 	return f
 }
@@ -215,6 +228,68 @@ func TestImpersonation_ServiceHasNoPermissions_EmptyACLReturned(t *testing.T) {
 	acl := impersonate(t, f, userCharlieSubject)
 
 	assert.Nil(t, acl.Global)
+	assert.Nil(t, acl.Organization)
+	assert.Nil(t, acl.Organizations)
+	assert.Nil(t, acl.Projects)
+}
+
+// TestImpersonation_UniExactBindingIntersectsWithServiceACL pins the full
+// impersonation path for the ID-398 spec requirement that a uni-exact global
+// role binding stays intersected with the calling service's ACL. The
+// impersonated actor's subject matches a binding on the UNI sentinel
+// (processImpersonatedPrincipalACL always resolves impersonated user
+// principals at that issuer), so processUserAccountACL grants the binding's
+// global scopes and skips membership resolution entirely (replace
+// semantics) — but the confused-deputy intersection in getSystemAccountACL
+// still strips whatever the impersonating service itself is not permitted
+// to touch.
+func TestImpersonation_UniExactBindingIntersectsWithServiceACL(t *testing.T) {
+	t.Parallel()
+
+	const boundRoleID = "role-uni-binding"
+
+	boundRole := &unikornv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      boundRoleID,
+		},
+		Spec: unikornv1.RoleSpec{
+			Scopes: unikornv1.RoleScopes{
+				Global: []unikornv1.RoleScope{
+					{Name: "identity:organizations", Operations: []unikornv1.Operation{unikornv1.Create, unikornv1.Read, unikornv1.Update, unikornv1.Delete}},
+					{Name: "identity:other", Operations: []unikornv1.Operation{unikornv1.Read}},
+				},
+			},
+		},
+	}
+
+	f := setupImpersonationEnvironmentWithBindings(t,
+		// Service ACL allows read on identity:organizations — a strict
+		// subset of the binding's grant, giving the intersection something
+		// to strip on both endpoints (partial-verb strip, full-endpoint drop).
+		// It also allows org:read: if replace semantics did NOT hold and Bob's
+		// own org membership were resolved, his org-scoped org:read grant
+		// would survive the intersection and land in acl.Organization,
+		// falsifying the assert.Nil below.
+		[]unikornv1.RoleScope{
+			{Name: "identity:organizations", Operations: []unikornv1.Operation{unikornv1.Read}},
+			{Name: "org:read", Operations: []unikornv1.Operation{unikornv1.Read}},
+		},
+		rbac.Options{
+			GlobalRoleBindings: rbac.GlobalRoleBindingsValue{
+				{Issuer: constants.UNISentinel, Subject: userBobSubject, RoleIDs: []string{boundRoleID}},
+			},
+		},
+		boundRole,
+	)
+
+	acl := impersonate(t, f, userBobSubject)
+
+	require.NotNil(t, acl.Global)
+	assert.Equal(t, openapi.AclEndpoints{{Name: "identity:organizations", Operations: []openapi.AclOperation{openapi.Read}}}, *acl.Global)
+
+	// Replace semantics under impersonation: membership resolution was
+	// skipped for the bound actor, so nothing outside Global should appear.
 	assert.Nil(t, acl.Organization)
 	assert.Nil(t, acl.Organizations)
 	assert.Nil(t, acl.Projects)

--- a/pkg/rbac/platform_admin_test.go
+++ b/pkg/rbac/platform_admin_test.go
@@ -235,10 +235,13 @@ func TestAdminFastPathRequiresServerSideGrant(t *testing.T) {
 	}
 }
 
-// TestAdminFastPathCaseInsensitiveSubject verifies that the platform-admin
-// fast-path matches regardless of case differences between the admin-list
-// entry subject and the (lowercased) token subject.
-func TestAdminFastPathCaseInsensitiveSubject(t *testing.T) {
+// TestAdminFastPathCaseSensitiveSubject verifies that the platform-admin
+// fast-path requires the admin-list entry subject to match the (lowercased,
+// trimmed) token subject exactly, including case. The validator already
+// normalizes the token subject to lower case, so an admin-list entry typed
+// in any other case is a configuration mistake, not an alternate spelling —
+// it must not match.
+func TestAdminFastPathCaseSensitiveSubject(t *testing.T) {
 	t.Parallel()
 
 	const staffIss = "https://staff.auth0.com"
@@ -250,19 +253,25 @@ func TestAdminFastPathCaseInsensitiveSubject(t *testing.T) {
 		wantAdminACL bool
 	}{
 		{
-			name:         "mixed-case entry matches lowercased token subject",
-			entrySubject: "Admin@Nscale.Com",
+			name:         "exact-case entry matches lowercased token subject",
+			entrySubject: "admin@nscale.com",
 			tokenSubject: "admin@nscale.com",
 			wantAdminACL: true,
 		},
 		{
-			name:         "lowercased entry matches mixed-case token subject",
-			entrySubject: "admin@nscale.com",
-			tokenSubject: "Admin@Nscale.Com",
-			wantAdminACL: true,
+			name:         "mixed-case entry does not match lowercased token subject",
+			entrySubject: "Admin@Nscale.Com",
+			tokenSubject: "admin@nscale.com",
+			wantAdminACL: false,
 		},
 		{
-			name:         "non-matching subject is denied even after normalisation",
+			name:         "lowercased entry does not match mixed-case token subject",
+			entrySubject: "admin@nscale.com",
+			tokenSubject: "Admin@Nscale.Com",
+			wantAdminACL: false,
+		},
+		{
+			name:         "non-matching subject is denied",
 			entrySubject: "Admin@Nscale.Com",
 			tokenSubject: "other@nscale.com",
 			wantAdminACL: false,

--- a/pkg/rbac/platform_admin_test.go
+++ b/pkg/rbac/platform_admin_test.go
@@ -72,7 +72,19 @@ func TestPlatformAdminSubjectsValueParse(t *testing.T) {
 
 // getACLForSubject builds a minimal RBAC environment with the given opts and
 // calls GetACL for the given subject+srcIss pair. It returns the resulting ACL.
-func getACLForSubject(t *testing.T, opts *rbac.Options, subject, srcIss string) *openapi.Acl {
+// extraRoles are created alongside the fixed "admin" role fixture, letting
+// tests that need additional role fixtures (e.g. wildcard-clamp/union
+// scenarios) inject them without a bespoke fake-client setup.
+func getACLForSubject(t *testing.T, opts *rbac.Options, subject, srcIss string, extraRoles ...*unikornv1.Role) *openapi.Acl {
+	t.Helper()
+
+	return getACLForSubjectWithOrgIDs(t, opts, subject, srcIss, nil, extraRoles...)
+}
+
+// getACLForSubjectWithOrgIDs is getACLForSubject with control over the
+// authz.OrgIds claim, used to prove that a bound subject skips membership
+// resolution entirely even when org memberships are present.
+func getACLForSubjectWithOrgIDs(t *testing.T, opts *rbac.Options, subject, srcIss string, orgIDs []string, extraRoles ...*unikornv1.Role) *openapi.Acl {
 	t.Helper()
 
 	scheme, err := unikornv1.SchemeBuilder.Build()
@@ -94,7 +106,13 @@ func getACLForSubject(t *testing.T, opts *rbac.Options, subject, srcIss string) 
 		},
 	}
 
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(adminRole).Build()
+	builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(adminRole)
+
+	for _, r := range extraRoles {
+		builder = builder.WithObjects(r)
+	}
+
+	c := builder.Build()
 	rbacClient := rbac.New(c, testNamespace, opts)
 
 	info := &authorization.Info{
@@ -102,6 +120,7 @@ func getACLForSubject(t *testing.T, opts *rbac.Options, subject, srcIss string) 
 			Sub: subject,
 			HttpsunikornCloudOrgauthz: &openapi.AuthClaims{
 				Acctype: openapi.User,
+				OrgIds:  orgIDs,
 			},
 		},
 		SrcIss: srcIss,

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -48,6 +48,7 @@ var (
 	ErrNotInOrganization      = goerrors.New("subject not a member of organization")
 	ErrInvalidPrincipalType   = goerrors.New("invalid impersonated principal type")
 	ErrBareAdminSubject       = goerrors.New("bare platform-administrator-subjects entry with non-UNI issuer trusted; migrate to issuer::subject")
+	ErrUntrustedBindingIssuer = goerrors.New("global role binding issuer is neither the UNI sentinel nor a trusted issuer")
 )
 
 // PlatformAdministratorSubject binds an admin subject to the issuer that must
@@ -109,31 +110,59 @@ type Options struct {
 	PlatformAdministratorRoleIDs  []string
 	PlatformAdministratorSubjects []PlatformAdministratorSubject
 	SystemAccountRoleIDs          map[string]string
+	GlobalRoleBindings            GlobalRoleBindingsValue
 }
 
 func (o *Options) AddFlags(f *pflag.FlagSet) {
 	f.StringSliceVar(&o.PlatformAdministratorRoleIDs, "platform-administrator-role-ids", nil, "Platform administrator role ID.")
 	f.Var((*PlatformAdministratorSubjectsValue)(&o.PlatformAdministratorSubjects), "platform-administrator-subjects", "Platform administrators as issuer::subject (bare value = UNI issuer).")
 	f.StringToStringVar(&o.SystemAccountRoleIDs, "system-account-roles-ids", nil, "System accounts map the X.509 Common Name to a role ID.")
+	f.Var(&o.GlobalRoleBindings, "global-role-binding", "Global role binding as issuer::subject::role[,role...]; subject '*' matches any subject from the issuer (clamped to read).")
 }
 
-// Validate reports whether the admin list still needs migrating: any bare
-// (UNI-sentinel) entry while a non-UNI issuer is trusted. Advisory only — the
-// caller logs the result rather than refusing to start; bare entries can
-// never match a CRD-declared issuer, so the runtime issuer-match in
-// processUserAccountACL remains the security control.
+// Validate reports two advisory (log-only) migration/hygiene issues, both if
+// present (joined with errors.Join, so errors.Is still matches each
+// individually): any bare (UNI-sentinel) admin entry while a non-UNI issuer
+// is trusted, and any GlobalRoleBindings issuer that is neither the UNI
+// sentinel nor in trustedNonUNIIssuers. Within each category only the first
+// offending entry is reported. Neither check blocks startup — bare entries
+// can never match a CRD-declared issuer and a stray binding issuer can never
+// match a real token, so the runtime issuer-match in processUserAccountACL /
+// resolveGlobalRoleBindings remains the sole security control; this only
+// surfaces the dominant failure mode (silent non-match on a mistyped or
+// stale issuer) to operators.
+//
+// Both checks are gated on a non-empty trustedNonUNIIssuers: the caller
+// (computeTrustedNonUNIIssuers) returns an empty slice both when there are
+// genuinely no trusted non-UNI issuers configured and when the provider
+// List call failed (treated as non-fatal), and Validate cannot tell those
+// two cases apart. Reporting on the failure case would be a false advisory
+// on every startup where the provider list happened to be unavailable, so
+// an empty list skips both checks entirely rather than risk that.
 func (o *Options) Validate(trustedNonUNIIssuers []string) error {
-	if len(trustedNonUNIIssuers) == 0 {
-		return nil
-	}
+	var bareAdminErr, untrustedIssuerErr error
 
-	for _, s := range o.PlatformAdministratorSubjects {
-		if s.Issuer == idconstants.UNISentinel {
-			return fmt.Errorf("%w: %q", ErrBareAdminSubject, s.Subject)
+	if len(trustedNonUNIIssuers) != 0 {
+		for _, s := range o.PlatformAdministratorSubjects {
+			if s.Issuer == idconstants.UNISentinel {
+				bareAdminErr = fmt.Errorf("%w: %q", ErrBareAdminSubject, s.Subject)
+
+				break
+			}
+		}
+
+		for _, b := range o.GlobalRoleBindings {
+			if b.Issuer == idconstants.UNISentinel || slices.Contains(trustedNonUNIIssuers, b.Issuer) {
+				continue
+			}
+
+			untrustedIssuerErr = fmt.Errorf("%w: %q", ErrUntrustedBindingIssuer, b.Issuer)
+
+			break
 		}
 	}
 
-	return nil
+	return goerrors.Join(bareAdminErr, untrustedIssuerErr)
 }
 
 // RBAC contains all the scoping rules for services across the platform.
@@ -141,14 +170,22 @@ type RBAC struct {
 	client    client.Client
 	namespace string
 	options   *Options
+	bindings  []GlobalRoleBinding
 }
 
 // New creates a new RBAC client.
 func New(client client.Client, namespace string, options *Options) *RBAC {
+	bindings := effectiveGlobalRoleBindings(options)
+
+	for _, b := range bindings {
+		slog.Info("global role binding active", "issuer", b.Issuer, "subject", b.Subject, "roleIDs", b.RoleIDs)
+	}
+
 	return &RBAC{
 		client:    client,
 		namespace: namespace,
 		options:   options,
+		bindings:  bindings,
 	}
 }
 
@@ -719,13 +756,19 @@ func (r *RBAC) processUserAccountACL(ctx context.Context, subject, srcIss, organ
 
 	acl := &openapi.Acl{}
 
-	if slices.ContainsFunc(r.options.PlatformAdministratorSubjects, func(p PlatformAdministratorSubject) bool {
-		return p.Issuer == srcIss && strings.EqualFold(strings.TrimSpace(p.Subject), strings.TrimSpace(subject))
-	}) {
-		if err := accumulateGlobalPermissions(acl, r.options.PlatformAdministratorRoleIDs, roles); err != nil {
-			return nil, err
+	if bindings := r.resolveGlobalRoleBindings(srcIss, subject); len(bindings) > 0 {
+		for _, b := range bindings {
+			accumulate := accumulateGlobalPermissions
+			if b.Wildcard {
+				accumulate = accumulateGlobalReadPermissions
+			}
+
+			if err := accumulate(acl, b.RoleIDs, roles); err != nil {
+				return nil, err
+			}
 		}
 
+		// Replace semantics: bound principals skip membership resolution.
 		return acl, nil
 	}
 

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -120,22 +120,15 @@ func (o *Options) AddFlags(f *pflag.FlagSet) {
 	f.Var(&o.GlobalRoleBindings, "global-role-binding", "Global role binding as issuer::subject::role[,role...]; subject '*' matches any subject from the issuer (clamped to read).")
 }
 
-// Validate reports two advisory (log-only) migration/hygiene issues without
-// blocking startup: any bare (UNI-sentinel) admin entry while a non-UNI
-// issuer is trusted, and any GlobalRoleBindings issuer that is neither the
-// UNI sentinel nor in trustedNonUNIIssuers. Every offending entry in each
-// category is reported (joined with errors.Join, so errors.Is still matches
-// each sentinel). The runtime issuer-match in resolveGlobalRoleBindings
-// remains the sole security control; see
-// pkg/rbac/README.md#global-role-bindings for the full rationale.
+// Validate reports advisory (log-only) startup findings: bare (UNI-sentinel)
+// admin entries while a non-UNI issuer is trusted, and GlobalRoleBindings
+// issuers outside trustedNonUNIIssuers. Every offender is reported, joined
+// with errors.Join so errors.Is still matches each sentinel.
 //
-// The bare-admin-subject check is gated on a non-empty trustedNonUNIIssuers:
-// a bare entry only matters once a non-UNI issuer is trusted to migrate away
-// from. The binding-issuer check has no such gate — it runs even against a
-// genuinely empty list, where every non-sentinel binding issuer is reported
-// as untrusted. Callers that cannot distinguish "no trusted issuers
-// configured" from "provider list unavailable" must not call Validate in the
-// latter case.
+// Only the bare-admin check is gated on a non-empty trustedNonUNIIssuers, so
+// a caller that cannot tell "none configured" from "provider list
+// unavailable" must not call Validate in the latter case. See
+// pkg/rbac/README.md#global-role-bindings for gating and security semantics.
 func (o *Options) Validate(trustedNonUNIIssuers []string) error {
 	errs := make([]error, 0, len(o.PlatformAdministratorSubjects)+len(o.GlobalRoleBindings))
 

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -1040,26 +1040,3 @@ func (r *RBAC) GetACL(ctx context.Context, organizationID string) (*openapi.Acl,
 
 	return r.processUserAccountACL(ctx, subject, srcIss, organizationID, authz)
 }
-
-func (r *RBAC) NewSuperContext(ctx context.Context) (context.Context, error) {
-	roles, err := r.getRoles(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	var globalACL openapi.AclEndpoints
-
-	for _, id := range r.options.PlatformAdministratorRoleIDs {
-		if role, ok := roles[id]; ok {
-			addScopesToEndpointList(&globalACL, role.Spec.Scopes.Global)
-		}
-	}
-
-	acl := &openapi.Acl{}
-
-	if len(globalACL) != 0 {
-		acl.Global = &globalACL
-	}
-
-	return NewContext(ctx, acl), nil
-}

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -120,49 +120,44 @@ func (o *Options) AddFlags(f *pflag.FlagSet) {
 	f.Var(&o.GlobalRoleBindings, "global-role-binding", "Global role binding as issuer::subject::role[,role...]; subject '*' matches any subject from the issuer (clamped to read).")
 }
 
-// Validate reports two advisory (log-only) migration/hygiene issues, both if
-// present (joined with errors.Join, so errors.Is still matches each
-// individually): any bare (UNI-sentinel) admin entry while a non-UNI issuer
-// is trusted, and any GlobalRoleBindings issuer that is neither the UNI
-// sentinel nor in trustedNonUNIIssuers. Within each category only the first
-// offending entry is reported. Neither check blocks startup — bare entries
-// can never match a CRD-declared issuer and a stray binding issuer can never
-// match a real token, so the runtime issuer-match in processUserAccountACL /
-// resolveGlobalRoleBindings remains the sole security control; this only
-// surfaces the dominant failure mode (silent non-match on a mistyped or
-// stale issuer) to operators.
+// Validate reports two advisory (log-only) migration/hygiene issues: any bare
+// (UNI-sentinel) admin entry while a non-UNI issuer is trusted, and any
+// GlobalRoleBindings issuer that is neither the UNI sentinel nor in
+// trustedNonUNIIssuers. Every offending entry in each category is reported
+// (joined with errors.Join, so errors.Is still matches each sentinel).
+// Neither check blocks startup — bare entries can never match a CRD-declared
+// issuer and a stray binding issuer can never match a real token, so the
+// runtime issuer-match in processUserAccountACL / resolveGlobalRoleBindings
+// remains the sole security control; this only surfaces the dominant failure
+// mode (silent non-match on a mistyped or stale issuer) to operators.
 //
-// Both checks are gated on a non-empty trustedNonUNIIssuers: the caller
-// (computeTrustedNonUNIIssuers) returns an empty slice both when there are
-// genuinely no trusted non-UNI issuers configured and when the provider
-// List call failed (treated as non-fatal), and Validate cannot tell those
-// two cases apart. Reporting on the failure case would be a false advisory
-// on every startup where the provider list happened to be unavailable, so
-// an empty list skips both checks entirely rather than risk that.
+// The bare-admin-subject check is gated on a non-empty trustedNonUNIIssuers:
+// a bare entry only matters once a non-UNI issuer is trusted to migrate away
+// from. The binding-issuer check has no such gate — it runs even against a
+// genuinely empty list, where every non-sentinel binding issuer is reported
+// as untrusted. Callers that cannot distinguish "no trusted issuers
+// configured" from "provider list unavailable" must not call Validate in the
+// latter case.
 func (o *Options) Validate(trustedNonUNIIssuers []string) error {
-	var bareAdminErr, untrustedIssuerErr error
+	errs := make([]error, 0, len(o.PlatformAdministratorSubjects)+len(o.GlobalRoleBindings))
 
 	if len(trustedNonUNIIssuers) != 0 {
 		for _, s := range o.PlatformAdministratorSubjects {
 			if s.Issuer == idconstants.UNISentinel {
-				bareAdminErr = fmt.Errorf("%w: %q", ErrBareAdminSubject, s.Subject)
-
-				break
+				errs = append(errs, fmt.Errorf("%w: %q", ErrBareAdminSubject, s.Subject))
 			}
-		}
-
-		for _, b := range o.GlobalRoleBindings {
-			if b.Issuer == idconstants.UNISentinel || slices.Contains(trustedNonUNIIssuers, b.Issuer) {
-				continue
-			}
-
-			untrustedIssuerErr = fmt.Errorf("%w: %q", ErrUntrustedBindingIssuer, b.Issuer)
-
-			break
 		}
 	}
 
-	return goerrors.Join(bareAdminErr, untrustedIssuerErr)
+	for _, b := range o.GlobalRoleBindings {
+		if b.Issuer == idconstants.UNISentinel || slices.Contains(trustedNonUNIIssuers, b.Issuer) {
+			continue
+		}
+
+		errs = append(errs, fmt.Errorf("%w: %q", ErrUntrustedBindingIssuer, b.Issuer))
+	}
+
+	return goerrors.Join(errs...)
 }
 
 // RBAC contains all the scoping rules for services across the platform.

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
-	"log/slog"
 	"slices"
 	"strings"
 
@@ -39,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -163,8 +163,10 @@ type RBAC struct {
 func New(client client.Client, namespace string, options *Options) *RBAC {
 	bindings := effectiveGlobalRoleBindings(options)
 
+	logger := log.Log.WithName("rbac")
+
 	for _, b := range bindings {
-		slog.Info("global role binding active", "issuer", b.Issuer, "subject", b.Subject, "roleIDs", b.RoleIDs)
+		logger.Info("global role binding active", "issuer", b.Issuer, "subject", b.Subject, "roleIDs", b.RoleIDs)
 	}
 
 	return &RBAC{
@@ -197,7 +199,7 @@ func (r *RBAC) groupSubjectFilter(ctx context.Context, subject string) func(unik
 		if len(group.Spec.UserIDs) > 0 {
 			if orgUserName, err := r.resolveOrganizationUserName(ctx, group.Namespace, subject); err == nil {
 				if slices.Contains(group.Spec.UserIDs, orgUserName) {
-					slog.Warn("group matched via deprecated userIDs field, migration to subjects required",
+					log.FromContext(ctx).Info("group matched via deprecated userIDs field, migration to subjects required",
 						"group", group.Name, "namespace", group.Namespace, "userID", orgUserName)
 
 					return false

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -47,7 +47,7 @@ var (
 	ErrWrongOrganizationCount = goerrors.New("expected exactly one organization ID")
 	ErrNotInOrganization      = goerrors.New("subject not a member of organization")
 	ErrInvalidPrincipalType   = goerrors.New("invalid impersonated principal type")
-	ErrBareAdminSubject       = goerrors.New("bare platform-administrator-subjects entry with non-UNI issuer trusted; migrate to issuer::subject")
+	ErrBareAdminSubject       = goerrors.New("bare platform-administrator-subjects entry with non-UNI issuer trusted; migrate to globalRoleBindings")
 	ErrUntrustedBindingIssuer = goerrors.New("global role binding issuer is neither the UNI sentinel nor a trusted issuer")
 )
 

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -120,16 +120,14 @@ func (o *Options) AddFlags(f *pflag.FlagSet) {
 	f.Var(&o.GlobalRoleBindings, "global-role-binding", "Global role binding as issuer::subject::role[,role...]; subject '*' matches any subject from the issuer (clamped to read).")
 }
 
-// Validate reports two advisory (log-only) migration/hygiene issues: any bare
-// (UNI-sentinel) admin entry while a non-UNI issuer is trusted, and any
-// GlobalRoleBindings issuer that is neither the UNI sentinel nor in
-// trustedNonUNIIssuers. Every offending entry in each category is reported
-// (joined with errors.Join, so errors.Is still matches each sentinel).
-// Neither check blocks startup — bare entries can never match a CRD-declared
-// issuer and a stray binding issuer can never match a real token, so the
-// runtime issuer-match in processUserAccountACL / resolveGlobalRoleBindings
-// remains the sole security control; this only surfaces the dominant failure
-// mode (silent non-match on a mistyped or stale issuer) to operators.
+// Validate reports two advisory (log-only) migration/hygiene issues without
+// blocking startup: any bare (UNI-sentinel) admin entry while a non-UNI
+// issuer is trusted, and any GlobalRoleBindings issuer that is neither the
+// UNI sentinel nor in trustedNonUNIIssuers. Every offending entry in each
+// category is reported (joined with errors.Join, so errors.Is still matches
+// each sentinel). The runtime issuer-match in resolveGlobalRoleBindings
+// remains the sole security control; see
+// pkg/rbac/README.md#global-role-bindings for the full rationale.
 //
 // The bare-admin-subject check is gated on a non-empty trustedNonUNIIssuers:
 // a bare entry only matters once a non-UNI issuer is trusted to migrate away

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -152,7 +152,9 @@ func (s *Server) GetServer(client client.Client, directclient client.Client) (*h
 	// not a vulnerability — warn, don't block boot. A hard failure here would
 	// fire at an unrelated pod restart long after the first bearerTrust CRD
 	// was created.
-	if err := s.RBACOptions.Validate(computeTrustedNonUNIIssuers(context.TODO(), client, s.CoreOptions.Namespace)); err != nil {
+	if trustedNonUNIIssuers, err := computeTrustedNonUNIIssuers(context.TODO(), client, s.CoreOptions.Namespace); err != nil {
+		log.FromContext(context.TODO()).Info("rbac options advisory check skipped: provider list unavailable", "error", err)
+	} else if err := s.RBACOptions.Validate(trustedNonUNIIssuers); err != nil {
 		log.FromContext(context.TODO()).Info("rbac options advisory check failed", "error", err)
 	}
 
@@ -217,13 +219,14 @@ func expandBareAdminSubjects(subjects []rbac.PlatformAdministratorSubject, legac
 // migration warning only; the runtime issuer-match in validatorForIssuer is
 // the real control.
 //
-// A List failure (e.g. informer cache not yet warm) is treated as non-fatal:
-// the check is skipped and returns an empty slice so startup is not blocked.
-func computeTrustedNonUNIIssuers(ctx context.Context, cli client.Client, namespace string) []string {
+// A List failure (e.g. informer cache not yet warm) is returned as an error
+// so the caller can skip the advisory check rather than mistake it for a
+// genuinely empty trusted-issuer list.
+func computeTrustedNonUNIIssuers(ctx context.Context, cli client.Client, namespace string) ([]string, error) {
 	var providers unikornv1.OAuth2ProviderList
 
 	if err := cli.List(ctx, &providers, &client.ListOptions{Namespace: namespace}); err != nil {
-		return nil
+		return nil, err
 	}
 
 	seen := make(map[string]struct{})
@@ -252,5 +255,5 @@ func computeTrustedNonUNIIssuers(ctx context.Context, cli client.Client, namespa
 		}
 	}
 
-	return result
+	return result, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -146,13 +146,14 @@ func (s *Server) GetServer(client client.Client, directclient client.Client) (*h
 		return nil, err
 	}
 
-	// Migration nudge: bare admin entries can never match a CRD-declared
-	// issuer (the runtime issuer-match in validatorForIssuer is the real
-	// control), so an unmigrated admin list is hygiene, not a vulnerability —
-	// warn, don't block boot. A hard failure here would fire at an unrelated
-	// pod restart long after the first bearerTrust CRD was created.
+	// Advisory nudge: Validate's checks (bare admin entries, untrusted
+	// global-role-binding issuers) can never match a real token or
+	// CRD-declared issuer, so an unmigrated/misconfigured entry is hygiene,
+	// not a vulnerability — warn, don't block boot. A hard failure here would
+	// fire at an unrelated pod restart long after the first bearerTrust CRD
+	// was created.
 	if err := s.RBACOptions.Validate(computeTrustedNonUNIIssuers(context.TODO(), client, s.CoreOptions.Namespace)); err != nil {
-		log.FromContext(context.TODO()).Info("platform-administrator-subjects migration pending", "error", err)
+		log.FromContext(context.TODO()).Info("rbac options advisory check failed", "error", err)
 	}
 
 	// Setup middleware.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -146,12 +146,9 @@ func (s *Server) GetServer(client client.Client, directclient client.Client) (*h
 		return nil, err
 	}
 
-	// Advisory nudge: Validate's checks (bare admin entries, untrusted
-	// global-role-binding issuers) can never match a real token or
-	// CRD-declared issuer, so an unmigrated/misconfigured entry is hygiene,
-	// not a vulnerability — warn, don't block boot. A hard failure here would
-	// fire at an unrelated pod restart long after the first bearerTrust CRD
-	// was created.
+	// Advisory only: warn, don't block boot. Issuer-qualified matching is the
+	// runtime control, and a hard failure here would fire at an unrelated pod
+	// restart long after the first bearerTrust CRD was created.
 	if trustedNonUNIIssuers, err := computeTrustedNonUNIIssuers(context.TODO(), client, s.CoreOptions.Namespace); err != nil {
 		log.FromContext(context.TODO()).Info("rbac options advisory check skipped: provider list unavailable", "error", err)
 	} else if err := s.RBACOptions.Validate(trustedNonUNIIssuers); err != nil {
@@ -213,11 +210,9 @@ func expandBareAdminSubjects(subjects []rbac.PlatformAdministratorSubject, legac
 
 // computeTrustedNonUNIIssuers returns the issuers (verbatim) of all
 // BearerTrust-enabled OAuth2Providers in the identity namespace, minus the
-// UNI sentinel. The legacy Auth0 flag issuer is deliberately excluded: bare
-// admin entries are mirrored onto it by expandBareAdminSubjects, so its
-// presence alone leaves nothing to migrate. The result feeds the advisory
-// migration warning only; the runtime issuer-match in validatorForIssuer is
-// the real control.
+// UNI sentinel. The legacy Auth0 flag issuer is deliberately excluded:
+// expandBareAdminSubjects already mirrors bare admin entries onto it, so its
+// presence alone leaves nothing to migrate.
 //
 // A List failure (e.g. informer cache not yet warm) is returned as an error
 // so the caller can skip the advisory check rather than mistake it for a

--- a/pkg/server/server_internal_test.go
+++ b/pkg/server/server_internal_test.go
@@ -26,9 +26,8 @@ import (
 
 // TestExpandBareAdminSubjects covers the legacy-compatibility mirroring of
 // bare (UNI-sentinel) platform-admin entries onto the deprecated
-// auth0-exchange issuer. Note the runtime match asymmetry the mirror feeds
-// into: subjects compare with EqualFold, issuers compare exactly — the mirror
-// therefore copies the flag issuer verbatim.
+// auth0-exchange issuer. The runtime match compares issuers exactly, so the
+// mirror copies the flag issuer verbatim.
 func TestExpandBareAdminSubjects(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/userdb/README.md
+++ b/pkg/userdb/README.md
@@ -61,7 +61,9 @@ organization-local membership is active before returning it.
 - organization membership is resolved through labeled `OrganizationUser` records
 - service accounts are part of the same local identity-resolution surface as users
 - unresolved, inactive, or multiply-resolved identities are normalized into
-  `ErrResourceReference`
+  `ErrResourceReference`; only the global-user path (`GetActiveUser`) distinguishes inactive as
+  `ErrUserInactive`, which wraps `ErrResourceReference` — the organization-user path
+  (`GetActiveOrganizationUser`) still collapses its inactive case into `ErrResourceReference`
 
 ## Caveats
 
@@ -69,9 +71,15 @@ organization-local membership is active before returning it.
   though its purpose is to shield other packages from that coupling.
 - Several lookups are implemented as list-and-filter operations, so they depend on label hygiene
   and on the current storage layout remaining coherent.
-- The package intentionally flattens several different unusable-identity cases into one read-side
-  failure surface. Missing, inactive, and multiply-resolved identities are all treated as "not a
-  usable local reference" for callers.
+- The package flattens most unusable-identity cases into one read-side failure surface: missing
+  and multiply-resolved identities are all treated as "not a usable local reference" via
+  `ErrResourceReference`. On the global-user path, the exists-but-inactive case
+  (`GetActiveUser`) is distinguishable as `ErrUserInactive`, which wraps `ErrResourceReference` so
+  existing `errors.Is(err, ErrResourceReference)` callers keep working unchanged. The distinction
+  exists because bearer-path admission must not resurrect a locally-suspended user with an
+  empty-membership passport just because an external identity provider still vouches for them.
+  The organization-user path (`GetActiveOrganizationUser`) is a different path, out of scope for
+  that distinction: it still collapses its inactive case into plain `ErrResourceReference`.
 - The package intentionally does not provide mutation or transactional semantics; it is a read-side
   adapter boundary only.
 

--- a/pkg/userdb/README.md
+++ b/pkg/userdb/README.md
@@ -75,11 +75,12 @@ organization-local membership is active before returning it.
   and multiply-resolved identities are all treated as "not a usable local reference" via
   `ErrResourceReference`. On the global-user path, the exists-but-inactive case
   (`GetActiveUser`) is distinguishable as `ErrUserInactive`, which wraps `ErrResourceReference` so
-  existing `errors.Is(err, ErrResourceReference)` callers keep working unchanged. The distinction
-  exists because bearer-path admission must not resurrect a locally-suspended user with an
-  empty-membership passport just because an external identity provider still vouches for them.
-  The organization-user path (`GetActiveOrganizationUser`) is a different path, out of scope for
-  that distinction: it still collapses its inactive case into plain `ErrResourceReference`.
+  existing `errors.Is(err, ErrResourceReference)` callers keep working unchanged. Bearer-path
+  admission relies on this distinction — see
+  [`docs/multi-issuer-token-contract.md#membership-resolution`](../../docs/multi-issuer-token-contract.md#membership-resolution)
+  for why, and for the org-suspension gap it does not close. The organization-user path
+  (`GetActiveOrganizationUser`) is a different path, out of scope for that distinction: it still
+  collapses its inactive case into plain `ErrResourceReference`.
 - The package intentionally does not provide mutation or transactional semantics; it is a read-side
   adapter boundary only.
 

--- a/pkg/userdb/README.md
+++ b/pkg/userdb/README.md
@@ -61,9 +61,7 @@ organization-local membership is active before returning it.
 - organization membership is resolved through labeled `OrganizationUser` records
 - service accounts are part of the same local identity-resolution surface as users
 - unresolved, inactive, or multiply-resolved identities are normalized into
-  `ErrResourceReference`; only the global-user path (`GetActiveUser`) distinguishes inactive as
-  `ErrUserInactive`, which wraps `ErrResourceReference` — the organization-user path
-  (`GetActiveOrganizationUser`) still collapses its inactive case into `ErrResourceReference`
+  `ErrResourceReference`, with one exception noted under Caveats
 
 ## Caveats
 
@@ -71,16 +69,12 @@ organization-local membership is active before returning it.
   though its purpose is to shield other packages from that coupling.
 - Several lookups are implemented as list-and-filter operations, so they depend on label hygiene
   and on the current storage layout remaining coherent.
-- The package flattens most unusable-identity cases into one read-side failure surface: missing
-  and multiply-resolved identities are all treated as "not a usable local reference" via
-  `ErrResourceReference`. On the global-user path, the exists-but-inactive case
-  (`GetActiveUser`) is distinguishable as `ErrUserInactive`, which wraps `ErrResourceReference` so
-  existing `errors.Is(err, ErrResourceReference)` callers keep working unchanged. Bearer-path
-  admission relies on this distinction — see
+- Missing and multiply-resolved identities return `ErrResourceReference`. `GetActiveUser` instead
+  returns `ErrUserInactive` for an inactive global user, which wraps `ErrResourceReference` so
+  existing `errors.Is` callers are unaffected; `GetActiveOrganizationUser` still returns the plain
+  error. See
   [`docs/multi-issuer-token-contract.md#membership-resolution`](../../docs/multi-issuer-token-contract.md#membership-resolution)
-  for why, and for the org-suspension gap it does not close. The organization-user path
-  (`GetActiveOrganizationUser`) is a different path, out of scope for that distinction: it still
-  collapses its inactive case into plain `ErrResourceReference`.
+  for the bearer-admission consequences and the organization-suspension gap this leaves open.
 - The package intentionally does not provide mutation or transactional semantics; it is a read-side
   adapter boundary only.
 

--- a/pkg/userdb/users.go
+++ b/pkg/userdb/users.go
@@ -33,6 +33,11 @@ import (
 var (
 	// ErrResourceReference is raised when a resource cannot be looked up.
 	ErrResourceReference = fmt.Errorf("resource reference error")
+
+	// ErrUserInactive wraps ErrResourceReference so existing callers keep
+	// rejecting; the bearer path distinguishes it to refuse inactive users
+	// regardless of allowExternalIdentity.
+	ErrUserInactive = fmt.Errorf("%w: user is not active", ErrResourceReference)
 )
 
 type UserDatabase struct {
@@ -73,7 +78,7 @@ func (d *UserDatabase) GetActiveUser(ctx context.Context, subject string) (*unik
 	}
 
 	if user.Spec.State != unikornv1.UserStateActive {
-		return nil, fmt.Errorf("%w: user is not active", ErrResourceReference)
+		return nil, ErrUserInactive
 	}
 
 	return user, nil

--- a/pkg/userdb/users.go
+++ b/pkg/userdb/users.go
@@ -34,9 +34,8 @@ var (
 	// ErrResourceReference is raised when a resource cannot be looked up.
 	ErrResourceReference = fmt.Errorf("resource reference error")
 
-	// ErrUserInactive wraps ErrResourceReference so existing callers keep
-	// rejecting; the bearer path distinguishes it to refuse inactive users
-	// regardless of allowExternalIdentity.
+	// ErrUserInactive identifies an inactive global user and wraps
+	// ErrResourceReference for compatibility.
 	ErrUserInactive = fmt.Errorf("%w: user is not active", ErrResourceReference)
 )
 

--- a/pkg/userdb/users_test.go
+++ b/pkg/userdb/users_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userdb_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/identity/pkg/userdb"
+)
+
+// TestErrUserInactiveWrapsErrResourceReference pins the compatibility contract:
+// existing errors.Is(err, ErrResourceReference) callers must keep matching.
+func TestErrUserInactiveWrapsErrResourceReference(t *testing.T) {
+	t.Parallel()
+
+	require.ErrorIs(t, userdb.ErrUserInactive, userdb.ErrResourceReference)
+}

--- a/test/README.md
+++ b/test/README.md
@@ -60,6 +60,8 @@ Optional variables for richer coverage:
 - `USER_AUTH_TOKEN`
 - `TEST_USER_SA_ID`
 - `IDENTITY_CA_CERT`
+- `PLATFORM_ADMIN_AUTH_TOKEN` — user token bound via legacy `platformAdministrators.subjects`
+- `BINDING_ADMIN_AUTH_TOKEN` — user token bound via `globalRoleBindings`
 
 Notes:
 

--- a/test/api/config.go
+++ b/test/api/config.go
@@ -28,6 +28,8 @@ type TestConfig struct {
 	AdminToken          string
 	UserToken           string
 	AuditToken          string
+	PlatformAdminToken  string
+	BindingAdminToken   string
 	OrgID               string
 	ProjectID           string
 	AdminGroupID        string
@@ -78,6 +80,8 @@ func LoadTestConfig() (*TestConfig, error) {
 		AdminToken:          firstNonEmpty(v.GetString("ADMIN_AUTH_TOKEN"), v.GetString("API_AUTH_TOKEN")),
 		UserToken:           v.GetString("USER_AUTH_TOKEN"),
 		AuditToken:          v.GetString("AUDIT_AUTH_TOKEN"),
+		PlatformAdminToken:  v.GetString("PLATFORM_ADMIN_AUTH_TOKEN"),
+		BindingAdminToken:   v.GetString("BINDING_ADMIN_AUTH_TOKEN"),
 		OrgID:               v.GetString("TEST_ORG_ID"),
 		ProjectID:           v.GetString("TEST_PROJECT_ID"),
 		AdminGroupID:        v.GetString("TEST_ADMIN_GROUP_ID"),

--- a/test/api/suites/global_role_bindings_test.go
+++ b/test/api/suites/global_role_bindings_test.go
@@ -1,0 +1,141 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:revive,testpackage // dot imports and package naming standard for Ginkgo
+package suites
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/unikorn-cloud/identity/test/api"
+)
+
+var _ = Describe("Global role bindings", func() {
+	var (
+		legacyAdminClient  *api.APIClient
+		bindingAdminClient *api.APIClient
+	)
+
+	Context("When a subject is bound via the legacy platform-administrator flags", func() {
+		BeforeEach(func() {
+			if config.PlatformAdminToken == "" {
+				Skip("PLATFORM_ADMIN_AUTH_TOKEN is required for legacy platform-administrator binding testing")
+			}
+			legacyAdminConfig := *config
+			legacyAdminConfig.AuthToken = config.PlatformAdminToken
+			legacyAdminClient = api.NewAPIClientWithConfig(&legacyAdminConfig)
+		})
+
+		Describe("an organization the subject is not a member of", func() {
+			BeforeEach(func() {
+				if config.UnauthorisedOrgID == "" {
+					Skip("UNAUTHORISED_ORG_ID is required for global role binding cross-organization testing")
+				}
+			})
+
+			It("can be read", func(ctx SpecContext) {
+				org, err := legacyAdminClient.GetOrganization(ctx, config.UnauthorisedOrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(org.Metadata.Id).To(Equal(config.UnauthorisedOrgID))
+			})
+		})
+	})
+
+	Context("When a subject is bound via --global-role-binding", func() {
+		BeforeEach(func() {
+			if config.BindingAdminToken == "" {
+				Skip("BINDING_ADMIN_AUTH_TOKEN is required for global-role-binding testing")
+			}
+			bindingAdminConfig := *config
+			bindingAdminConfig.AuthToken = config.BindingAdminToken
+			bindingAdminClient = api.NewAPIClientWithConfig(&bindingAdminConfig)
+		})
+
+		Describe("an organization the subject is not a member of", func() {
+			BeforeEach(func() {
+				if config.UnauthorisedOrgID == "" {
+					Skip("UNAUTHORISED_ORG_ID is required for global role binding cross-organization testing")
+				}
+			})
+
+			It("can be read", func(ctx SpecContext) {
+				org, err := bindingAdminClient.GetOrganization(ctx, config.UnauthorisedOrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(org.Metadata.Id).To(Equal(config.UnauthorisedOrgID))
+			})
+		})
+	})
+
+	Context("When a bound subject is also an organization member", func() {
+		BeforeEach(func() {
+			if config.BindingAdminToken == "" {
+				Skip("BINDING_ADMIN_AUTH_TOKEN is required for global-role-binding testing")
+			}
+			bindingAdminConfig := *config
+			bindingAdminConfig.AuthToken = config.BindingAdminToken
+			bindingAdminClient = api.NewAPIClientWithConfig(&bindingAdminConfig)
+		})
+
+		Describe("their ACL for that organization", func() {
+			It("is global-only — membership resolution is replaced, not merged", func(ctx SpecContext) {
+				// The direct e2e detector for replace semantics: an
+				// accidentally-additive rewrite would populate Organizations
+				// alongside Global instead of replacing membership resolution.
+				acl, err := bindingAdminClient.GetOrganizationACL(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(acl.Global).NotTo(BeNil())
+				Expect(acl.Organizations).To(BeNil())
+			})
+		})
+	})
+
+	Context("Given an unbound user token", func() {
+		BeforeEach(func() {
+			if userClient == nil {
+				Skip("USER_AUTH_TOKEN is required for unbound user organization list testing")
+			}
+			if config.UnauthorisedOrgID == "" {
+				Skip("UNAUTHORISED_ORG_ID is required for unbound user organization list testing")
+			}
+		})
+
+		Describe("the organization list", func() {
+			It("includes the user's own organization but not organizations they are not a member of", func(ctx SpecContext) {
+				// Unscoped ACL resolution error mapping for a direct GET is not
+				// this feature's contract; the stable, body-asserting check is
+				// list contents.
+				//
+				// Asserting only the negative (absence of UnauthorisedOrgID)
+				// would pass vacuously against an empty or otherwise broken
+				// list, so first prove the list was actually populated for
+				// this member by requiring their own organization to be
+				// present.
+				orgs, err := userClient.ListOrganizations(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(orgs).To(ContainElement(HaveField("Metadata.Id", config.OrgID)))
+				Expect(orgs).NotTo(ContainElement(HaveField("Metadata.Id", config.UnauthorisedOrgID)))
+			})
+		})
+	})
+})


### PR DESCRIPTION
Replaces the platform-administrator fast-path in `processUserAccountACL` with one generic mechanism — a **global role binding** mapping an `(issuer, subject | "*")` pair to a set of role IDs — configured via a repeated `--global-role-binding` flag and a `globalRoleBindings` chart value.

## Motivation

Global authority is a hardcoded special case. `processUserAccountACL` short-circuits before role resolution: if `(src_iss, subject)` matches a `--platform-administrator-subjects` entry, the caller gets the global permissions of `--platform-administrator-role-ids` and RBAC returns early (`pkg/rbac/rbac.go:722` on `main`).

Two consequences:

- Each new kind of global principal — ID-399's platform-wide staff reader is the next one — needs another bespoke fast-path and flag, duplicating the issuer URL into deployment config, where the verbatim, trailing-slash-sensitive `iss` match is easy to get wrong.
- The decision lives outside RBAC, so it cannot move cleanly to the policy engine (Cerbos Phase 1).

This replaces the fast-path with one mechanism: `(issuer, subject | "*") → [role IDs]`. Platform administrators become one binding of that kind, ID-399's staff reader another, and neither needs Go changes.

## Semantics

- **Replace, not merge.** A matched principal skips membership resolution for that session, so org-scoped writes are absent while authenticated via a bound issuer. This is session-level privilege separation, and it is the behaviour the direct integration assertion pins.
- **Wildcards are clamped to read** at accumulation time, and never match the `uni` sentinel or an unset issuer — so impersonated principals and pre-`src_iss` passports fail closed. The clamp bounds *verbs, not payload sensitivity*: read endpoints can still return credential material, so any role referenced by a wildcard binding needs a read-surface audit first.
- **Issuer-wide bindings are only appropriate** for issuers whose entire user population is itself an authorization decision.

## Compatibility

Compatible. The legacy `--platform-administrator-*` flags are translated verbatim into exact bindings and keep working unchanged — a legacy subject literally `*` stays an exact match and never widens to wildcard semantics. `--platform-administrator-role-ids` keeps its meaning as the role set granted to those subjects, and no chart value changed meaning.

One symbol is removed: `rbac.NewSuperContext`, which lost its only caller when onboarding was deleted (#491) and has none in any nscaledev repo — verified by org-wide code search. It was the last non-binding reader of `PlatformAdministratorRoleIDs`, so dropping it puts the legacy flags on a real removal path. Every other exported symbol is unchanged.

A unit test pins that the legacy flags and equivalent bindings produce identical ACLs, and the integration suite proves it against a live cluster with two bound identities, one per mechanism.

## Two hardening fixes riding along

- **`src_iss` in the ACL cache key** (ID-367 finding 6). Bindings make the authenticated issuer authorization-relevant, so the old key let the same subject value from two issuers share a cached ACL. Every user-influenced segment is length-prefixed rather than plainly joined, because subjects routinely contain the `|` delimiter (Auth0 emits `auth0|<id>`) and an unescaped join lets one identity forge another's key.
- **Inactive users rejected on the bearer path**, regardless of `allowExternalIdentity`. That flag is meant to admit subjects UNI has never seen, not to re-admit one it has explicitly deactivated. `ErrUserInactive` wraps `ErrResourceReference`, so every existing `errors.Is` caller behaves as before.

## Reviewer notes

- **Misconfiguration fails the Helm render, not the pod.** Subjects are trimmed once before every guard reads them, and `::` — the flag separator, which would silently shift the right-anchored parse — is rejected on both issuer and subject. The chart is the only layer that can catch the separator case: once the flag string is built the mis-parse is undetectable server-side. `hack/check_chart_render.sh` (wired into `make lint`) asserts each negative case fails for *its own* reason, so one broken guard can't hide behind another's error.
- **Role-set drift is the one class the render cannot cover, and it fails closed.** A role name absent from the chart's catalogue produces a perfectly valid flag that then 500s every user of that issuer at request time; a `Role` CRD deleted *after* a successful render does the same, because roles are live CRDs read per request. Erroring beats silently resolving a smaller ACL on an authorization path, so this is deliberate — but it is an availability cliff worth knowing about before referencing a role from a wildcard binding.
- **Known gaps, deliberately not closed here.** Both concern the inactive-user rejection, and both are documented in `docs/multi-issuer-token-contract.md`:
  - Organization-level suspension takes a different path that resolves to an empty `orgIds` list with no error, so a user suspended in every org is still admitted. Flagged for ID-399, which would build wildcard bindings directly on top of it.
  - The rejection can only fire on a record the lookup finds, and `GetUser` compares `spec.subject` verbatim while the bearer path lower-cases the email claim first. A `User` stored with a mixed-case subject is never matched and is admitted as never-onboarded, while bindings — which match case-insensitively — still grant it authority. The matcher's `EqualFold` is verbatim the legacy fast-path's, so this branch makes a pre-existing gap visible rather than introducing one. Closing it means normalising `GetUser` or `spec.subject` at creation: a change to global identity resolution with a duplicate-record migration attached, tracked separately.
- Commits are self-contained and file-disjoint; each builds and vets independently (`git rebase --exec`), so the branch is bisectable.

## Verification

- `make touch license validate lint generate` with a clean tree, plus `make test-unit`.
- `go vet -tags integration ./test/api/...`.
- Full `make integration-test` against fresh KinD: **192/192 specs, 0 failed, 0 skipped**, including four new specs covering both binding mechanisms and the global-only ACL that detects an accidentally-additive rewrite. That run predates the review fixes above; CI covers the current head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)