### PR TITLE
feat(chart): add a protected platform-reader role (ID-399)

### DIFF
--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -156,7 +156,8 @@ platformAdministrators:
 # per-subject bindings here are the only route to global write authority.
 # Full semantics: pkg/rbac/README.md#global-role-bindings.
 # Helm rejects invalid separators and wildcard bindings on roles that grant any
-# non-read global operation — no role shipped below qualifies for wildcard use.
+# non-read global operation — platform-reader is the only role shipped below
+# with global scopes that qualifies for wildcard use.
 # Rollout ordering: the flag is emitted only when this list is non-empty, and
 # older server binaries do not recognise it — deploy a binary that understands
 # --global-role-binding before enabling bindings; on rollback, clear this
@@ -164,7 +165,7 @@ platformAdministrators:
 globalRoleBindings: []
 #  - issuer: https://staff.example.auth0.com/
 #    subject: "*"
-#    roles: [platform-reader] # example only: role must already exist in roles/additionalRoles
+#    roles: [platform-reader]
 #  - issuer: uni
 #    subjects: [alice@example.com, bob@example.com]
 #    roles: [platform-administrator]
@@ -232,6 +233,47 @@ roles:
         storage:objectstorageclasses: [create,read,update,delete]
         storage:objectstorageendpoints: [create,read,update,delete]
         storage:objectstorageendpoints/accesskeys: [create,read,update,delete]
+  # A platform-reader has global read-only visibility for support tooling.
+  # Definition = read-projection of platform-administrator's global scopes
+  # minus credential-bearing and unserved scopes. The projection, the
+  # exclusion list, and read-only-ness are pinned by the contract test in
+  # pkg/rbac (see docs/platform-reader.md for the audit record and runbook).
+  platform-reader:
+    description: Platform reader
+    protected: true
+    scopes:
+      global:
+        identity:organizations: [read]
+        identity:oauth2providers: [read]
+        identity:roles: [read]
+        identity:serviceaccounts: [read]
+        identity:users: [read]
+        identity:groups: [read]
+        identity:projects: [read]
+        identity:quotas: [read]
+        identity:allocations: [read]
+        region:regions: [read]
+        region:flavors: [read]
+        region:images: [read]
+        region:externalnetworks: [read]
+        region:networks: [read]
+        region:networks:v2: [read]
+        region:loadbalancers:v2: [read]
+        region:securitygroups: [read]
+        region:securitygroups:v2: [read]
+        region:volumeclasses:v2: [read]
+        region:filestorage:v2: [read]
+        region:filestorageclass:v2: [read]
+        region:sshcertificateauthorities:v2: [read]
+        kubernetes:regions: [read]
+        kubernetes:flavors: [read]
+        kubernetes:images: [read]
+        kubernetes:clustermanagers: [read]
+        compute:regions: [read]
+        compute:flavors: [read]
+        compute:images: [read]
+        storage:objectstorageclasses: [read]
+        storage:objectstorageendpoints: [read]
   region-service:
     decription: Region service
     protected: true

--- a/docs/platform-reader.md
+++ b/docs/platform-reader.md
@@ -1,0 +1,209 @@
+# The `platform-reader` Role
+
+`platform-reader` is a **protected**, global-only, read-only role in the identity role catalogue.
+It exists so staff support tooling can gain cross-organization read visibility without the
+blast radius of `platform-administrator` (full CRUD everywhere). It is the first real wildcard
+consumer of the generic global-role-binding mechanism landed by ID-398 (PR #533): every
+wildcard-specific runtime behaviour — the render-time guard, the runtime read clamp, the
+issuer-wide blast radius — goes live in production for the first time with this role.
+
+The role's definition is the **read-projection of `platform-administrator`'s global scope block**,
+minus an explicit, machine-checked exclusion list and a fail-closed omission list for scopes
+nothing currently serves. That projection, the exclusion/omission classification, and the
+role's read-only-ness are pinned by `pkg/rbac/platform_reader_contract_test.go`: any future PR
+that changes `platform-administrator`'s global read surface fails that test until the change is
+explicitly classified for `platform-reader`.
+
+This document is the audit record produced by that classification, the revocation story for
+principals granted this role, and the operational runbook for rolling it out.
+
+## Read-surface audit record (point-in-time: 2026-08-07)
+
+The audit examined, for every scope on `platform-administrator`'s global block that carries
+`read`, what the corresponding downstream read endpoint actually returns, across the following
+audited refs:
+
+- uni-identity: PR #533 branch
+- uni-region: `0663d38c`
+- uni-kubernetes: `47f4b451`
+- uni-compute: `aff93d82`
+- uni-storage: `e3bf7f61`
+
+This record is a snapshot at those SHAs, not a live guarantee — see Limitation below.
+
+### Excluded scopes (credential- or control-equivalent reads)
+
+| Scope | Reason |
+| --- | --- |
+| `region:identities` | Read returns live cloud credentials: base64 `clouds.yaml` application credential and SSH private key, on both list and get (`uni-region pkg/handler/identity/client.go:61-103`). |
+| `region:servers` | `GET /api/v2/servers/{id}/sshkey` returns the SSH private key; console-session reads return a token-bearing VNC URL; v2 power actions (start/stop/reboot) are gated only by the read check. |
+| `kubernetes:clusters` | Kubeconfig download shares scope+operation with listing and returns the admin kubeconfig verbatim (`uni-kubernetes pkg/server/handler/cluster/client.go:212`). |
+| `kubernetes:virtualclusters` | Same pattern (`virtualcluster/client.go:205`). |
+| `compute:instances` | Proxies the region sshkey endpoint (private key), console sessions, and read-gated power actions. |
+| `storage:objectstorageendpoints/accesskeys` | Read returns only the access-key **ID**, never the secret half (`uni-storage accesskey.go:194-214`); exclusion is conservative judgment because the scope's entire subject is credentials, not because of a leak. Exclusion verified effective: every accesskey route gates on this exact sub-scope, not the included parent (`uni-storage accesskey.go:34,62,99` read; `:122` create; `:142` delete). |
+
+### Omitted vacuous scopes (fail-closed)
+
+Nothing serves a read on these today; omission fails closed so a future API landing forces a
+deliberate re-audit before `platform-reader` gains the surface, instead of silently inheriting it.
+
+| Scope | Why vacuous |
+| --- | --- |
+| `identity:projects/references` | Only PUT/DELETE endpoints, gated create/delete. |
+| `region:identities/references` | Scope string absent from uni-region entirely. |
+| `region:networks/references` | Scope string absent from uni-region entirely. |
+| `region:networks:v2/references` | Only PUT/DELETE, gated create/delete. |
+| `region:servers:v2` | No code checks it; v2 server endpoints check `region:servers`. |
+| `region:volumes:v2` | Volumes API not shipped at audit time (storage model only). |
+| `compute:clusters` | Zero matches in uni-compute; nothing serves it. |
+
+### Included scopes
+
+The 31 scopes below are the ones `platform-reader` actually carries, all at global scope with
+`[read]` only. This table is the audit's condensed record of what each read surface actually
+returns.
+
+| Scope | Read surface (all metadata-only unless noted) | Evidence |
+| --- | --- | --- |
+| `identity:organizations` | Get + list-all-organizations branch; org metadata | `pkg/handler/handler.go:452`; `organizations/client.go:234` |
+| `identity:oauth2providers` | Org-scoped list; `clientSecret` redacted by conversion (regression-tested) | `oauth2providers/client.go:66-88` |
+| `identity:roles` | List; metadata-only, protected roles filtered | `roles/client.go:46-77` |
+| `identity:serviceaccounts` | List only; `accessToken` emitted solely by create/rotate (regression-tested) | `serviceaccounts/client.go:80-113` |
+| `identity:users` | Org user list; PII (names/emails), no credentials | `users/client.go:246-284` |
+| `identity:groups` | List/get; membership data | `groups/client.go:59-97` |
+| `identity:projects` | List/get; group IDs | `projects/client.go:57-70` |
+| `identity:quotas` | Accounting quantities | `quotas/client.go:106-160` |
+| `identity:allocations` | Allocation quantities | `allocations/client.go:74-105` |
+| `region:regions` | Region metadata; kubeconfig lives only under separate `region:regions/detail` scope | uni-region `handler.go:96,112` |
+| `region:flavors` / `region:images` / `region:externalnetworks` | Catalog data | uni-region `handler.go:144,128`; `handler_image.go:50` |
+| `region:networks` | v1 list/get, no secret fields | uni-region `handler.go:230,267` |
+| `region:networks:v2` | List/get, clean | uni-region `network/client_v2.go:156,177` |
+| `region:loadbalancers:v2` | List/get, clean | uni-region `loadbalancer/client_v2.go:228,249` |
+| `region:securitygroups` / `:v2` | Rules only | uni-region `handler.go:300,351`; `securitygroup/client_v2.go:161,182` |
+| `region:volumeclasses:v2` | Storage catalog | uni-region `handler_v2_volumeclass.go:31` |
+| `region:filestorage:v2` | Includes `mountSource`/NFS `mountOptions` — data-plane topology, not credentials (deliberately included) | uni-region `storage/client.go:320,354,151` |
+| `region:filestorageclass:v2` | Catalog | uni-region `storage/client.go:746` |
+| `region:sshcertificateauthorities:v2` | CA **public** key only; private material never stored/served | uni-region `sshcertificateauthority/client_v2.go:62-66` |
+| `kubernetes:regions` / `flavors` / `images` | Catalog passthrough | uni-kubernetes `handler.go:112,131,150` |
+| `kubernetes:clustermanagers` | Metadata-only | uni-kubernetes `handler.go:184` |
+| `compute:regions` / `flavors` / `images` | Catalog | uni-compute `handler.go:90,109,128` |
+| `storage:objectstorageclasses` | Class metadata | uni-storage `objectstorage.go:612`; `conversion.go:25-40` |
+| `storage:objectstorageendpoints` | Endpoint metadata + identity policies (config, not credentials) | uni-storage `objectstorage.go:69,140`; `conversion.go:42-61` |
+
+### Sensitivity taxonomy of INCLUDED scopes
+
+The included scopes fall into four sensitivity classes:
+
+- **Credential** — none, by construction. Every scope whose read surface returns credential or
+  control-equivalent material is excluded above.
+- **Data-plane topology** — `region:filestorage:v2` mount coordinates (`mountSource`, NFS
+  `mountOptions`), networks, security-group rules, load-balancer members, and private IPs. This
+  is infrastructure shape, not a credential, and is included deliberately because support tooling
+  needs it.
+- **PII / directory** — `identity:users` global read enables cross-organization
+  user-to-organization lookup by email; this is deliberate, since that lookup is the point of
+  support tooling. `identity:organizations` global read lists every organization on the platform.
+- **Plain inventory** — catalogues, flavors, images, quotas, allocations, and storage/object
+  classes: metadata with no PII or credential content.
+
+### Limitation
+
+The contract test ratchets the **identity role catalogue** only — it forces a classification
+decision whenever `platform-administrator`'s global read-bearing scope set changes. It cannot see
+a downstream service adding a new credential-returning GET route under a scope that is already
+included here; that route-level semantics is owned by the downstream service. See Follow-ups.
+
+## Revocation
+
+IdP offboarding is the only revocation lever for a principal granted `platform-reader` through a
+wildcard global role binding. No local compensating control is built for this role, deliberately:
+introducing one would re-establish per-principal local state that the wildcard binding mechanism
+exists to remove.
+
+Concretely:
+
+- **Organization-level suspension is a silent no-op for bound users.** A principal admitted with
+  an empty `orgIds` slice (the normal case for a staff/support subject under
+  `allowExternalIdentity: true`) has no organization membership to suspend, so removing them from
+  an organization changes nothing about their access via the binding.
+- **With `allowExternalIdentity: true`, there is usually no global `User` record to suspend
+  either.** These subjects are typically never onboarded as ordinary UNI users in the first place
+  — that is the case the flag exists for.
+- **Worst-case revocation latency is not immediate.** It is bounded by the remaining lifetime of
+  the external IdP's access token, plus the passport lifetime, plus the ACL cache TTL. Offboarding
+  a subject at the IdP does not revoke a token already issued; it only prevents new tokens.
+- **Best-effort break-glass:** if the subject does have an inactive global `User` record, the
+  bearer path rejects it (`ErrUserInactive`) regardless of `allowExternalIdentity`. This is
+  unreliable as a control today because the underlying lookup
+  (`UserDatabase.GetUser`) is case-sensitive while the bearer path lower-cases the email claim
+  first — a mixed-case record is treated as never-onboarded rather than inactive. See
+  [docs/multi-issuer-token-contract.md#membership-resolution](multi-issuer-token-contract.md#membership-resolution)
+  for the tracked gap. Until that gap is fixed, this path is documented as best-effort, not a
+  relied-upon control.
+
+## Runbook
+
+### Blast radius
+
+A global role binding that references an unresolvable role fails closed as a 500 for every user
+of the issuer it is bound to. For an issuer-wide (wildcard) staff binding, that means every staff
+user authenticating through that issuer, all at once. `protected: true` keeps `platform-reader`
+out of the user-facing role list (`pkg/handler/roles/client.go:76`) and blocks it from being
+granted through a group (`pkg/handler/groups/client.go:357`) — there is no role delete endpoint
+in the API at all to guard against. Neither mechanism prevents chart or CRD drift: an operator can
+still rename or remove the role at the Helm/CRD layer, leaving a binding that references it
+unresolvable and failing closed exactly as above.
+
+### Rollout
+
+0. **Pre-upgrade check.** Confirm the target environment's values do not already define
+   `additionalRoles.platform-reader`. Adding this built-in role reserves that name, and the chart
+   render fails loudly on the collision. Remediation is to rename the custom role first, before
+   upgrading.
+1. Deploy the chart containing `platform-reader` with the global role binding absent.
+2. Verify the live `Role` CRD for `platform-reader` and its contents (scopes, `protected: true`)
+   before granting anything against it.
+3. Enable the wildcard binding in the **deployment repo's** environment values — the binding
+   itself is environment-specific deployment configuration, never a chart default, and is
+   deliberately kept out of this repository.
+
+Rollback reverses this order: disable the binding in deployment values first, then remove the
+role from the chart if needed. This ordering is in addition to, not a replacement for, PR #533's
+binary-before-flag ordering (deploy a server binary that understands
+`--global-role-binding` before enabling any binding that relies on it).
+
+Before enabling the binding in production, run a staging smoke test against the real staff
+issuer, using its exact, verbatim `iss` value (including any trailing slash, as Auth0 emits).
+Only the Auth0 applications and connections intended to represent staff should be able to mint
+tokens for the trusted audience — this is an IdP-side configuration prerequisite, not something
+this role or its binding enforces.
+
+## Follow-ups
+
+The audit surfaced seven follow-up items, recorded here. None block this change.
+
+- **uni-kubernetes:** split kubeconfig retrieval out of `kubernetes:clusters` and
+  `kubernetes:virtualclusters` read (for example, a `.../kubeconfig` sub-scope) so that listing
+  clusters and virtual clusters can rejoin `platform-reader`.
+- **uni-region:** split `GET /api/v2/servers/{id}/sshkey` and console-session reads out of
+  `region:servers` read. This also carries a security defect found by the audit: v2 power actions
+  (start/stop/reboot) are gated only by the read check, not an update check as v1 requires.
+- **uni-compute:** the same split for `compute:instances` — it proxies the region sshkey
+  endpoint, console sessions, and the same read-gated power actions.
+- **uni-region:** `region:identities` read returns live credentials (`clouds.yaml` application
+  credential and SSH private key) on both list and get; redact or split this scope before it can
+  rejoin `platform-reader`.
+- **Cross-service:** each service owning a scope included in `platform-reader` should adopt its
+  own route-level "safe for platform-reader" classification, so a future read-surface change
+  under an already-included scope cannot land unaudited. The identity-side contract test cannot
+  see that class of change.
+- **uni-identity (hygiene, optional):** clean up or annotate stale grants already present on
+  `platform-administrator` — `region:servers:v2`, `compute:clusters`, and the unserved
+  `/references` scopes — which the omission table above had to classify as vacuous.
+- **uni-identity (hardening, optional):** the contract test pins the role as defined in this
+  repository's `values.yaml`, but a deployment can still merge extra scopes into
+  `.Values.roles.platform-reader`. Such an override defeats the audit while still satisfying the
+  read-only render guard. No trust boundary is crossed — anyone able to set those values already
+  controls the whole identity deployment — so this is an operator-drift concern (see Blast radius
+  above) rather than a privilege-escalation path. A template-level equality check on the scope set
+  of any wildcard-bound role would close it at render time.

--- a/docs/platform-reader.md
+++ b/docs/platform-reader.md
@@ -115,10 +115,11 @@ included here; that route-level semantics is owned by the downstream service. Se
 
 ## Revocation
 
-IdP offboarding is the only revocation lever for a principal granted `platform-reader` through a
-wildcard global role binding. No local compensating control is built for this role, deliberately:
-introducing one would re-establish per-principal local state that the wildcard binding mechanism
-exists to remove.
+IdP offboarding is the only **per-principal** revocation lever for a subject granted
+`platform-reader` through a wildcard global role binding. No per-principal local control is
+built, deliberately: it would re-establish the local state the wildcard mechanism exists to
+remove. Revoking **every** holder at once is different — the platform owns a fast lever for
+that: see [Break-glass](#break-glass-revoking-the-whole-binding) in the Runbook.
 
 Concretely:
 
@@ -153,6 +154,31 @@ granted through a group (`pkg/handler/groups/client.go:357`) — there is no rol
 in the API at all to guard against. Neither mechanism prevents chart or CRD drift: an operator can
 still rename or remove the role at the Helm/CRD layer, leaving a binding that references it
 unresolvable and failing closed exactly as above.
+
+### Break-glass: revoking the whole binding
+
+The blast radius above is also the deliberate incident lever — the only fast, self-owned
+revocation the platform has. To cut off every holder of the binding at once, empty the role's
+global scopes (the resource name must be fully qualified — bare `roles` resolves to the
+Kubernetes RBAC kind):
+
+```sh
+kubectl -n unikorn-identity get roles.identity.unikorn-cloud.org \
+  -l unikorn-cloud.org/name=platform-reader
+kubectl -n unikorn-identity patch roles.identity.unikorn-cloud.org <ID> \
+  --type=merge -p '{"spec":{"scopes":{"global":null}}}'
+```
+
+- **Takes effect within `--acl-cache-timeout` (default 1m)** as cached ACLs expire — no
+  restart, no deploy. Unlike IdP offboarding, already-issued tokens and passports do not
+  extend the window: the role is read live on the next uncached ACL computation.
+- Emptying scopes denies as clean **403s** ("no global-scope permissions"). Deleting the Role
+  CRD also works but fails closed as **500s** for every user of the bound issuer — the
+  unresolvable-role path above. The patch is the calmer signal for downstream tooling.
+- `protected: true` blocks neither — it gates the API surface; there is no admission webhook.
+- **Pair it with the durable fix**: remove the binding from the deployment repo's values. Any
+  `helm upgrade` — including one unrelated to this role — reverts the patch, because Helm's
+  three-way merge restores drifted fields the chart specifies.
 
 ### Rollout
 

--- a/hack/check_chart_render.sh
+++ b/hack/check_chart_render.sh
@@ -49,6 +49,14 @@ reader_role_id=$(role_id_of reader <<<"$out")
 [[ -n "$reader_role_id" ]] || die "could not resolve role ID for 'reader'"
 assert_one_match "$out" "--global-role-binding=https://staff.example.com/::\*::${reader_role_id}\""
 
+# The first non-vacuous positive for the wildcard guard: platform-reader is a
+# genuinely read-only GLOBAL role, so this proves the guard accepts read-only
+# global scopes rather than merely roles with no global block at all.
+out=$(render '[{"issuer":"https://staff.example.com/","subject":"*","roles":["platform-reader"]}]')
+platform_reader_role_id=$(role_id_of platform-reader <<<"$out")
+[[ -n "$platform_reader_role_id" ]] || die "could not resolve role ID for 'platform-reader'"
+assert_one_match "$out" "--global-role-binding=https://staff.example.com/::\*::${platform_reader_role_id}\""
+
 out=$(render '[{"issuer":"uni","subjects":["a@x.com","b@x.com"],"roles":["platform-administrator"]}]')
 role_id=$(role_id_of platform-administrator <<<"$out")
 [[ -n "$role_id" ]] || die "could not resolve role ID for 'platform-administrator'"

--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -44,6 +44,7 @@ import (
 	"path/filepath"
 	"time"
 
+	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
 	coreopenapi "github.com/unikorn-cloud/core/pkg/openapi"
 	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
 	handlercommon "github.com/unikorn-cloud/identity/pkg/handler/common"
@@ -347,6 +348,24 @@ func findGlobalUserID(ctx context.Context, k8s client.Client, namespace, subject
 	return ""
 }
 
+// findRoleID resolves a Role CRD ID by its friendly name label. Protected
+// roles never appear in the user-facing role listing, so the API cannot be
+// used for this.
+func findRoleID(ctx context.Context, k8s client.Client, namespace, name string) string {
+	roles := &unikornv1.RoleList{}
+
+	if err := k8s.List(ctx, roles, client.InNamespace(namespace),
+		client.MatchingLabels{coreconstants.NameLabel: name}); err != nil {
+		fatalf("failed to list roles: %v", err)
+	}
+
+	if len(roles.Items) != 1 {
+		fatalf("expected exactly one role named %q, got %d", name, len(roles.Items))
+	}
+
+	return roles.Items[0].Name
+}
+
 func issueUserToken(ctx context.Context, k8s client.Client, namespace, baseURL, subject, globalUserID string) string {
 	issuer := handlercommon.IssuerValue{}
 	if err := issuer.Set(baseURL); err != nil {
@@ -595,6 +614,21 @@ func main() {
 	bindingAdminToken := issueUserToken(ctx, k8s, *namespace, *baseURL, bindingAdminSubject,
 		findGlobalUserID(ctx, k8s, *namespace, bindingAdminSubject))
 
+	// ci-platform-reader: bound to the protected platform-reader role via an
+	// exact uni binding in hack/ci/test-values.yaml. Like legacyAdminSubject,
+	// it needs no group membership — its authority comes entirely from the
+	// binding.
+	const platformReaderSubject = "ci-platform-reader@nscale.test"
+
+	createUser(ctx, ac, orgID, platformReaderSubject, []string{})
+	platformReaderToken := issueUserToken(ctx, k8s, *namespace, *baseURL, platformReaderSubject,
+		findGlobalUserID(ctx, k8s, *namespace, platformReaderSubject))
+
+	// Protected roles are invisible through the API by design, so the role ID
+	// for the non-grantability test is resolved from the Role CRD by its
+	// unikorn-cloud.org/name label.
+	platformReaderRoleID := findRoleID(ctx, k8s, *namespace, "platform-reader")
+
 	// ── Output .env fragment to stdout ────────────────────────────────────────
 	fmt.Printf("IDENTITY_BASE_URL=%s\n", *baseURL)
 	fmt.Printf("IDENTITY_CA_CERT=%s\n", *caCertPath)
@@ -614,4 +648,6 @@ func main() {
 	fmt.Printf("AUDIT_AUTH_TOKEN=%s\n", auditToken)
 	fmt.Printf("PLATFORM_ADMIN_AUTH_TOKEN=%s\n", legacyAdminToken)
 	fmt.Printf("BINDING_ADMIN_AUTH_TOKEN=%s\n", bindingAdminToken)
+	fmt.Printf("PLATFORM_READER_AUTH_TOKEN=%s\n", platformReaderToken)
+	fmt.Printf("TEST_PLATFORM_READER_ROLE_ID=%s\n", platformReaderRoleID)
 }

--- a/hack/ci/test-values.yaml
+++ b/hack/ci/test-values.yaml
@@ -15,3 +15,11 @@ globalRoleBindings:
 - issuer: uni
   subject: ci-binding-admin@nscale.test
   roles: [platform-administrator]
+# Exact uni binding for the ID-399 platform-reader canary: exercises the real
+# role's ACL end-to-end, unclamped (exact bindings bypass the wildcard clamp),
+# so a write verb sneaking into the role fails the suite instead of being
+# masked. A wildcard binding is untestable here: KinD hosts no external JWKS
+# issuer and wildcards are rejected on the uni sentinel.
+- issuer: uni
+  subject: ci-platform-reader@nscale.test
+  roles: [platform-reader]

--- a/pkg/handler/oauth2providers/client_internal_test.go
+++ b/pkg/handler/oauth2providers/client_internal_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oauth2providers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestConvertRedactsClientSecret pins the read-path redaction that the ID-399
+// read-surface audit's INCLUDE verdict for identity:oauth2providers rests on:
+// the stored client secret must never appear in a serialized read response.
+func TestConvertRedactsClientSecret(t *testing.T) {
+	t.Parallel()
+
+	const secret = "super-secret-client-credential"
+
+	in := &unikornv1.OAuth2Provider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "provider-id",
+		},
+		Spec: unikornv1.OAuth2ProviderSpec{
+			Issuer:       "https://login.example.com",
+			ClientSecret: secret,
+		},
+	}
+
+	out := convert(in)
+
+	serialized, err := json.Marshal(out)
+	require.NoError(t, err)
+	require.NotContains(t, string(serialized), secret,
+		"serialized read response must not contain the client secret")
+	require.NotContains(t, string(serialized), "clientSecret",
+		"serialized read response must omit the clientSecret key entirely")
+}

--- a/pkg/handler/serviceaccounts/client_internal_test.go
+++ b/pkg/handler/serviceaccounts/client_internal_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccounts
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestConvertRedactsAccessToken pins the read-path redaction that the ID-399
+// read-surface audit's INCLUDE verdict for identity:serviceaccounts rests on:
+// the stored long-lived access token is emitted only by convertCreate (create/
+// rotate), never by the plain read conversion.
+func TestConvertRedactsAccessToken(t *testing.T) {
+	t.Parallel()
+
+	const token = "live-long-lived-access-token"
+
+	in := &unikornv1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sa-id",
+		},
+		Spec: unikornv1.ServiceAccountSpec{
+			AccessToken: token,
+			// Fixed date: deterministic, and convert dereferences Expiry.Time,
+			// so this must be non-nil (Expiry is *metav1.Time, types.go:410).
+			Expiry: &metav1.Time{Time: time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)},
+		},
+	}
+
+	out := convert(in, &unikornv1.GroupList{})
+
+	serialized, err := json.Marshal(out)
+	require.NoError(t, err)
+	require.NotContains(t, string(serialized), token,
+		"serialized read response must not contain the access token")
+	require.NotContains(t, string(serialized), "accessToken",
+		"serialized read response must omit the accessToken key entirely")
+}

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -89,6 +89,10 @@ deployment time.
 
 - `platform-administrator` — global authority across platform resources; can act in any
   organization or project.
+- `platform-reader` — global read-only visibility for staff support tooling; the
+  read-projection of `platform-administrator` minus credential-bearing scopes,
+  pinned by the contract test in `platform_reader_contract_test.go`. Audit
+  record, revocation story, and runbook: [docs/platform-reader.md](../../docs/platform-reader.md).
 - `region-service`, `kubernetes-service`, `compute-service`, `storage-service` — system
   accounts mapped from an mTLS certificate common name (see the Actor Model). Each holds
   only the global permissions the corresponding service actually exercises;
@@ -171,10 +175,11 @@ cannot exercise permissions that either side lacks.
 
 Global privileges are expressed through a single mechanism: a **global role binding** maps an
 `(issuer, subject | "*")` pair to a set of role IDs. Every kind of global principal — platform
-administrators today, and any future issuer-wide grant such as ID-399's planned platform-reader —
-is expressed as data through this one mechanism; no per-class fast-path or role name is hardcoded
-in Go. `resolveGlobalRoleBindings` is the only path by which global privileges are granted,
-evaluated at the top of `processUserAccountACL` before membership resolution.
+administrators and platform-reader (ID-399's issuer-wide read grant) today, and any future
+issuer-wide grant — is expressed as data through this one mechanism; no per-class fast-path or
+role name is hardcoded in Go. `resolveGlobalRoleBindings` is the only path by which global
+privileges are granted, evaluated at the top of `processUserAccountACL` before membership
+resolution.
 
 Bindings are configured with the repeated flag
 `--global-role-binding=<issuer>::<subject>::<roleID>[,<roleID>...]`, rendered by the chart from
@@ -211,16 +216,16 @@ bindings (for example an exact and a wildcard entry on the same issuer) accumula
 so pointing a wildcard at a CRUD role yields read-everything, never write. It says nothing about
 what a read endpoint *returns* — some return credential material, such as object-storage access
 keys — so any role referenced by a wildcard binding needs its own read-surface audit first.
-`platform-reader` receives that audit under ID-399.
+`platform-reader` received that audit — see [docs/platform-reader.md](../../docs/platform-reader.md).
 
 **A chart render-time guard complements the runtime clamp.** The chart
 (`charts/identity/templates/identity/deployment.yaml`) fails to render if a wildcard binding
 references a role whose global scopes include any non-`read` operation, naming the binding index,
 role, and offending scope. That keeps the Role CRD authoritative for what an operator can
 *configure*, but Roles are live and can gain write scopes after the render — which no render-time
-check can see, so the clamp above remains the backstop. No role currently shipped in
-`charts/identity/values.yaml` passes this guard; only a dedicated, audited read-only role
-(`platform-reader`, ID-399) will.
+check can see, so the clamp above remains the backstop. `platform-reader` is the only role shipped in
+`charts/identity/values.yaml` with a global scope block that passes this guard — a dedicated,
+audited read-only role (see [docs/platform-reader.md](../../docs/platform-reader.md)).
 
 **Sentinel and impersonation rules.** A wildcard subject can never match the `uni` sentinel or an
 empty issuer — rejected at parse time for the sentinel, and guarded again at match time

--- a/pkg/rbac/platform_reader_acl_test.go
+++ b/pkg/rbac/platform_reader_acl_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac_test
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
+)
+
+// These tests compose PR #533's wildcard-binding mechanics with the REAL
+// platform-reader role parsed from charts/identity/values.yaml, per the ID-399
+// acceptance criteria. Generic mechanics (parse-time uni::* rejection,
+// sentinel/empty-issuer guards, clamping, replace semantics) are pinned by
+// bindings_test.go and are deliberately not repeated here.
+func TestPlatformReaderWildcardBinding(t *testing.T) {
+	t.Parallel()
+
+	const (
+		staffIssuer = "https://staff.example.com/"
+		roleID      = "platform-reader-role-id"
+	)
+
+	reader, ok := loadChartRoles(t)["platform-reader"]
+	require.True(t, ok, "platform-reader missing from chart role catalogue")
+
+	roles := map[string]*unikornv1.Role{
+		roleID: {
+			Spec: unikornv1.RoleSpec{
+				Scopes: unikornv1.RoleScopes{
+					Global: toRoleScopes(reader.Scopes.Global),
+				},
+			},
+		},
+	}
+
+	var bindings rbac.GlobalRoleBindingsValue
+
+	require.NoError(t, bindings.Set(staffIssuer+"::*::"+roleID))
+
+	// Positive: any subject from the staff issuer matches the wildcard.
+	matched := rbac.ResolveGlobalRoleBindingsForTest(bindings, staffIssuer, "someone@nscale.com")
+	require.Len(t, matched, 1)
+	require.Equal(t, []string{roleID}, matched[0].RoleIDs)
+
+	acl := &openapi.Acl{}
+	require.NoError(t, rbac.AccumulateGlobalReadPermissionsForTest(acl, matched[0].RoleIDs, roles))
+	require.NotNil(t, acl.Global)
+
+	// The resolved ACL is exactly the role's scope set, read-only, with every
+	// excluded scope absent. (Read-only-ness is structural on this path — the
+	// wildcard accumulator clamps unconditionally; the role DEFINITION's
+	// read-only-ness is what the contract test and the unclamped exact-binding
+	// integration canary pin.)
+	granted := make([]string, 0, len(*acl.Global))
+
+	for _, endpoint := range *acl.Global {
+		granted = append(granted, endpoint.Name)
+
+		require.Equal(t, []openapi.AclOperation{openapi.Read}, endpoint.Operations,
+			"ACL endpoint %q must be read-only", endpoint.Name)
+	}
+
+	require.ElementsMatch(t, slices.Collect(maps.Keys(reader.Scopes.Global)), granted)
+
+	for scope := range platformReaderExcludedScopes() {
+		require.NotContains(t, granted, scope, "excluded scope %q leaked into the ACL", scope)
+	}
+
+	// Authorization outcomes against the resolved ACL.
+	ctx := rbac.NewContext(t.Context(), acl)
+
+	require.NoError(t, rbac.AllowGlobalScope(ctx, "identity:organizations", openapi.Read))
+	require.Error(t, rbac.AllowGlobalScope(ctx, "identity:organizations", openapi.Update),
+		"write must be denied")
+	require.Error(t, rbac.AllowGlobalScope(ctx, "storage:objectstorageendpoints/accesskeys", openapi.Read),
+		"access-key read must be denied")
+
+	// Negative — the acceptance-criterion scenario: a UNI-local principal
+	// (src_iss = uni) facing the staff wildcard binding resolves no roles.
+	require.Empty(t, rbac.ResolveGlobalRoleBindingsForTest(bindings, "uni", "someone@nscale.com"))
+}

--- a/pkg/rbac/platform_reader_contract_test.go
+++ b/pkg/rbac/platform_reader_contract_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac_test
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The read-surface audit classification for platform-reader (ID-399).
+// Every platform-administrator global scope that carries `read` MUST appear in
+// exactly one place: platform-reader's global block, platformReaderExcludedScopes,
+// or platformReaderOmittedScopes. The audit record with full evidence lives in
+// docs/platform-reader.md.
+//
+// LIMITATION: this ratchet governs the identity role catalogue only. It cannot
+// see a downstream service adding a credential-returning GET route under an
+// already-included scope — route-level semantics are owned by the downstream
+// services (see docs/platform-reader.md#follow-ups).
+
+// platformReaderExcludedScopes lists read-bearing admin scopes whose read
+// endpoints are credential- or control-equivalent. Functions rather than
+// package-level vars: gochecknoglobals is enabled repo-wide and fires on
+// test-file globals too.
+func platformReaderExcludedScopes() map[string]string {
+	return map[string]string{
+		"region:identities":                         "read returns clouds.yaml application credential and SSH private key",
+		"region:servers":                            "sshkey/console-session reads return credentials; v2 power actions are read-gated",
+		"kubernetes:clusters":                       "kubeconfig download shares scope+read with listing and returns admin kubeconfig",
+		"kubernetes:virtualclusters":                "kubeconfig download shares scope+read with listing and returns admin kubeconfig",
+		"compute:instances":                         "proxies region sshkey/console-session; power actions are read-gated",
+		"storage:objectstorageendpoints/accesskeys": "credential-class sub-resource; conservative exclusion, the scope's entire subject is credentials",
+	}
+}
+
+// platformReaderOmittedScopes lists read-bearing admin scopes nothing serves
+// today; omitted fail-closed so a future API forces a fresh classification.
+func platformReaderOmittedScopes() map[string]string {
+	return map[string]string{
+		"identity:projects/references":  "write-only sub-resource; no read endpoint exists",
+		"region:identities/references":  "scope string unserved by uni-region",
+		"region:networks/references":    "scope string unserved by uni-region",
+		"region:networks:v2/references": "write-only sub-resource; no read endpoint exists",
+		"region:servers:v2":             "no code checks this scope; v2 server endpoints check region:servers",
+		"region:volumes:v2":             "volumes API not shipped at audit time (2026-08-07)",
+		"compute:clusters":              "scope unserved by uni-compute",
+	}
+}
+
+// readProjection returns the scopes whose verb lists include read, projected
+// from a role's global block. Extracted to keep TestPlatformReaderContract
+// under the cyclop ceiling with headroom.
+func readProjection(global endpointOperations) map[string]bool {
+	projection := map[string]bool{}
+
+	for scope, ops := range global {
+		if slices.Contains(ops, "read") {
+			projection[scope] = true
+		}
+	}
+
+	return projection
+}
+
+func TestPlatformReaderContract(t *testing.T) {
+	t.Parallel()
+
+	roles := loadChartRoles(t)
+
+	admin, ok := roles["platform-administrator"]
+	require.True(t, ok, "platform-administrator missing from chart role catalogue")
+
+	reader, ok := roles["platform-reader"]
+	require.True(t, ok, "platform-reader missing from chart role catalogue")
+
+	require.True(t, reader.Protected, "platform-reader must be protected: true")
+	require.Empty(t, reader.Scopes.Organization, "platform-reader must be global-only: no organization block")
+	require.Empty(t, reader.Scopes.Project, "platform-reader must be global-only: no project block")
+
+	// The read-projection: every admin global scope whose verbs include read.
+	projection := readProjection(admin.Scopes.Global)
+
+	excluded := platformReaderExcludedScopes()
+	omitted := platformReaderOmittedScopes()
+
+	// Classification sets must partition cleanly and must not go stale:
+	// every entry must still be read-bearing on platform-administrator.
+	for scope, rationale := range excluded {
+		require.NotEmpty(t, rationale, "exclusion %q must carry a rationale", scope)
+		require.NotContains(t, omitted, scope, "scope classified as both excluded and omitted")
+		require.Contains(t, projection, scope,
+			"stale exclusion: %q is no longer read-bearing on platform-administrator; delete its entry so a future read-grant forces re-classification", scope)
+	}
+
+	for scope, rationale := range omitted {
+		require.NotEmpty(t, rationale, "omission %q must carry a rationale", scope)
+		require.Contains(t, projection, scope,
+			"stale omission: %q is no longer read-bearing on platform-administrator; delete its entry so a future read-grant forces re-classification", scope)
+	}
+
+	// Expected reader surface = projection minus both classification sets.
+	expected := maps.Clone(projection)
+
+	maps.DeleteFunc(expected, func(scope string, _ bool) bool {
+		_, isExcluded := excluded[scope]
+		_, isOmitted := omitted[scope]
+
+		return isExcluded || isOmitted
+	})
+
+	for scope, ops := range reader.Scopes.Global {
+		require.Equal(t, []string{"read"}, ops, "platform-reader scope %q must grant exactly [read]", scope)
+		require.Contains(t, expected, scope,
+			"platform-reader grants %q, which is not an included read-projection scope of platform-administrator; either remove it or reclassify it in this test with an audit rationale", scope)
+	}
+
+	for scope := range expected {
+		require.Contains(t, reader.Scopes.Global, scope,
+			"unclassified read-bearing scope %q on platform-administrator: add %q: [read] to platform-reader after a read-surface audit, or add it to platformReaderExcludedScopes/platformReaderOmittedScopes with a rationale (see docs/platform-reader.md)", scope, scope)
+	}
+}

--- a/test/README.md
+++ b/test/README.md
@@ -62,6 +62,11 @@ Optional variables for richer coverage:
 - `IDENTITY_CA_CERT`
 - `PLATFORM_ADMIN_AUTH_TOKEN` — user token bound via legacy `platformAdministrators.subjects`
 - `BINDING_ADMIN_AUTH_TOKEN` — user token bound via `globalRoleBindings`
+- `PLATFORM_READER_AUTH_TOKEN` — token for a subject bound to the protected `platform-reader` role
+  via an exact `uni` global role binding; the platform-reader suite skips without it.
+- `TEST_PLATFORM_READER_ROLE_ID` — Role CRD ID of `platform-reader`, resolved by the fixtures from
+  the cluster (protected roles are invisible via the API); the non-grantability test skips without
+  it.
 
 Notes:
 

--- a/test/api/config.go
+++ b/test/api/config.go
@@ -25,20 +25,22 @@ import (
 // TestConfig extends the base config with Identity-specific fields.
 type TestConfig struct {
 	coreconfig.BaseConfig
-	AdminToken          string
-	UserToken           string
-	AuditToken          string
-	PlatformAdminToken  string
-	BindingAdminToken   string
-	OrgID               string
-	ProjectID           string
-	AdminGroupID        string
-	UserGroupID         string
-	UserID              string
-	UserSubjectEmail    string
-	UserSAID            string
-	UnauthorisedOrgID   string
-	ServiceAccountToken string
+	AdminToken           string
+	UserToken            string
+	AuditToken           string
+	PlatformAdminToken   string
+	BindingAdminToken    string
+	PlatformReaderToken  string
+	PlatformReaderRoleID string
+	OrgID                string
+	ProjectID            string
+	AdminGroupID         string
+	UserGroupID          string
+	UserID               string
+	UserSubjectEmail     string
+	UserSAID             string
+	UnauthorisedOrgID    string
+	ServiceAccountToken  string
 }
 
 // LoadTestConfig loads configuration from environment variables and .env files using viper.
@@ -77,20 +79,22 @@ func LoadTestConfig() (*TestConfig, error) {
 			LogRequests:     v.GetBool("LOG_REQUESTS"),
 			LogResponses:    v.GetBool("LOG_RESPONSES"),
 		},
-		AdminToken:          firstNonEmpty(v.GetString("ADMIN_AUTH_TOKEN"), v.GetString("API_AUTH_TOKEN")),
-		UserToken:           v.GetString("USER_AUTH_TOKEN"),
-		AuditToken:          v.GetString("AUDIT_AUTH_TOKEN"),
-		PlatformAdminToken:  v.GetString("PLATFORM_ADMIN_AUTH_TOKEN"),
-		BindingAdminToken:   v.GetString("BINDING_ADMIN_AUTH_TOKEN"),
-		OrgID:               v.GetString("TEST_ORG_ID"),
-		ProjectID:           v.GetString("TEST_PROJECT_ID"),
-		AdminGroupID:        v.GetString("TEST_ADMIN_GROUP_ID"),
-		UserGroupID:         v.GetString("TEST_USER_GROUP_ID"),
-		UserID:              v.GetString("TEST_USER_ID"),
-		UserSubjectEmail:    v.GetString("TEST_USER_SUBJECT_EMAIL"),
-		UserSAID:            v.GetString("TEST_USER_SA_ID"),
-		UnauthorisedOrgID:   v.GetString("UNAUTHORISED_ORG_ID"),
-		ServiceAccountToken: v.GetString("SERVICE_ACCOUNT_TOKEN"),
+		AdminToken:           firstNonEmpty(v.GetString("ADMIN_AUTH_TOKEN"), v.GetString("API_AUTH_TOKEN")),
+		UserToken:            v.GetString("USER_AUTH_TOKEN"),
+		AuditToken:           v.GetString("AUDIT_AUTH_TOKEN"),
+		PlatformAdminToken:   v.GetString("PLATFORM_ADMIN_AUTH_TOKEN"),
+		BindingAdminToken:    v.GetString("BINDING_ADMIN_AUTH_TOKEN"),
+		PlatformReaderToken:  v.GetString("PLATFORM_READER_AUTH_TOKEN"),
+		PlatformReaderRoleID: v.GetString("TEST_PLATFORM_READER_ROLE_ID"),
+		OrgID:                v.GetString("TEST_ORG_ID"),
+		ProjectID:            v.GetString("TEST_PROJECT_ID"),
+		AdminGroupID:         v.GetString("TEST_ADMIN_GROUP_ID"),
+		UserGroupID:          v.GetString("TEST_USER_GROUP_ID"),
+		UserID:               v.GetString("TEST_USER_ID"),
+		UserSubjectEmail:     v.GetString("TEST_USER_SUBJECT_EMAIL"),
+		UserSAID:             v.GetString("TEST_USER_SA_ID"),
+		UnauthorisedOrgID:    v.GetString("UNAUTHORISED_ORG_ID"),
+		ServiceAccountToken:  v.GetString("SERVICE_ACCOUNT_TOKEN"),
 	}
 
 	// Validate required fields

--- a/test/api/suites/platform_reader_test.go
+++ b/test/api/suites/platform_reader_test.go
@@ -1,0 +1,181 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:revive,testpackage // dot imports and package naming standard for Ginkgo
+package suites
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/unikorn-cloud/identity/test/api"
+)
+
+// The platform-reader canary (ID-399). This is a role-content test, not a
+// production-path stand-in: production binds platform-reader issuer-wide via a
+// wildcard on the staff issuer, which KinD cannot exercise (no external JWKS
+// issuer; wildcards are rejected on the uni sentinel). The fixture instead
+// binds the role to ci-platform-reader@nscale.test via an EXACT uni binding,
+// which bypasses the wildcard read-clamp — so a write verb sneaking into the
+// role definition fails these tests instead of being silently masked.
+var _ = Describe("Platform reader role", func() {
+	var readerClient *api.APIClient
+
+	// Only the specs that authenticate AS the bound subject need the reader
+	// token. The protected-role specs below use adminClient, so gating them on
+	// this token too would silently drop protection coverage in an environment
+	// that has admin credentials but no reader fixture.
+	requireReaderClient := func() {
+		if config.PlatformReaderToken == "" {
+			Skip("PLATFORM_READER_AUTH_TOKEN is required for platform-reader testing")
+		}
+
+		readerConfig := *config
+		readerConfig.AuthToken = config.PlatformReaderToken
+		readerClient = api.NewAPIClientWithConfig(&readerConfig)
+	}
+
+	Context("When a bound subject reads across organizations", func() {
+		BeforeEach(requireReaderClient)
+
+		Describe("an organization the subject is not a member of", func() {
+			BeforeEach(func() {
+				if config.UnauthorisedOrgID == "" {
+					Skip("UNAUTHORISED_ORG_ID is required for cross-organization read testing")
+				}
+			})
+
+			It("can be read", func(ctx SpecContext) {
+				org, err := readerClient.GetOrganization(ctx, config.UnauthorisedOrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(org.Metadata.Id).To(Equal(config.UnauthorisedOrgID))
+			})
+		})
+	})
+
+	Context("When a bound subject attempts a write", func() {
+		BeforeEach(requireReaderClient)
+
+		Describe("a group create in an organization", func() {
+			It("is denied", func(ctx SpecContext) {
+				// No cleanup: the request is denied, so nothing is created —
+				// the same shape as rbac_matrix_test.go's forbidden-request
+				// pattern. DoRequest returns an error on any non-403 status,
+				// so asserting on err alone pins the status.
+				payload := api.NewGroupPayload().Build()
+
+				bodyBytes, err := json.Marshal(payload)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Pure RBAC case: status-only assertion via the typed
+				// client's DoRequest, the rbac_matrix_test.go pattern.
+				_, _, err = readerClient.DoRequest(ctx, http.MethodPost,
+					api.NewEndpoints().ListGroups(config.OrgID), bytes.NewReader(bodyBytes), http.StatusForbidden)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Context("When the bound subject's ACL is resolved", func() {
+		BeforeEach(requireReaderClient)
+
+		Describe("the global endpoint grants", func() {
+			It("contain no excluded scope and no non-read operation", func(ctx SpecContext) {
+				// In-repo proxy for "access-key reads return 403 at the
+				// storage service": the ACL identity serves to storage simply
+				// lacks the scope. Replace-vs-merge semantics are pinned by
+				// the global role bindings suite, not re-asserted here.
+				acl, err := readerClient.GetOrganizationACL(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(acl.Global).NotTo(BeNil())
+
+				// Positive anchor so the negative loop below cannot pass
+				// vacuously on an empty ACL.
+				Expect(*acl.Global).To(ContainElement(HaveField("Name", "identity:organizations")))
+
+				for _, endpoint := range *acl.Global {
+					Expect(endpoint.Name).NotTo(Equal("storage:objectstorageendpoints/accesskeys"),
+						"excluded credential scope leaked into the ACL")
+
+					for _, op := range endpoint.Operations {
+						Expect(string(op)).To(Equal("read"),
+							"endpoint %s grants non-read operation %s", endpoint.Name, op)
+					}
+				}
+			})
+		})
+	})
+
+	Context("Given the role is protected", func() {
+		Describe("the user-facing role listing", func() {
+			It("does not contain platform-reader", func(ctx SpecContext) {
+				roles, err := adminClient.ListRoles(ctx, config.OrgID)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				// Positive anchor (a known user-facing role) so the negative
+				// loop cannot pass vacuously on an empty or broken listing —
+				// the rbac_matrix_test.go pattern.
+				Expect(roles).To(ContainElement(HaveField("Metadata.Name", "reader")))
+
+				for _, role := range roles {
+					Expect(role.Metadata.Name).NotTo(Equal("platform-reader"))
+				}
+			})
+		})
+
+		Describe("granting it through a group", func() {
+			BeforeEach(func() {
+				if config.PlatformReaderRoleID == "" {
+					Skip("TEST_PLATFORM_READER_ROLE_ID is required for non-grantability testing")
+				}
+			})
+
+			It("is rejected even for an administrator", func(ctx SpecContext) {
+				// Uses the ADMIN client so the request passes endpoint RBAC
+				// and reaches the protected-role guard itself
+				// (pkg/handler/groups/client.go validateRoleIDs, which
+				// returns HTTPForbidden for protected roles); the reader
+				// client would be rejected earlier, proving nothing about
+				// protection.
+				// No cleanup: the guard denies the request, so nothing is
+				// created (see the denial case above).
+				payload := api.NewGroupPayload().
+					WithRoleIDs([]string{config.PlatformReaderRoleID}).
+					Build()
+
+				bodyBytes, err := json.Marshal(payload)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Pure RBAC case: status-only assertion via DoRequest.
+				_, _, err = adminClient.DoRequest(ctx, http.MethodPost,
+					api.NewEndpoints().ListGroups(config.OrgID), bytes.NewReader(bodyBytes), http.StatusForbidden)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+})


### PR DESCRIPTION
Stacked on #533 — do not merge before it.

Adds `platform-reader` to the chart role catalogue: a protected, global, read-only role for support tooling, and the first real consumer of #533's wildcard bindings. Zero production Go — policy data plus guardrails.

## Motivation

Support tooling needs read-only visibility across every organisation. The only cross-organisation role today is `platform-administrator` (full CRUD everywhere), far too dangerous to hand out for that purpose.

Read-only-ness alone is not safety: #533's clamp bounds *verbs, not payload sensitivity*, so a global `read` can still return credentials. Hence a systematic read-surface audit across uni-identity, uni-region, uni-kubernetes, uni-compute and uni-storage — and a contract test that pins the role **definition**, not observed ACL output, which the clamp would mask.

## Definition

The read-projection of `platform-administrator`'s global block: 44 read-bearing scopes minus 6 credential-bearing exclusions and 7 vacuous omissions, leaving **31 scopes, all `[read]`**, `protected: true`, global-only.

Excluded: `region:identities`, `region:servers`, `kubernetes:clusters`, `kubernetes:virtualclusters`, `compute:instances`, `storage:objectstorageendpoints/accesskeys`. Omissions are fail-closed so a future API forces fresh classification.

The contract test ratchets: every read-bearing admin scope must land in exactly one of the three sets with a rationale, and a stale entry fails the build.

## Compatibility

Compatible, purely additive. No existing role, flag, API surface, or production Go changed. The role ships **unbound** — the issuer-wide binding is deployment config in the environment repo, so merging grants no privilege.

## Reviewer notes

- **`identity:users` global read is deliberate**: cross-organisation user lookup is the point of support tooling.
- **Revocation is IdP-only.** Organisation suspension is a silent no-op for a bound subject, and with `allowExternalIdentity: true` there is usually no global `User` record to suspend. Documented, along with #533's case-sensitivity gap.
- **The ratchet covers the identity catalogue only** — a downstream service adding a credential-returning GET under an included scope is invisible to it. One of six follow-ups in `docs/platform-reader.md#follow-ups`.
- **`protected: true` does less than the design spec claimed**: there is no role delete endpoint, so it blocks nothing there. It filters the role from the user-facing listing and blocks granting it through a group. The doc states the real mechanisms.
- The canary binds via an **exact `uni` binding**, bypassing the wildcard clamp, so a write verb in the role fails the suite instead of being masked.
- Commits are file-disjoint and each builds independently; the branch is bisectable.

## Verification

- `make touch license validate lint generate` clean, `make test-unit`, `go vet -tags integration ./test/api/suites/`.
- `hack/check_chart_render.sh`, now with the first *non-vacuous* positive case for the wildcard guard (the existing `reader` case has no global block).
- Full `make integration-test` on fresh KinD: **197/197 specs, 0 failed, 0 skipped**, including five new platform-reader specs.
- Every guardrail mutation-tested: a write verb fails the contract test and the render guard; un-redacting `clientSecret`/`accessToken` fails the redaction tests; a removed scope fails the ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
