### PR TITLE
feat(chart): reduce administrator to read on identity:oauth2providers

### DIFF
--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -325,13 +325,15 @@ roles:
         identity:projects/references: [create,delete]
         identity:allocations: [create,read,update,delete]
         region:networks:v2/references: [create,read,update,delete]
-  # An administrator can do anything within an organization.
+  # An administrator can do anything within an organization, except configure
+  # its upstream identity providers: provider writes would let an organization
+  # lock its own users out of login, so they stay with the platform operator.
   administrator:
     description: Organization administrator
     scopes:
       organization:
         identity:organizations: [read,update]
-        identity:oauth2providers: [create,read,update,delete]
+        identity:oauth2providers: [read]
         identity:serviceaccounts: [create,read,update,delete]
         identity:users: [create,read,update,delete]
         identity:roles: [create,read,update,delete]

--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -558,11 +558,13 @@ func main() {
 
 	// ── Resolve role IDs ─────────────────────────────────────────────────────
 	// platform-administrator is protected and not returned by the API.
-	// We use administrator (org-scoped, full identity CRUD) and user (project-scoped).
+	// We use administrator (org-scoped identity CRUD, minus oauth2provider writes) and
+	// user (project-scoped).
 	administratorRoleID, userRoleID, auditRoleID := resolveRoles(ctx, ac, orgID)
 
 	// ── Create Groups ─────────────────────────────────────────────────────────
-	// ci-admin-group: organization administrator — full identity CRUD at org scope.
+	// ci-admin-group: organization administrator — identity CRUD at org scope, except
+	// oauth2providers, which is read-only.
 	adminGroupID := createGroup(ctx, ac, orgID, "ci-admin-group", []string{administratorRoleID})
 
 	// ci-user-group: project user — project-scoped access only.

--- a/pkg/handler/oauth2providers/README.md
+++ b/pkg/handler/oauth2providers/README.md
@@ -40,6 +40,10 @@ login.
   longer-term production direction is greater reliance on third-party identity
   providers directly rather than identity acting as the primary long-term IdP
   surface itself
+- organizations read their providers but do not configure them: writes need
+  global `identity:oauth2providers`, held only by `platform-administrator`. The
+  self-service federation this endpoint was shaped for is not a live use case,
+  and granting it back would let an organization lock its own users out of login
 - the code still contains a note about secret visibility and client-secret write
   requirements, which suggests the secret-handling model is intentionally
   cautious but not yet fully tightened

--- a/pkg/rbac/README.md
+++ b/pkg/rbac/README.md
@@ -105,10 +105,15 @@ administrator grants to groups.
 
 | Role | organization block | project block |
 | --- | --- | --- |
-| `administrator` | full CRUD across identity, region, storage, Kubernetes and compute | — |
+| `administrator` | full CRUD across identity, region, storage, Kubernetes and compute, except read-only `identity:oauth2providers` | — |
 | `auditor` | read-only across all of the above | — |
 | `user` | org-wide reads, plus `region:images` create/delete | CRUD on workloads: networks, load balancers, security groups, volumes, file storage, object storage, SSH CAs, clusters, instances |
 | `reader` | org-wide reads (`region:images` read only) | read-only on those same workloads |
+
+Upstream provider configuration is the one organization resource no organization role may
+write. `administrator` and `auditor` both hold `identity:oauth2providers: [read]`; writes
+belong to `platform-administrator` at global scope, so an organization cannot delete its
+own provider and lock its users out of login.
 
 `administrator` and `auditor` hold all their authority at organization scope. `user` and
 `reader` keep a thin organization-wide read baseline but place their real workload

--- a/pkg/rbac/grant_guard_test.go
+++ b/pkg/rbac/grant_guard_test.go
@@ -393,3 +393,16 @@ func TestBuiltinSystemServicesDoNotReceiveVolumePermissions(t *testing.T) {
 		}
 	}
 }
+
+// TestAdministratorCannotWriteOAuth2Providers pins the organization administrator to read-only
+// access on upstream providers. The grant lattice is satisfied by both read and full CRUD, and
+// the chart render guard only inspects global scopes, so nothing else catches a restored write
+// verb here.
+func TestAdministratorCannotWriteOAuth2Providers(t *testing.T) {
+	t.Parallel()
+
+	role, ok := loadChartRoles(t)["administrator"]
+	require.True(t, ok, "built-in role \"administrator\" is missing")
+
+	require.Equal(t, []string{"read"}, role.Scopes.Organization["identity:oauth2providers"])
+}

--- a/test/README.md
+++ b/test/README.md
@@ -61,7 +61,9 @@ Optional variables for richer coverage:
 - `TEST_USER_SA_ID`
 - `IDENTITY_CA_CERT`
 - `PLATFORM_ADMIN_AUTH_TOKEN` — user token bound via legacy `platformAdministrators.subjects`
-- `BINDING_ADMIN_AUTH_TOKEN` — user token bound via `globalRoleBindings`
+- `BINDING_ADMIN_AUTH_TOKEN` — user token bound via `globalRoleBindings`; also carries the
+  global `identity:oauth2providers` writes no organization role holds, so the oauth2provider
+  write specs skip without it.
 - `PLATFORM_READER_AUTH_TOKEN` — token for a subject bound to the protected `platform-reader` role
   via an exact `uni` global role binding; the platform-reader suite skips without it.
 - `TEST_PLATFORM_READER_ROLE_ID` — Role CRD ID of `platform-reader`, resolved by the fixtures from

--- a/test/api/suites/bearer_trust_test.go
+++ b/test/api/suites/bearer_trust_test.go
@@ -57,6 +57,8 @@ var _ = Describe("OAuth2Provider bearerTrust", func() {
 	Context("When an operator creates a provider with a bearerTrust-relevant issuer", func() {
 		Describe("the persisted resource", func() {
 			It("retains the canonical issuer and is accepted", func() {
+				requireGlobalAdminClient()
+
 				// bearerTrust is CRD-only and not settable via the OpenAPI surface;
 				// we create a standard OAuth2Provider and assert that the issuer and
 				// ID round-trip correctly, confirming the provider CRD path works.
@@ -66,7 +68,7 @@ var _ = Describe("OAuth2Provider bearerTrust", func() {
 					WithIssuer(canonicalIssuer).
 					Build()
 
-				created, providerID := api.CreateOauth2ProviderWithCleanup(client, ctx, config, payload)
+				created, providerID := api.CreateOauth2ProviderWithCleanup(globalAdminClient, ctx, config, payload)
 
 				Expect(providerID).NotTo(BeEmpty(),
 					"Metadata.Id must be set on the created OAuth2Provider")

--- a/test/api/suites/oauth2providers_test.go
+++ b/test/api/suites/oauth2providers_test.go
@@ -34,7 +34,9 @@ var _ = Describe("OAuth2 Provider Management", func() {
 	Context("When listing OAuth2 providers", func() {
 		Describe("Given valid organization", func() {
 			It("should return all OAuth2 providers in the organization", func() {
-				api.CreateOauth2ProviderWithCleanup(client, ctx, config, api.NewOauth2ProviderPayload().Build())
+				requireGlobalAdminClient()
+
+				api.CreateOauth2ProviderWithCleanup(globalAdminClient, ctx, config, api.NewOauth2ProviderPayload().Build())
 
 				providers, err := client.ListOauth2Providers(ctx, config.OrgID)
 
@@ -61,11 +63,14 @@ var _ = Describe("OAuth2 Provider Management", func() {
 		})
 	})
 
+	// Provider writes are platform-operator only; organization roles hold read.
 	Context("When creating OAuth2 providers", func() {
+		BeforeEach(requireGlobalAdminClient)
+
 		Describe("Given valid provider data", func() {
 			It("should create a provider and return complete metadata", func() {
 				payload := api.NewOauth2ProviderPayload().Build()
-				created, providerID := api.CreateOauth2ProviderWithCleanup(client, ctx, config, payload)
+				created, providerID := api.CreateOauth2ProviderWithCleanup(globalAdminClient, ctx, config, payload)
 
 				Expect(providerID).NotTo(BeEmpty())
 				Expect(created.Metadata.Id).To(Equal(providerID))
@@ -78,7 +83,7 @@ var _ = Describe("OAuth2 Provider Management", func() {
 
 			It("should create a provider and find it in the organization list", func() {
 				payload := api.NewOauth2ProviderPayload().Build()
-				created, providerID := api.CreateOauth2ProviderWithCleanup(client, ctx, config, payload)
+				created, providerID := api.CreateOauth2ProviderWithCleanup(globalAdminClient, ctx, config, payload)
 
 				providers, err := client.ListOauth2Providers(ctx, config.OrgID)
 
@@ -104,7 +109,7 @@ var _ = Describe("OAuth2 Provider Management", func() {
 			It("should return error when creating in non-existent organization", func() {
 				payload := api.NewOauth2ProviderPayload().Build()
 
-				_, err := client.CreateOauth2Provider(ctx, "invalid-org-id", payload)
+				_, err := globalAdminClient.CreateOauth2Provider(ctx, "invalid-org-id", payload)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -112,16 +117,18 @@ var _ = Describe("OAuth2 Provider Management", func() {
 	})
 
 	Context("When updating OAuth2 providers", func() {
+		BeforeEach(requireGlobalAdminClient)
+
 		Describe("Given existing provider", func() {
 			It("should update provider name successfully", func() {
 				payload := api.NewOauth2ProviderPayload().Build()
-				original, providerID := api.CreateOauth2ProviderWithCleanup(client, ctx, config, payload)
+				original, providerID := api.CreateOauth2ProviderWithCleanup(globalAdminClient, ctx, config, payload)
 
 				updatedPayload := api.NewOauth2ProviderPayload().
 					WithName(original.Metadata.Name + "-updated").
 					Build()
 
-				err := client.UpdateOauth2Provider(ctx, config.OrgID, providerID, updatedPayload)
+				err := globalAdminClient.UpdateOauth2Provider(ctx, config.OrgID, providerID, updatedPayload)
 
 				Expect(err).NotTo(HaveOccurred())
 
@@ -149,13 +156,13 @@ var _ = Describe("OAuth2 Provider Management", func() {
 
 			It("should update provider client ID successfully", func() {
 				payload := api.NewOauth2ProviderPayload().Build()
-				_, providerID := api.CreateOauth2ProviderWithCleanup(client, ctx, config, payload)
+				_, providerID := api.CreateOauth2ProviderWithCleanup(globalAdminClient, ctx, config, payload)
 
 				updatedPayload := api.NewOauth2ProviderPayload().
 					WithClientID("updated-client-id").
 					Build()
 
-				err := client.UpdateOauth2Provider(ctx, config.OrgID, providerID, updatedPayload)
+				err := globalAdminClient.UpdateOauth2Provider(ctx, config.OrgID, providerID, updatedPayload)
 
 				Expect(err).NotTo(HaveOccurred())
 
@@ -182,7 +189,7 @@ var _ = Describe("OAuth2 Provider Management", func() {
 			It("should return not-found error", func() {
 				payload := api.NewOauth2ProviderPayload().Build()
 
-				err := client.UpdateOauth2Provider(ctx, config.OrgID, "00000000-0000-0000-0000-000000000000", payload)
+				err := globalAdminClient.UpdateOauth2Provider(ctx, config.OrgID, "00000000-0000-0000-0000-000000000000", payload)
 
 				Expect(err).To(HaveOccurred())
 				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
@@ -191,12 +198,14 @@ var _ = Describe("OAuth2 Provider Management", func() {
 	})
 
 	Context("When deleting OAuth2 providers", func() {
+		BeforeEach(requireGlobalAdminClient)
+
 		Describe("Given existing provider", func() {
 			It("should delete provider and verify it is gone from the list", func() {
 				payload := api.NewOauth2ProviderPayload().Build()
-				_, providerID := api.CreateOauth2ProviderWithCleanup(client, ctx, config, payload)
+				_, providerID := api.CreateOauth2ProviderWithCleanup(globalAdminClient, ctx, config, payload)
 
-				err := client.DeleteOauth2Provider(ctx, config.OrgID, providerID)
+				err := globalAdminClient.DeleteOauth2Provider(ctx, config.OrgID, providerID)
 
 				Expect(err).NotTo(HaveOccurred())
 
@@ -215,7 +224,7 @@ var _ = Describe("OAuth2 Provider Management", func() {
 
 		Describe("Given invalid provider ID", func() {
 			It("should return not-found error", func() {
-				err := client.DeleteOauth2Provider(ctx, config.OrgID, "00000000-0000-0000-0000-000000000000")
+				err := globalAdminClient.DeleteOauth2Provider(ctx, config.OrgID, "00000000-0000-0000-0000-000000000000")
 
 				Expect(err).To(HaveOccurred())
 				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())

--- a/test/api/suites/rbac_matrix_test.go
+++ b/test/api/suites/rbac_matrix_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/unikorn-cloud/identity/test/api"
 )
 
-func expectUserRequestForbidden(method, path string, payload any) {
+func expectRequestForbidden(c *api.APIClient, actor, method, path string, payload any) {
 	GinkgoHelper()
 
 	var body io.Reader
@@ -44,11 +44,17 @@ func expectUserRequestForbidden(method, path string, payload any) {
 		body = bytes.NewReader(bodyBytes)
 	}
 
-	resp, _, err := userClient.DoRequest(ctx, method, path, body, http.StatusForbidden)
+	resp, _, err := c.DoRequest(ctx, method, path, body, http.StatusForbidden)
 	Expect(err).NotTo(HaveOccurred(),
-		"user %s %s should return 403 Forbidden", method, path)
+		"%s %s %s should return 403 Forbidden", actor, method, path)
 	Expect(resp).NotTo(BeNil())
 	Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+}
+
+func expectUserRequestForbidden(method, path string, payload any) {
+	GinkgoHelper()
+
+	expectRequestForbidden(userClient, "user", method, path, payload)
 }
 
 var _ = Describe("RBAC Enforcement", func() {
@@ -224,6 +230,24 @@ var _ = Describe("RBAC Enforcement", func() {
 			})
 		})
 
+		// Upstream provider writes are platform-operator only: an organization administrator
+		// could otherwise delete their own provider and lock the organization out of login.
+		// A synthetic ID suffices — the handler authorizes before it looks the provider up,
+		// which also keeps these specs free of a platform-operator fixture.
+		Describe("Given a request to create an OAuth2 provider", func() {
+			It("should be denied with a forbidden response", func() {
+				expectRequestForbidden(adminClient, "administrator", http.MethodPost,
+					api.NewEndpoints().ListOauth2Providers(config.OrgID),
+					api.NewOauth2ProviderPayload().Build())
+			})
+		})
+
+		Describe("Given a request to delete an OAuth2 provider", func() {
+			It("should be denied with a forbidden response", func() {
+				expectRequestForbidden(adminClient, "administrator", http.MethodDelete,
+					api.NewEndpoints().GetOauth2Provider(config.OrgID, "00000000-0000-0000-0000-000000000000"), nil)
+			})
+		})
 	})
 
 	Context("When authenticated as a user", func() {
@@ -407,7 +431,9 @@ var _ = Describe("RBAC Enforcement", func() {
 
 		Describe("Given a request to delete an OAuth2 provider", func() {
 			It("should be denied with a forbidden response", func() {
-				_, providerID := api.CreateOauth2ProviderWithCleanup(adminClient, ctx, config,
+				requireGlobalAdminClient()
+
+				_, providerID := api.CreateOauth2ProviderWithCleanup(globalAdminClient, ctx, config,
 					api.NewOauth2ProviderPayload().Build())
 
 				expectUserRequestForbidden(http.MethodDelete,

--- a/test/api/suites/suite_test.go
+++ b/test/api/suites/suite_test.go
@@ -35,10 +35,23 @@ var (
 	adminClient          *api.APIClient
 	userClient           *api.APIClient
 	auditClient          *api.APIClient
+	globalAdminClient    *api.APIClient
 	serviceAccountClient *api.APIClient
 	ctx                  context.Context
 	config               *api.TestConfig
 )
+
+// requireGlobalAdminClient gates specs that need a write verb the organization roles no longer
+// hold. BINDING_ADMIN_AUTH_TOKEN rather than PLATFORM_ADMIN_AUTH_TOKEN: both carry global
+// authority, but the latter comes from the transitional platformAdministrators.subjects path,
+// so it would vanish with that path and skip these specs into silence.
+func requireGlobalAdminClient() {
+	GinkgoHelper()
+
+	if globalAdminClient == nil {
+		Skip("BINDING_ADMIN_AUTH_TOKEN is required for platform-operator writes")
+	}
+}
 
 var _ = BeforeSuite(func() {
 	patchTLSTransport()
@@ -69,6 +82,13 @@ var _ = BeforeEach(func() {
 		auditConfig := *config
 		auditConfig.AuthToken = config.AuditToken
 		auditClient = api.NewAPIClientWithConfig(&auditConfig)
+	}
+
+	globalAdminClient = nil
+	if config.BindingAdminToken != "" {
+		globalAdminConfig := *config
+		globalAdminConfig.AuthToken = config.BindingAdminToken
+		globalAdminClient = api.NewAPIClientWithConfig(&globalAdminConfig)
 	}
 
 	serviceAccountClient = nil


### PR DESCRIPTION
Stacked on #536 — do not merge before it. Raised in [review on #536](https://github.com/nscaledev/uni-identity/pull/536#issuecomment-5241044219).

Drops the organization `administrator` from `[create,read,update,delete]` to `[read]` on `identity:oauth2providers`. Policy data plus tests; zero production Go.

## Why

An organization administrator can delete their own provider and lock every user in that organization out of login. And once the provider record carries any authority-relevant field, creating one becomes an escalation path out of an ordinary customer role.

`auditor` already had organization-scoped read, so this just makes the two organization roles agree. `platform-administrator` keeps global CRUD, which is not reachable through organization membership. Nobody uses org-scoped providers in staging or production today.

## Notes for review

- The value is pinned in `pkg/rbac/grant_guard_test.go`, mutation-tested. The grant lattice passes under both `[read]` and CRUD and the render guard only sees global scopes, so nothing fast catches a restored write verb without it.
- Two integration specs assert the denial. They use a synthetic ID — the handler authorizes before lookup — so they need no fixture and never skip.
- The default integration `client` is an `administrator`, so provider writes in the suites moved to `BINDING_ADMIN_AUTH_TOKEN`. Not `PLATFORM_ADMIN_AUTH_TOKEN`: that one rides the transitional `platformAdministrators.subjects` path and would take the specs down with it.
- Revocation lands within `--acl-cache-timeout` (default 1m); no pod restart. Break-glass is Helm, not API — `platform-administrator` is protected.
- Deployments granting provider writes via `additionalRoles` keep resolved ACLs, but group membership edits on such a role start failing (`AllowRole` revalidates on update). Worth a grep before merge.

## Verification

`make touch license validate lint generate` clean, `git status` clean, `make test-unit`, `go vet -tags integration`. Probed live: binding-admin creates (201) and deletes (200) providers.

**The integration suite is red on the base branch too** — untouched `andreyyantsen/id-399` fails 9/197. Two runs here failed 19/199 and 25/199, the second with no failures in any suite this PR touches, and the untouched baseline failed four specs that passed here. Intermittent `401 token validation failed` on user and globally-bound tokens, not expiry. Lives in the global role binding token path; worth chasing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)